### PR TITLE
Prefer direct path-based resume uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Updates are staged and validated before replacement. The immediately previous sk
 | 🔎 Discover | 🎯 Qualify | 📝 Apply |
 |---|---|---|
 | Finds active roles on direct career pages and major ATS platforms. | Scores seniority, skills, location, eligibility, work mode, and compensation. | Fills forms using only verified profile and résumé facts. |
-| Resolves social and aggregator leads to direct employer pages. | Skips closed, duplicated, ineligible, and weak-fit opportunities. | Uploads one canonical résumé and drafts truthful short answers. |
+| Resolves social and aggregator leads to direct employer pages. | Skips closed, duplicated, ineligible, and weak-fit opportunities. | Uploads one canonical résumé directly by path when the browser supports it, and drafts truthful short answers. |
 
 | 🔐 Protect | 📚 Track | 📈 Improve |
 |---|---|---|

--- a/job-application-agent/SKILL.md
+++ b/job-application-agent/SKILL.md
@@ -52,7 +52,7 @@ Do not lower seniority, compensation, location, work mode, or evidence threshold
 4. Keep authentication in the existing browser session. Never inspect cookies, local storage, passwords, or session files.
 5. Fill only explicit profile fields, candidate-provided answers, or facts verified in the canonical resume.
 6. Follow [references/APPLICATION_GUIDANCE.md](references/APPLICATION_GUIDANCE.md) for narrative answers.
-7. Upload only the canonical resume unless the candidate explicitly provides another attachment.
+7. Upload only the canonical resume unless the candidate explicitly provides another attachment. Resolve its absolute path with `resume path`, then follow [references/BROWSER_UPLOADS.md](references/BROWSER_UPLOADS.md). Use the browser's privileged path-based upload capability first; treat a visible native file picker as a fallback.
 8. Do not answer demographic questions. Stop for login/SSO/MFA, CAPTCHA, legal attestations, unclear authorization or compensation, sensitive identifiers, and judgment-only questions.
 9. Verify every required field, answer, attachment, and disclosure. Submit only when the current request and confirmation policy authorize it.
 10. Record `submitted` only after visible success confirmation. Record no submission when confirmation is missing or ambiguous.
@@ -78,6 +78,7 @@ node scripts/job-application.mjs profile migrate --stdin
 node scripts/job-application.mjs profile check
 node scripts/job-application.mjs profile field <allowed-field>
 node scripts/job-application.mjs resume import <google-doc-url-or-local-pdf>
+node scripts/job-application.mjs resume path
 node scripts/job-application.mjs score --stdin
 node scripts/job-application.mjs ledger check --stdin
 node scripts/job-application.mjs ledger add --stdin

--- a/job-application-agent/references/BROWSER_UPLOADS.md
+++ b/job-application-agent/references/BROWSER_UPLOADS.md
@@ -1,0 +1,19 @@
+# Browser uploads
+
+Use this procedure whenever an application requires the canonical resume or another candidate-authorized attachment.
+
+1. Run `node scripts/job-application.mjs resume path` and use the returned absolute path. Stop if the command reports that no canonical resume is imported.
+2. Read the selected browser tool's upload documentation. Prefer its privileged path-based upload capability over native UI automation.
+3. When the browser exposes a file chooser, start waiting for the chooser before clicking the actual `input[type="file"]` or its associated upload control, then set the absolute path directly. For example:
+
+   ```js
+   const chooserPromise = tab.playwright.waitForEvent("filechooser", { timeoutMs: 10000 });
+   await tab.playwright.locator('input[type="file"]').click();
+   const chooser = await chooserPromise;
+   await chooser.setFiles([resumePath]);
+   ```
+
+4. Use an equivalent documented primitive such as `setInputFiles` when that is what the selected browser provides. Do not assign `input.value`, synthesize a `DataTransfer`, inject file bytes through page JavaScript, or inspect browser session storage.
+5. Use a native file picker only as a fallback after the privileged upload path is unavailable or fails and the browser-specific troubleshooting has been exhausted. Never make Finder, Explorer, or another visible picker the default flow.
+6. Wait for the ATS to finish uploading or parsing. Verify the displayed filename, attachment success state, and any fields repopulated from the resume. Restore verified fields that parsing cleared or changed before continuing.
+7. Keep the local path, filename, file bytes, and resume metadata out of telemetry, application answers, logs, and third-party messages.

--- a/job-application-agent/scripts/job-application.mjs
+++ b/job-application-agent/scripts/job-application.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from 'node:crypto';
-import { appendFile, chmod, mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { appendFile, chmod, mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { platform } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 
@@ -649,6 +649,18 @@ async function importResume(source) {
   return { path: target, sha256: metadata.sha256, bytes: metadata.bytes };
 }
 
+async function canonicalResumePath() {
+  const target = join(await ensureStateDir(), 'resume.pdf');
+  try {
+    const details = await stat(target);
+    if (!details.isFile()) throw new Error('Canonical resume path is not a file. Import the resume again.');
+  } catch (error) {
+    if (error.code === 'ENOENT') throw new Error('Canonical resume is not imported. Run resume import first.');
+    throw error;
+  }
+  return { path: target };
+}
+
 function duplicateResult(entries, candidate) {
   const candidateCompany = normalizedText(candidate.company);
   const candidateRole = normalizedText(candidate.role);
@@ -806,6 +818,7 @@ async function executeCommand([area, action, value], telemetry, session) {
     if (![...STRING_PROFILE_FIELDS, ...ARRAY_PROFILE_FIELDS, ...NUMBER_PROFILE_FIELDS, ...OBJECT_PROFILE_FIELDS].includes(value)) throw new Error('Profile field is not allowed.');
     result = { [value]: storedProfile()[value] ?? null };
   } else if (area === 'resume' && action === 'import' && value) result = await importResume(value);
+  else if (area === 'resume' && action === 'path' && value == null) result = await canonicalResumePath();
   else if (area === 'score' && action === '--stdin') {
     const job = await jsonStdin();
     result = scoreJob(job, job.target ?? storedProfile());
@@ -828,7 +841,7 @@ async function executeCommand([area, action, value], telemetry, session) {
     domainEvents.push(reviewTelemetry(result));
   } else if (area === 'ledger' && action === 'review-ack' && value === '--stdin') {
     result = await ledgerReviewAcknowledge(await jsonStdin());
-  } else throw new Error('Usage: profile set|migrate --stdin; profile check|field <name>; resume import <url-or-pdf>; score --stdin; ledger check|add|outcome|review-ack --stdin; ledger review; telemetry status|enable|disable|reset|preview --stdin|record --stdin');
+  } else throw new Error('Usage: profile set|migrate --stdin; profile check|field <name>; resume import <url-or-pdf>|path; score --stdin; ledger check|add|outcome|review-ack --stdin; ledger review; telemetry status|enable|disable|reset|preview --stdin|record --stdin');
   for (const event of domainEvents) await telemetry.record(event, session);
   return result;
 }

--- a/job-application-agent/tests/job-application.test.mjs
+++ b/job-application-agent/tests/job-application.test.mjs
@@ -65,6 +65,20 @@ test('validates a candidate-defined target profile', () => {
   assert.throws(() => validateProfile({ ...target, submissionMode: 'always' }), /review-each/);
 });
 
+test('returns the canonical resume path for direct browser uploads', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-resume-path-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const resume = join(directory, 'resume.pdf');
+  await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
+  await writeFile(resume, '%PDF-1.7\ncanonical resume fixture');
+  const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
+
+  const result = JSON.parse(execFileSync(process.execPath, [script, 'resume', 'path'], { env, encoding: 'utf8' }));
+
+  assert.deepEqual(result, { path: resume });
+});
+
 test('migrates a legacy profile without discarding identity or salary preference', () => {
   const legacy = {
     name: 'Test Candidate', email: 'candidate@example.com', phone: '+1 555 0100',

--- a/job-application-agent/tests/skill-contract.test.mjs
+++ b/job-application-agent/tests/skill-contract.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('requires direct path resume upload before native picker fallback', async () => {
+  const skill = await readFile(new URL('../SKILL.md', import.meta.url), 'utf8');
+  const guidance = await readFile(new URL('../references/BROWSER_UPLOADS.md', import.meta.url), 'utf8');
+
+  assert.match(skill, /resume path/);
+  assert.match(skill, /BROWSER_UPLOADS\.md/);
+  assert.match(guidance, /absolute path/i);
+  assert.match(guidance, /file chooser/i);
+  assert.match(guidance, /setFiles/);
+  assert.match(guidance, /native (file )?picker.*fallback/i);
+  assert.match(guidance, /verify.*filename/i);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-application-agent",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-application-agent",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "bin": {
         "job-application-agent": "bin/job-application-agent.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-application-agent",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A privacy-first Agent Skill and CLI for evidence-based job discovery, application completion, and outcome tracking.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## What changed

- add `resume path` to expose the canonical local résumé path deterministically
- require browser-native chooser/path upload before any Finder or Explorer fallback
- verify the displayed attachment and resume-parsed fields after upload
- document the behavior in the public README
- release as v3.0.1

## Why

Agents were opening the native file picker even when the canonical résumé path was already available. That made automated application rounds brittle and unnecessarily interrupted users.

## Validation

- skill structure validation
- JavaScript syntax checks
- 80 package tests
- privacy audit
- packed npm installation smoke test
