### PR TITLE
Use tokenless npm trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,16 +16,15 @@ jobs:
     environment: npm-production
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - run: npm ci
       - run: npm run check && npm test && npm run privacy-audit
       - name: Verify release tag matches package version
         if: github.event_name == 'release'
         run: test "v$(node -p "require('./package.json').version")" = "${{ github.event.release.tag_name }}"
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public


### PR DESCRIPTION
## Summary\n- update release actions to current major versions\n- disable dependency caching in release jobs\n- remove the long-lived npm token from publishing\n\n## Verification\n- npm run check\n- npm test (62 passing)\n- npm run privacy-audit\n- git diff --check