### PR TITLE
Fix background updater Node resolution

### DIFF
--- a/installer/src/runner.mjs
+++ b/installer/src/runner.mjs
@@ -8,15 +8,16 @@ function shellQuote(value) {
 export async function createUpdateRunner({ platform = process.platform, codexHome, nodePath = process.execPath, npmCliPath }) {
   if (!npmCliPath) throw new Error('npm CLI path is required to create the automatic-update runner.');
   const managerDir = path.join(codexHome, 'job-application-agent');
+  const nodeDir = path.dirname(nodePath);
   await mkdir(managerDir, { recursive: true });
   if (platform === 'win32') {
     const filePath = path.join(managerDir, 'update.cmd');
-    const script = `@echo off\r\nset "CODEX_HOME=${codexHome}"\r\n"${nodePath}" "${npmCliPath}" exec --yes --package=job-application-agent@latest -- job-application-agent auto-update\r\n`;
+    const script = `@echo off\r\nset "CODEX_HOME=${codexHome}"\r\nset "PATH=${nodeDir};%PATH%"\r\n"${nodePath}" "${npmCliPath}" exec --yes --package=job-application-agent@latest -- job-application-agent auto-update\r\n`;
     await writeFile(filePath, script, { mode: 0o700 });
     return { path: filePath };
   }
   const filePath = path.join(managerDir, 'update');
-  const script = `#!/bin/sh\nCODEX_HOME=${shellQuote(codexHome)}\nexport CODEX_HOME\nexec ${shellQuote(nodePath)} ${shellQuote(npmCliPath)} exec --yes --package=job-application-agent@latest -- job-application-agent auto-update\n`;
+  const script = `#!/bin/sh\nCODEX_HOME=${shellQuote(codexHome)}\nPATH=${shellQuote(nodeDir)}:\${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}\nexport CODEX_HOME PATH\nexec ${shellQuote(nodePath)} ${shellQuote(npmCliPath)} exec --yes --package=job-application-agent@latest -- job-application-agent auto-update\n`;
   await writeFile(filePath, script, { mode: 0o700 });
   await chmod(filePath, 0o700);
   return { path: filePath };

--- a/installer/tests/runner.test.mjs
+++ b/installer/tests/runner.test.mjs
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { promisify } from 'node:util';
 
 import { createUpdateRunner } from '../src/runner.mjs';
+
+const execFileAsync = promisify(execFile);
 
 test('creates a durable Unix launcher that always executes the latest npm package', async () => {
   const codexHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-'));
@@ -19,6 +23,21 @@ test('creates a durable Unix launcher that always executes the latest npm packag
   assert.match(script, /job-application-agent@latest/);
   assert.match(script, /auto-update/);
   assert.equal((await stat(result.path)).mode & 0o777, 0o700);
+});
+
+test('Unix launcher exposes its Node directory to npm child processes under a minimal scheduler PATH', async () => {
+  const codexHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-path-'));
+  const emptyPath = await mkdtemp(path.join(os.tmpdir(), 'job-agent-empty-path-'));
+  const fakeNpmCli = path.join(codexHome, 'fake-npm-cli.mjs');
+  await writeFile(fakeNpmCli, `import { spawnSync } from 'node:child_process';\nconst child = spawnSync('node', ['--version']);\nprocess.exit(child.status ?? 1);\n`);
+  const result = await createUpdateRunner({
+    platform: 'darwin',
+    codexHome,
+    nodePath: process.execPath,
+    npmCliPath: fakeNpmCli,
+  });
+
+  await execFileAsync(result.path, ['auto-update'], { env: { PATH: emptyPath } });
 });
 
 test('creates a durable Windows launcher that always executes the latest npm package', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-application-agent",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-application-agent",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "bin": {
         "job-application-agent": "bin/job-application-agent.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-application-agent",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A self-updating Codex skill for evidence-based job discovery, application completion, and outcome tracking.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary\n- add the installed Node directory to the generated updater PATH\n- support macOS LaunchAgent and other minimal scheduler environments\n- add a regression test that executes the launcher with an otherwise empty PATH\n- release as 2.0.2\n\n## Verification\n- regression test failed before the fix and passes afterward\n- npm test (63 passing)\n- npm run privacy-audit\n- npm run smoke:package\n- npm audit (0 vulnerabilities)\n- git diff --check