### PR TITLE
Add autonomous resumable application runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Updates are staged and validated before replacement. The immediately previous sk
 | 🔐 Protect | 📚 Track | 📈 Improve |
 |---|---|---|
 | Keeps profile data in OS-backed storage and browser auth in the browser. | Records only visibly confirmed submissions in a private local ledger. | Reviews results every ten applications and proposes targeting changes. |
-| Stops at sensitive or judgment-heavy steps. | Captures outcomes plus optional interview quality and failure points. | Never changes preferences or instructions without your approval. |
+| Stops at sensitive or judgment-heavy steps. | Captures explicit round IDs and a resumable attention queue. | Opens tested, sanitized improvement PRs without merging or publishing them. |
 
 ## 🛡️ Safety by design
 
@@ -104,6 +104,15 @@ The agent will ask for your canonical résumé and missing application facts. Yo
 - `review-each` — inspect every completed application before submission.
 - `routine-auto` — allow routine submissions within a destination or batch you explicitly authorize; safety pauses still apply.
 
+For continuing autonomy across resumable and scheduled runs, explicitly grant the fixed routine scope once:
+
+```sh
+echo '{"mode":"routine-auto"}' | node ~/.agents/skills/job-application-agent/scripts/job-application.mjs autonomy grant --stdin
+node ~/.agents/skills/job-application-agent/scripts/job-application.mjs autonomy status
+```
+
+The grant covers routine discovery, filling, canonical résumé upload, submission, verified recruiting email, ledger/outcome updates, completed-tab cleanup, and sanitized improvement-PR creation. It never bypasses login, MFA, CAPTCHA, legal/demographic steps, host permission prompts, or ambiguous facts. `autonomy revoke` stops future routine transmissions without deleting history.
+
 ### 3. Use natural commands
 
 ```text
@@ -111,6 +120,7 @@ search jobs
 apply https://company.example/jobs/123
 apply all relevant jobs from this thread: <URL>
 run a round of 10
+show attention queue
 record outcome Company — Senior Engineer — interview
 ```
 
@@ -129,7 +139,7 @@ flowchart LR
     H --> I["Confirm success and update ledger"]
 ```
 
-The bundled script provides deterministic profile validation, résumé import, scoring, deduplication, ledger updates, and ten-application reviews. The current coding agent handles discovery and browser interaction while following the guardrails in [`SKILL.md`](job-application-agent/SKILL.md).
+The bundled script provides deterministic profile validation, résumé import, scoring, company/requisition deduplication, explicit round accounting, attention/friction queues, ledger updates, and ten-application reviews. The current coding agent handles discovery and browser interaction while following the guardrails in [`SKILL.md`](job-application-agent/SKILL.md).
 
 ## 🔐 Privacy model
 
@@ -138,6 +148,7 @@ The bundled script provides deterministic profile validation, résumé import, s
 | Candidate profile | OS-backed secret store (macOS Keychain, or Windows Credential Manager + DPAPI) | Never committed |
 | Canonical résumé | Owner-only local state directory | Never committed |
 | Application ledger | Owner-only local state directory | Never committed |
+| Autonomy, round, attention, and friction state | Owner-only local state directory | Never committed |
 | Browser authentication | Existing browser session | Never exported |
 | Skill instructions and scripts | Local skill directory | Version controlled |
 

--- a/SHARE_PROMPT.md
+++ b/SHARE_PROMPT.md
@@ -18,11 +18,14 @@ Support these commands:
 - `apply <URL>`: verify the role is active and eligible, fill the form using only my verified profile and resume facts, upload the canonical resume, draft concise truthful answers, and complete the application.
 - `apply all relevant jobs from <URL/thread/list>`: inspect every lead, apply to every active and eligible strong match, and report precise skip reasons for the rest.
 - `run a round of <N>`: continue until N unique applications have visibly succeeded; do not count closed pages, duplicates, drafts, emails left unsent, or unconfirmed submissions.
+- `attention list`: show one prioritized checklist of authentication/CAPTCHA, legal/authorization, and judgment/video blockers while continuing other applications.
 - `record outcome <application>`: record interview, rejection, offer, or withdrawal feedback.
 
 Ask me whether I want `review each submission` or `routine auto-submit`. Even with auto-submit, obey browser or tool confirmation requirements. Always stop for passwords, SSO/MFA, CAPTCHA, legal attestations, demographic questions, sensitive government identifiers, unclear compensation or work authorization, and any unverifiable claim. Never inspect cookies, local storage, passwords, session files, or MFA codes.
 
-Before submitting, validate every field, answer, attachment, and disclosure. Record an application as submitted only when the site visibly confirms success. Deduplicate by direct job URL or employer job ID. After every ten confirmed submissions, review outcomes and propose improvements to targeting and answer guidance, but change nothing without my approval.
+If I explicitly say “apply autonomously,” persist a local routine-autonomy grant so you do not ask again for skill-level résumé-upload or routine-submission approval. The grant may also cover verified recruiting email, ledger/outcome updates, completed-tab cleanup, and creating tested public-agent improvement PRs. It must never bypass the hard stops above or any browser/host permission prompt. It must never authorize merging, releasing, publishing, changing my facts, or changing targeting thresholds.
+
+Before submitting, validate every field, answer, attachment, and disclosure. Record an application as submitted only when the site visibly confirms success. Give every batch a round ID, separately record where a lead was discovered and where it was submitted, and deduplicate at both company and requisition level. Queue blockers and continue elsewhere. Record bounded reproducible general failures; after the round, a qualifying failure may produce a sanitized regression-tested PR, but never merge or publish it. After every ten confirmed submissions, review outcomes and propose improvements to targeting and answer guidance, but change nothing without my approval.
 
 Use the browser I request. If I do not specify one, use the best available browser that preserves my existing login session.
 

--- a/job-application-agent/SKILL.md
+++ b/job-application-agent/SKILL.md
@@ -22,8 +22,9 @@ Use `scripts/job-application.mjs` for private state and deterministic checks. Re
 3. Preserve identity fields during migration. Map legacy `salaryPreference` to `targetCompensation`. Add `compensationFloor` only when the candidate provides an amount, currency, and annual comparison basis.
 4. Store the profile in OS-backed profile storage (macOS Keychain, or Windows Credential Manager with a DPAPI-protected local file). Store the canonical resume and append-only ledgers in the owner-only state directory.
 5. Use `review-each` for per-application approval. Use `routine-auto` only when the current request authorizes the destination or batch and every automatic-eligibility condition passes.
-6. Obey browser and tool confirmation requirements regardless of the stored mode.
-7. Disclose default-enabled structured anonymous analytics and the `telemetry disable` control. The CLI also displays this disclosure.
+6. When the candidate explicitly grants continuing autonomy, read [references/AUTONOMY.md](references/AUTONOMY.md) and persist it with `autonomy grant --stdin`. Do not repeat skill-level upload or submission approval prompts while the active grant and profile both use `routine-auto`.
+7. Obey browser and tool confirmation requirements regardless of the stored mode or autonomy grant.
+8. Disclose default-enabled structured anonymous analytics and the `telemetry disable` control. The CLI also displays this disclosure.
 
 Never store passwords, MFA codes, government IDs, demographic data, CAPTCHA answers, browser session data, or inferred candidate facts.
 
@@ -46,17 +47,20 @@ Do not lower seniority, compensation, location, work mode, or evidence threshold
 
 ## Apply
 
+For batches, scheduled work, or resumable handoffs, read [references/RUNS.md](references/RUNS.md), create a round ID, and use the attention and friction queues.
+
 1. Recheck employer, title, direct domain, posting status, eligibility, and `autoEligible` immediately before submission.
-2. Run `ledger check --stdin` with the internal ledger ID, canonical URL, employer job ID, company, and role when available.
+2. Run `ledger check --stdin` with the internal ledger ID, canonical URL, employer job ID, company, and role when available. Review both requisition duplicate status and same-company history.
 3. Stop on a hard duplicate. Treat a same-company/same-role match without a shared job ID as a possible duplicate. Use `duplicateOverride: "NEW REQUISITION CONFIRMED"` only after verifying it is a distinct requisition.
 4. Keep authentication in the existing browser session. Never inspect cookies, local storage, passwords, or session files.
 5. Fill only explicit profile fields, candidate-provided answers, or facts verified in the canonical resume.
 6. Follow [references/APPLICATION_GUIDANCE.md](references/APPLICATION_GUIDANCE.md) for narrative answers.
 7. Upload only the canonical resume unless the candidate explicitly provides another attachment. Resolve its absolute path with `resume path`, then follow [references/BROWSER_UPLOADS.md](references/BROWSER_UPLOADS.md). Use the browser's privileged path-based upload capability first; treat a visible native file picker as a fallback.
 8. Do not answer demographic questions. Stop for login/SSO/MFA, CAPTCHA, legal attestations, unclear authorization or compensation, sensitive identifiers, and judgment-only questions.
-9. Verify every required field, answer, attachment, and disclosure. Submit only when the current request and confirmation policy authorize it.
-10. Record `submitted` only after visible success confirmation. Record no submission when confirmation is missing or ambiguous.
+9. Verify every required field, answer, attachment, and disclosure. Submit when the current request or active autonomy grant authorizes it.
+10. Record `submitted` only after visible success confirmation, using independent `discoverySource`, `applicationChannel`, and `roundId` values. Record no submission when confirmation is missing or ambiguous.
 11. Record workflow telemetry with `telemetry record --stdin`. Let `ledger add` emit `application_submitted`; do not emit it twice. Pass job URLs and structured metrics only through documented transient fields.
+12. Queue hard stops with `attention add --stdin` and continue elsewhere. Record reproducible general-purpose failures with `friction record --stdin`; improvement work must never delay application work.
 
 ## Outcomes and reviews
 
@@ -85,6 +89,14 @@ node scripts/job-application.mjs ledger add --stdin
 node scripts/job-application.mjs ledger outcome --stdin
 node scripts/job-application.mjs ledger review
 node scripts/job-application.mjs ledger review-ack --stdin
+node scripts/job-application.mjs autonomy grant --stdin
+node scripts/job-application.mjs autonomy status|preview|revoke
+node scripts/job-application.mjs round start|complete --stdin
+node scripts/job-application.mjs round status [round-id]
+node scripts/job-application.mjs attention add|resolve --stdin
+node scripts/job-application.mjs attention list
+node scripts/job-application.mjs friction record --stdin
+node scripts/job-application.mjs friction list
 node scripts/job-application.mjs telemetry status|enable|disable|reset
 node scripts/job-application.mjs telemetry preview --stdin
 node scripts/job-application.mjs telemetry record --stdin

--- a/job-application-agent/references/ANALYTICS.md
+++ b/job-application-agent/references/ANALYTICS.md
@@ -29,7 +29,9 @@ Telemetry is best effort. It has no offline queue, uses a short network timeout,
 
 Analytics never includes the candidate's name, email, phone, exact address, profile URLs, candidate location, work authorization, personal compensation or compensation floor, target profile or thresholds, resume or attachments, must-have evidence or coverage details, rejection reasons, prompts, responses, job descriptions, form questions, drafted answers, notes, passwords, MFA, CAPTCHA, legal or demographic answers, browser data, IP address, request headers, user agent, or raw error messages.
 
-Structured job context may include company, role title, canonical destination domain, a SHA-256 hash of the job URL after removing query parameters and fragments, ATS, source channel, job country, work mode, employment type, seniority, role family, published salary band, fit score, match/gap categories, workflow stages, field categories, pause reasons, submission result, outcome, bounded interview quality, and bounded interview failure point.
+Structured job context may include company, role title, canonical destination domain, a SHA-256 hash of the job URL after removing query parameters and fragments, bounded discovery source, ATS/application channel, job country, work mode, employment type, seniority, role family, published salary band, fit score, match/gap categories, workflow stages, field categories, pause reasons, submission result, outcome, bounded interview quality, and bounded interview failure point.
+
+Local attention details and friction evidence are never transmitted. Analytics may receive only their already-documented bounded stage, ATS, pause reason, result, and aggregate count fields.
 
 Company and title values are bounded and rejected when they resemble an email, phone number, URL, LinkedIn profile, or GitHub profile.
 

--- a/job-application-agent/references/AUTONOMY.md
+++ b/job-application-agent/references/AUTONOMY.md
@@ -1,0 +1,28 @@
+# Standing autonomy
+
+Use a durable autonomy grant only after an explicit candidate instruction such as “apply autonomously.” Store no prompt text in the grant.
+
+```text
+node scripts/job-application.mjs autonomy grant --stdin
+node scripts/job-application.mjs autonomy status
+node scripts/job-application.mjs autonomy preview
+node scripts/job-application.mjs autonomy revoke
+```
+
+Grant input:
+
+```json
+{ "mode": "routine-auto" }
+```
+
+An active grant covers discovery, assessment, verified form filling, canonical résumé upload, routine submission, verified recruiting email, ledger/outcome recording, completed-tab cleanup, and opening a sanitized improvement PR. Do not ask for another skill-level upload or submission approval while both the profile and grant use `routine-auto`.
+
+Always stop for authentication, MFA, CAPTCHA, legal attestations, demographic responses, government identifiers, unverifiable claims, and ambiguous work authorization or compensation. Obey every browser, host, and tool permission prompt; the grant never bypasses an access control.
+
+`autonomy revoke` blocks new routine transmissions without deleting applications, outcomes, rounds, or queued attention items.
+
+## Improvement boundary
+
+Record friction while the application round continues. Open a public-agent PR only when the issue is reproducible, general-purpose, sanitized, and covered by a regression test. Validate the full suite, privacy audit, package smoke test, and secret scan before marking the PR ready.
+
+Never automatically merge, tag, release, or publish. Never alter telemetry privacy boundaries, candidate facts, résumé claims, targeting thresholds, or answer guidance from an improvement PR. Keep live application work on the latest released package; do not hot-swap unmerged code.

--- a/job-application-agent/references/RUNS.md
+++ b/job-application-agent/references/RUNS.md
@@ -1,0 +1,48 @@
+# Resumable application runs
+
+## Round lifecycle
+
+Start each batch with an explicit ID:
+
+```text
+node scripts/job-application.mjs round start --stdin
+node scripts/job-application.mjs round status [round-id]
+node scripts/job-application.mjs round complete --stdin
+```
+
+Start input: `{ "requestedCount": 30 }`. Complete input: `{ "roundId": "round-..." }`.
+
+Count only unique applications with a visible employer/ATS confirmation or a verified sent recruiting email that were also added to the ledger with the same `roundId`. Filled forms, blockers, drafts, unsent email, and ambiguous confirmations never count. `round complete` rejects an under-target round.
+
+Run both company-level and requisition-level duplicate checks before filling and again immediately before transmission. A prior company application is a review signal, not by itself proof that a distinct requisition is a duplicate.
+
+Resolve the canonical résumé with `resume path`, upload its absolute path through the browser’s privileged chooser first, and verify the filename and parsed fields. Use a visible native picker only as a fallback.
+
+Store independent attribution on every new ledger row:
+
+- `discoverySource`: where the lead was found (`linkedin`, `x`, `yc`, `hacker-news`, `job-board`, `direct-company`, `email`, `user-supplied`, `web-search`, or `other`).
+- `applicationChannel`: where it was submitted (`ashby`, `greenhouse`, `lever`, `workday`, `company`, `email`, and the other documented ATS values).
+- `source`: the legacy-compatible application channel.
+
+## Attention queue
+
+Append blocked work instead of interrupting the round:
+
+```text
+node scripts/job-application.mjs attention add --stdin
+node scripts/job-application.mjs attention list
+node scripts/job-application.mjs attention resolve --stdin
+```
+
+Store only application ID, canonical URL, round ID, stage, blocker enum, timestamp, and bounded required-action enums. Never store passwords, MFA codes, CAPTCHA answers, demographic answers, government IDs, or legal responses. Prioritize authentication/MFA/CAPTCHA, then legal/authorization/compensation, then judgment/video/site issues. Preserve the tab when supported; otherwise reopen the canonical URL and refill verified data.
+
+## Friction queue
+
+Record bounded general workflow failures without candidate data:
+
+```text
+node scripts/job-application.mjs friction record --stdin
+node scripts/job-application.mjs friction list
+```
+
+Use a stable kebab-case error code, documented stage and ATS, and Boolean `reproducible` and `general` fields. Only entries where both are true qualify for a tested public-agent PR. Never include URLs, form text, answers, résumé metadata, identity, or raw errors.

--- a/job-application-agent/references/SCHEMAS.md
+++ b/job-application-agent/references/SCHEMAS.md
@@ -48,6 +48,8 @@ Treat `mustHaves[].evidence` as private resume analysis. It is used locally and 
   "company": "Example",
   "description": "Posting text",
   "source": "greenhouse",
+  "discoverySource": "linkedin",
+  "applicationChannel": "greenhouse",
   "url": "https://job-boards.greenhouse.io/example/jobs/123",
   "postingStatus": "active",
   "eligibility": "eligible",
@@ -69,6 +71,8 @@ Treat `mustHaves[].evidence` as private resume analysis. It is used locally and 
 ```
 
 Allowed sources: `linkedin`, `greenhouse`, `lever`, `ashby`, `workable`, `comeet`, `workday`, `rippling`, `smartrecruiters`, `google-form`, `company`, `email`, and `other`.
+
+`source` remains the backward-compatible application channel. New workflows should also supply `discoverySource` (`direct-company`, `linkedin`, `x`, `yc`, `hacker-news`, `job-board`, `email`, `user-supplied`, `web-search`, or `other`) and `applicationChannel` using the allowed `source` values.
 
 Allowed posting statuses: `active`, `closed`, `unclear`. Allowed eligibility: `eligible`, `unclear`, `ineligible`. Allowed seniority: `junior`, `mid`, `senior`, `staff`, `principal`, `lead`, `manager`, `director`, `founding`, `unspecified`. Allowed work modes: `remote`, `hybrid`, `onsite`, `unspecified`. Must-have statuses: `met`, `partial`, `missing`, `unclear`.
 
@@ -102,6 +106,9 @@ Add only after visible success confirmation.
   "url": "https://jobs.example.com/roles/123",
   "employerJobId": "greenhouse:123",
   "source": "company",
+  "discoverySource": "x",
+  "applicationChannel": "company",
+  "roundId": "round-2026-01-15-00000000-0000-4000-8000-000000000000",
   "score": 84,
   "status": "submitted",
   "submittedAt": "2026-01-15T10:00:00.000Z",
@@ -118,6 +125,55 @@ Add only after visible success confirmation.
 ```
 
 Use `duplicateOverride` only for a verified distinct requisition after a possible-duplicate warning. It and `telemetry` are transient and are not written to the application ledger. Use approval `APPROVE SUBMIT` for per-application approval or `STANDING AUTHORIZATION` when the current request authorizes routine batch submission.
+
+`discoverySource`, `applicationChannel`, and `roundId` are optional for backward compatibility and should be supplied for new resumable rounds. `ledger check` returns hard requisition/URL duplicate status plus bounded same-company history so a distinct role can be reviewed without conflating it with a duplicate.
+
+## Autonomy grant input
+
+Create a grant only from an explicit candidate instruction. Do not store the instruction text.
+
+```json
+{ "mode": "routine-auto" }
+```
+
+The owner-only `autonomy.json` stores the fixed routine scopes, grant time, and enabled state. Revocation preserves ledgers and stops future routine transmissions. Hard stops and host permission prompts remain mandatory.
+
+## Round input
+
+```json
+{ "requestedCount": 30 }
+```
+
+`round start --stdin` appends a `started` event to owner-only `rounds.ndjson` and returns a generated `roundId`. Add that ID to every confirmed ledger entry. `round complete --stdin` accepts `{ "roundId": "round-..." }` and appends a completion event only after the target count is present in the ledger.
+
+## Attention input
+
+```json
+{
+  "roundId": "round-...",
+  "applicationId": "example-role",
+  "url": "https://jobs.example.com/role",
+  "stage": "submission",
+  "blocker": "captcha",
+  "requiredActions": ["complete-captcha"]
+}
+```
+
+Allowed blockers: `authentication`, `mfa`, `captcha`, `legal-attestation`, `demographic`, `government-id`, `ambiguous-authorization`, `ambiguous-compensation`, `unverifiable-claim`, `judgment`, `video`, `upload`, `site-error`, and `other`. Resolve with `{ "id": "attention-..." }`. The queue never stores the candidate's response.
+
+## Friction input
+
+```json
+{
+  "stage": "upload",
+  "ats": "ashby",
+  "errorCode": "direct-upload-fallback-opened",
+  "reproducible": true,
+  "general": true
+}
+```
+
+Use only documented stage/ATS values and a stable kebab-case code. Never include URLs, identity, résumé metadata, answers, form text, or raw errors. Only reproducible general events qualify for a tested public-agent PR.
 
 ## Outcome input
 

--- a/job-application-agent/scripts/job-application.mjs
+++ b/job-application-agent/scripts/job-application.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, chmod, mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { platform } from 'node:os';
 import { basename, join, resolve } from 'node:path';
@@ -10,6 +10,7 @@ import { TelemetryClient } from './telemetry-client.mjs';
 import { jobIdentity } from './telemetry-schema.mjs';
 
 const SOURCES = new Set(['linkedin', 'greenhouse', 'lever', 'ashby', 'workable', 'comeet', 'workday', 'rippling', 'smartrecruiters', 'google-form', 'company', 'email', 'other']);
+const DISCOVERY_SOURCES = new Set(['direct-company', 'linkedin', 'x', 'yc', 'hacker-news', 'job-board', 'email', 'user-supplied', 'web-search', 'other']);
 const ELIGIBILITY = new Set(['eligible', 'unclear', 'ineligible']);
 const POSTING_STATUS = new Set(['active', 'closed', 'unclear']);
 const WORK_MODES = new Set(['remote', 'hybrid', 'onsite', 'unspecified']);
@@ -21,6 +22,11 @@ const FAILURE_POINTS = new Set(['role-scope', 'company-problem', 'constraints', 
 const APPROVALS = new Set(['APPROVE SUBMIT', 'STANDING AUTHORIZATION']);
 const MODES = new Set(['review-each', 'routine-auto']);
 const TELEMETRY_DURATIONS = new Set(['under-1s', '1-5s', '5-30s', '30-60s', '1-2m', '2-5m', '5-15m', '15m-plus']);
+const AUTONOMY_SCOPES = Object.freeze(['discover', 'assess', 'fill', 'upload-resume', 'submit', 'send-recruiting-email', 'record-ledger', 'record-outcomes', 'cleanup-tabs', 'open-improvement-pr']);
+const AUTONOMY_HARD_STOPS = Object.freeze(['authentication', 'mfa', 'captcha', 'legal-attestation', 'demographic', 'government-id', 'unverifiable-claim', 'ambiguous-authorization', 'ambiguous-compensation']);
+const ATTENTION_STAGES = new Set(['discovery', 'assessment', 'application', 'contact', 'resume', 'questions', 'legal', 'demographic', 'review', 'submission', 'confirmation', 'outcome', 'answers', 'upload']);
+const ATTENTION_BLOCKERS = new Set(['authentication', 'mfa', 'captcha', 'legal-attestation', 'demographic', 'government-id', 'ambiguous-authorization', 'ambiguous-compensation', 'unverifiable-claim', 'judgment', 'video', 'upload', 'site-error', 'other']);
+const REQUIRED_ACTIONS = new Set(['sign-in', 'complete-mfa', 'complete-captcha', 'review-legal', 'choose-demographic', 'provide-government-id', 'provide-authorization', 'provide-compensation', 'verify-claim', 'provide-judgment', 'record-video', 'enable-upload', 'retry-site']);
 const REQUIRED_PROFILE = ['name', 'email', 'phone', 'location', 'workAuthorization', 'roleFamilies', 'seniority', 'targetLocations', 'workModes', 'submissionMode', 'yearsExperience', 'autoSubmitMinScore', 'manualReviewMinScore', 'minMustHaveCoverage'];
 const STRING_PROFILE_FIELDS = new Set(['name', 'email', 'phone', 'location', 'workAuthorization', 'linkedin', 'github', 'portfolio', 'availability', 'currentCompensation', 'targetCompensation', 'submissionMode']);
 const ARRAY_PROFILE_FIELDS = new Set(['roleFamilies', 'seniority', 'skills', 'targetLocations', 'excludedLocations', 'workModes', 'industries', 'excludedCompanies']);
@@ -70,6 +76,9 @@ export function commandCategory([area, action]) {
   if (area === 'ledger' && action === 'review-ack') return 'review';
   if (area === 'ledger') return 'apply';
   if (area === 'telemetry') return 'telemetry';
+  if (area === 'autonomy') return 'profile';
+  if (area === 'round') return 'round';
+  if (area === 'attention' || area === 'friction') return 'batch';
   return 'other';
 }
 
@@ -120,7 +129,7 @@ export async function telemetryJobAssessed(job, result) {
       ...identity,
       company: job.company,
       title: job.title,
-      ats: sourceToAts(String(job.source).toLowerCase()),
+      ats: sourceToAts(String(job.applicationChannel ?? job.source).toLowerCase()),
       fitScore: result.score,
       eligibility: String(job.eligibility).toLowerCase(),
       decision: result.decision,
@@ -138,7 +147,7 @@ async function telemetryApplicationSubmitted(entry, details = {}) {
       ...identity,
       company: entry.company,
       title: entry.role,
-      ats: sourceToAts(entry.source),
+      ats: sourceToAts(entry.applicationChannel ?? entry.source),
       durationBucket: details.durationBucket ?? 'under-1s',
       fieldsFilled: details.fieldsFilled ?? answers.length,
       shortAnswerCount: details.shortAnswerCount ?? answers.filter((key) => !/resume|attachment/i.test(key)).length,
@@ -240,12 +249,16 @@ export function scoreJob(input, target) {
   const company = string(job.company, 'job.company', 300);
   const description = string(job.description, 'job.description', 40000);
   const source = string(job.source, 'job.source', 40).toLowerCase();
+  const discoverySource = job.discoverySource == null ? null : string(job.discoverySource, 'job.discoverySource', 40).toLowerCase();
+  const applicationChannel = job.applicationChannel == null ? null : string(job.applicationChannel, 'job.applicationChannel', 40).toLowerCase();
   const eligibility = string(job.eligibility, 'job.eligibility', 40).toLowerCase();
   const postingStatus = string(job.postingStatus ?? 'unclear', 'job.postingStatus', 40).toLowerCase();
   const seniority = string(job.seniority ?? 'unspecified', 'job.seniority', 40).toLowerCase();
   const roleFamily = string(job.roleFamily ?? 'other', 'job.roleFamily', 80).toLowerCase();
   const workMode = string(job.workMode ?? (job.remote === true ? 'remote' : 'unspecified'), 'job.workMode', 40).toLowerCase();
   if (!SOURCES.has(source)) throw new Error('job.source is invalid.');
+  if (discoverySource != null && !DISCOVERY_SOURCES.has(discoverySource)) throw new Error('job.discoverySource is invalid.');
+  if (applicationChannel != null && !SOURCES.has(applicationChannel)) throw new Error('job.applicationChannel is invalid.');
   if (!ELIGIBILITY.has(eligibility)) throw new Error('job.eligibility must be eligible, unclear, or ineligible.');
   if (!POSTING_STATUS.has(postingStatus)) throw new Error('job.postingStatus must be active, closed, or unclear.');
   if (!JOB_SENIORITIES.has(seniority)) throw new Error('job.seniority is invalid.');
@@ -393,7 +406,12 @@ export function validateLedgerEntry(input) {
     answers: entry.answers ?? {},
   };
   if (entry.employerJobId != null) normalized.employerJobId = string(entry.employerJobId, 'entry.employerJobId', 300);
+  if (entry.discoverySource != null) normalized.discoverySource = string(entry.discoverySource, 'entry.discoverySource', 40).toLowerCase();
+  if (entry.applicationChannel != null) normalized.applicationChannel = string(entry.applicationChannel, 'entry.applicationChannel', 40).toLowerCase();
+  if (entry.roundId != null) normalized.roundId = string(entry.roundId, 'entry.roundId', 180);
   if (!SOURCES.has(normalized.source)) throw new Error('entry.source is invalid.');
+  if (normalized.discoverySource != null && !DISCOVERY_SOURCES.has(normalized.discoverySource)) throw new Error('entry.discoverySource is invalid.');
+  if (normalized.applicationChannel != null && !SOURCES.has(normalized.applicationChannel)) throw new Error('entry.applicationChannel is invalid.');
   if (!Number.isInteger(normalized.score) || normalized.score < 0 || normalized.score > 100) throw new Error('entry.score must be an integer from 0 to 100.');
   if (normalized.status !== 'submitted') throw new Error('New ledger entries must have status submitted.');
   if (!APPROVALS.has(normalized.approval)) throw new Error('entry.approval is invalid.');
@@ -596,6 +614,63 @@ async function withStateLock(name, action) {
   }
 }
 
+async function writePrivateJson(file, value) {
+  const temporary = `${file}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporary, file);
+  await chmod(file, 0o600);
+}
+
+async function readPrivateJson(file, fallback) {
+  try { return JSON.parse(await readFile(file, 'utf8')); }
+  catch (error) {
+    if (error.code === 'ENOENT') return fallback;
+    throw new Error(`${basename(file)} is missing or unreadable.`);
+  }
+}
+
+function autonomyView(value) {
+  const enabled = value?.enabled === true && value?.mode === 'routine-auto';
+  return {
+    version: 1,
+    enabled,
+    mode: enabled ? 'routine-auto' : null,
+    scopes: enabled ? [...AUTONOMY_SCOPES] : [],
+    hardStops: [...AUTONOMY_HARD_STOPS],
+    maySubmitRoutineApplications: enabled,
+    maySendVerifiedRecruitingEmail: enabled,
+    mayCreateImprovementPr: enabled,
+    mayMergeReleaseOrPublish: false,
+    mayBypassHostPermissionPrompts: false,
+    ...(value?.grantedAt ? { grantedAt: value.grantedAt } : {}),
+    ...(value?.revokedAt ? { revokedAt: value.revokedAt } : {}),
+  };
+}
+
+async function autonomyStatus() {
+  const file = join(await ensureStateDir(), 'autonomy.json');
+  return autonomyView(await readPrivateJson(file, { version: 1, enabled: false }));
+}
+
+async function autonomyGrant(input) {
+  const value = object(input, 'autonomy grant');
+  const allowed = new Set(['mode']);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`Unknown autonomy grant property: ${key}.`);
+  if (value.mode !== 'routine-auto') throw new Error('autonomy grant mode must be routine-auto.');
+  const grant = { version: 1, enabled: true, mode: 'routine-auto', scopes: [...AUTONOMY_SCOPES], grantedAt: new Date().toISOString() };
+  const file = join(await ensureStateDir(), 'autonomy.json');
+  await writePrivateJson(file, grant);
+  return autonomyView(grant);
+}
+
+async function autonomyRevoke() {
+  const file = join(await ensureStateDir(), 'autonomy.json');
+  const current = await readPrivateJson(file, { version: 1, enabled: false });
+  const revoked = { version: 1, enabled: false, revokedAt: new Date().toISOString(), ...(current.grantedAt ? { grantedAt: current.grantedAt } : {}) };
+  await writePrivateJson(file, revoked);
+  return autonomyView(revoked);
+}
+
 async function storeProfile(profileInput) {
   const profile = validateProfile(profileInput);
   if (process.platform === 'win32') await ensureStateDir();
@@ -671,11 +746,22 @@ function duplicateResult(entries, candidate) {
     || normalizeUrl(entry.url) === candidateUrl);
   const possible = hard ? null : entries.find(sameCompanyRole);
   const match = hard ?? possible;
+  const companyApplications = candidateCompany
+    ? entries.filter((entry) => normalizedText(entry.company) === candidateCompany).slice(-20).map((entry) => ({
+      id: entry.id,
+      company: entry.company,
+      role: entry.role,
+      submittedAt: entry.submittedAt,
+      ...(entry.employerJobId ? { employerJobId: entry.employerJobId } : {}),
+    }))
+    : [];
   return {
     duplicate: Boolean(hard),
     possibleDuplicate: Boolean(possible),
     reason: hard ? (hard.id === candidate.id ? 'id' : candidate.employerJobId && hard.employerJobId ? 'employer-job-id' : 'url') : possible ? 'company-role' : null,
     match: match ? { id: match.id, company: match.company, role: match.role, submittedAt: match.submittedAt } : null,
+    sameCompany: companyApplications.length > 0,
+    companyApplications,
   };
 }
 
@@ -691,13 +777,178 @@ async function ledgerAdd(entryInput, duplicateOverride) {
   return withStateLock('applications', async (dir) => {
     const file = join(dir, 'applications.ndjson');
     const entries = await jsonLines(file);
+    if (entry.roundId) {
+      const roundEvents = await jsonLines(join(dir, 'rounds.ndjson'));
+      if (!roundEvents.some((event) => event.type === 'started' && event.roundId === entry.roundId)) throw new Error('entry.roundId does not identify a started round.');
+      if (roundEvents.some((event) => event.type === 'completed' && event.roundId === entry.roundId)) throw new Error('entry.roundId identifies a completed round.');
+    }
     const duplicate = duplicateResult(entries, entry);
     if (duplicate.duplicate) throw new Error('This application is already recorded.');
     if (duplicate.possibleDuplicate && duplicateOverride !== 'NEW REQUISITION CONFIRMED') throw new Error('A possible same-company role duplicate requires NEW REQUISITION CONFIRMED.');
     await appendFile(file, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
     await chmod(file, 0o600);
+    if (entry.roundId) {
+      const roundsFile = join(dir, 'rounds.ndjson');
+      await appendFile(roundsFile, `${JSON.stringify({ type: 'submission-confirmed', roundId: entry.roundId, applicationId: entry.id, occurredAt: entry.submittedAt })}\n`, { mode: 0o600 });
+      await chmod(roundsFile, 0o600);
+    }
     return { recorded: entry.id, review: buildReview([...entries, entry]) };
   });
+}
+
+async function appendPrivateEvent(name, event) {
+  return withStateLock(name, async (dir) => {
+    const file = join(dir, `${name}.ndjson`);
+    await appendFile(file, `${JSON.stringify(event)}\n`, { mode: 0o600 });
+    await chmod(file, 0o600);
+    return event;
+  });
+}
+
+function isoDate(value, label) {
+  const result = string(value ?? new Date().toISOString(), label, 80);
+  if (Number.isNaN(Date.parse(result))) throw new Error(`${label} must be an ISO date.`);
+  return result;
+}
+
+async function roundStart(input) {
+  const value = object(input, 'round');
+  const allowed = new Set(['requestedCount', 'startedAt']);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`Unknown round property: ${key}.`);
+  const event = {
+    type: 'started',
+    roundId: `round-${new Date().toISOString().slice(0, 10)}-${randomUUID()}`,
+    requestedCount: integer(value.requestedCount, 'round.requestedCount', 1, 1000),
+    occurredAt: isoDate(value.startedAt, 'round.startedAt'),
+  };
+  await appendPrivateEvent('rounds', event);
+  return { roundId: event.roundId, requestedCount: event.requestedCount, startedAt: event.occurredAt, completed: false };
+}
+
+function replayAttention(events, roundId = null) {
+  const active = new Map();
+  for (const event of events) {
+    if (event.type === 'opened') active.set(event.id, event);
+    else if (event.type === 'resolved') active.delete(event.id);
+  }
+  const priority = (blocker) => {
+    if (['authentication', 'mfa', 'captcha'].includes(blocker)) return 0;
+    if (['legal-attestation', 'ambiguous-authorization', 'ambiguous-compensation'].includes(blocker)) return 1;
+    return 2;
+  };
+  return [...active.values()]
+    .filter((item) => roundId == null || item.roundId === roundId)
+    .sort((a, b) => priority(a.blocker) - priority(b.blocker) || Date.parse(a.createdAt) - Date.parse(b.createdAt));
+}
+
+async function attentionList(roundId = null) {
+  const events = await jsonLines(join(await ensureStateDir(), 'attention.ndjson'));
+  const items = replayAttention(events, roundId);
+  return { count: items.length, items };
+}
+
+async function attentionAdd(input) {
+  const value = object(input, 'attention item');
+  const allowed = new Set(['roundId', 'applicationId', 'url', 'stage', 'blocker', 'requiredActions', 'createdAt']);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`Unknown attention property: ${key}.`);
+  const stage = string(value.stage, 'attention.stage', 40).toLowerCase();
+  const blocker = string(value.blocker, 'attention.blocker', 60).toLowerCase();
+  if (!ATTENTION_STAGES.has(stage)) throw new Error('attention.stage is invalid.');
+  if (!ATTENTION_BLOCKERS.has(blocker)) throw new Error('attention.blocker is invalid.');
+  const requiredActions = stringArray(value.requiredActions, 'attention.requiredActions', true).map((item) => item.toLowerCase());
+  if (requiredActions.length > 8 || requiredActions.some((item) => !REQUIRED_ACTIONS.has(item))) throw new Error('attention.requiredActions must contain only documented actions.');
+  const event = {
+    type: 'opened',
+    id: `attention-${randomUUID()}`,
+    roundId: string(value.roundId, 'attention.roundId', 180),
+    applicationId: string(value.applicationId, 'attention.applicationId', 180),
+    url: string(value.url, 'attention.url', 2048),
+    stage,
+    blocker,
+    requiredActions: [...new Set(requiredActions)],
+    createdAt: isoDate(value.createdAt, 'attention.createdAt'),
+  };
+  await appendPrivateEvent('attention', event);
+  return event;
+}
+
+async function attentionResolve(input) {
+  const value = object(input, 'attention resolution');
+  const allowed = new Set(['id', 'resolvedAt']);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`Unknown attention resolution property: ${key}.`);
+  const id = string(value.id, 'attention.id', 180);
+  const current = await attentionList();
+  if (!current.items.some((item) => item.id === id)) throw new Error('Attention item is not active.');
+  const event = { type: 'resolved', id, resolvedAt: isoDate(value.resolvedAt, 'attention.resolvedAt') };
+  await appendPrivateEvent('attention', event);
+  return { resolved: id };
+}
+
+async function roundStatus(roundId = null) {
+  const dir = await ensureStateDir();
+  const events = await jsonLines(join(dir, 'rounds.ndjson'));
+  const starts = events.filter((event) => event.type === 'started');
+  const id = roundId ?? starts.at(-1)?.roundId;
+  if (!id) throw new Error('No application round has been started.');
+  const started = starts.find((event) => event.roundId === id);
+  if (!started) throw new Error('Application round was not found.');
+  const applications = (await jsonLines(join(dir, 'applications.ndjson'))).filter((entry) => entry.roundId === id && entry.status === 'submitted');
+  const confirmedCount = new Set(applications.map((entry, index) => canonicalApplicationKey(entry, String(index)))).size;
+  const attention = await attentionList(id);
+  const completion = events.find((event) => event.type === 'completed' && event.roundId === id);
+  return {
+    roundId: id,
+    requestedCount: started.requestedCount,
+    confirmedCount,
+    remainingCount: Math.max(0, started.requestedCount - confirmedCount),
+    blockedCount: attention.count,
+    completed: Boolean(completion),
+    startedAt: started.occurredAt,
+    ...(completion ? { completedAt: completion.occurredAt } : {}),
+  };
+}
+
+async function roundComplete(input) {
+  const value = object(input, 'round completion');
+  const allowed = new Set(['roundId', 'completedAt']);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`Unknown round completion property: ${key}.`);
+  const status = await roundStatus(string(value.roundId, 'round.roundId', 180));
+  if (status.completed) return status;
+  if (status.confirmedCount < status.requestedCount) throw new Error(`Round requires ${status.requestedCount} confirmed submissions before completion.`);
+  const event = { type: 'completed', roundId: status.roundId, occurredAt: isoDate(value.completedAt, 'round.completedAt') };
+  await appendPrivateEvent('rounds', event);
+  return { ...status, completed: true, completedAt: event.occurredAt };
+}
+
+async function frictionRecord(input) {
+  const value = object(input, 'friction event');
+  const allowed = new Set(['stage', 'ats', 'errorCode', 'reproducible', 'general', 'observedAt']);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`Unknown friction property: ${key}.`);
+  const stage = string(value.stage, 'friction.stage', 40).toLowerCase();
+  const ats = string(value.ats, 'friction.ats', 40).toLowerCase();
+  const errorCode = string(value.errorCode, 'friction.errorCode', 100).toLowerCase();
+  if (!ATTENTION_STAGES.has(stage)) throw new Error('friction.stage is invalid.');
+  if (!SOURCES.has(ats)) throw new Error('friction.ats is invalid.');
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(errorCode)) throw new Error('friction.errorCode must be a stable kebab-case code.');
+  if (typeof value.reproducible !== 'boolean' || typeof value.general !== 'boolean') throw new Error('friction.reproducible and friction.general must be Booleans.');
+  const event = {
+    id: `friction-${randomUUID()}`,
+    type: 'observed',
+    stage,
+    ats,
+    errorCode,
+    reproducible: value.reproducible,
+    general: value.general,
+    qualifiesForPr: value.reproducible && value.general,
+    observedAt: isoDate(value.observedAt, 'friction.observedAt'),
+  };
+  await appendPrivateEvent('friction', event);
+  return event;
+}
+
+async function frictionList() {
+  const items = (await jsonLines(join(await ensureStateDir(), 'friction.ndjson'))).filter((event) => event.type === 'observed');
+  return { count: items.length, items, prCandidates: items.filter((item) => item.qualifiesForPr) };
 }
 
 async function ledgerOutcome(outcomeInput) {
@@ -781,7 +1032,7 @@ async function outcomeTelemetry(application, outcome) {
       ...identity,
       company: application.company,
       title: application.role,
-      ats: sourceToAts(application.source),
+      ats: sourceToAts(application.applicationChannel ?? application.source),
       outcome: outcome.status,
       daysSinceSubmission: Math.max(0, Math.min(3650, Math.floor((Date.parse(outcome.occurredAt) - Date.parse(application.submittedAt)) / 86_400_000))),
       ...(outcome.interviewQuality ? { interviewQuality: outcome.interviewQuality } : {}),
@@ -800,6 +1051,21 @@ function reviewTelemetry(review) {
       offerCount: review.outcomeCounts.offer,
       withdrawalCount: review.outcomeCounts.withdrawn,
       reviewDue: review.reviewDue,
+    },
+  };
+}
+
+function roundCompletedTelemetry(round) {
+  return {
+    event: 'round_completed',
+    properties: {
+      requestedCount: round.requestedCount,
+      submittedCount: round.confirmedCount,
+      assessedCount: round.confirmedCount,
+      skippedCount: 0,
+      pausedCount: round.blockedCount,
+      errorCount: 0,
+      durationBucket: durationBucket(Math.max(0, Date.parse(round.completedAt) - Date.parse(round.startedAt))),
     },
   };
 }
@@ -841,7 +1107,21 @@ async function executeCommand([area, action, value], telemetry, session) {
     domainEvents.push(reviewTelemetry(result));
   } else if (area === 'ledger' && action === 'review-ack' && value === '--stdin') {
     result = await ledgerReviewAcknowledge(await jsonStdin());
-  } else throw new Error('Usage: profile set|migrate --stdin; profile check|field <name>; resume import <url-or-pdf>|path; score --stdin; ledger check|add|outcome|review-ack --stdin; ledger review; telemetry status|enable|disable|reset|preview --stdin|record --stdin');
+  } else if (area === 'autonomy' && action === 'grant' && value === '--stdin') result = await autonomyGrant(await jsonStdin());
+  else if (area === 'autonomy' && action === 'status' && value == null) result = await autonomyStatus();
+  else if (area === 'autonomy' && action === 'preview' && value == null) result = await autonomyStatus();
+  else if (area === 'autonomy' && action === 'revoke' && value == null) result = await autonomyRevoke();
+  else if (area === 'round' && action === 'start' && value === '--stdin') result = await roundStart(await jsonStdin());
+  else if (area === 'round' && action === 'status') result = await roundStatus(value ?? null);
+  else if (area === 'round' && action === 'complete' && value === '--stdin') {
+    result = await roundComplete(await jsonStdin());
+    domainEvents.push(roundCompletedTelemetry(result));
+  } else if (area === 'attention' && action === 'add' && value === '--stdin') result = await attentionAdd(await jsonStdin());
+  else if (area === 'attention' && action === 'list' && value == null) result = await attentionList();
+  else if (area === 'attention' && action === 'resolve' && value === '--stdin') result = await attentionResolve(await jsonStdin());
+  else if (area === 'friction' && action === 'record' && value === '--stdin') result = await frictionRecord(await jsonStdin());
+  else if (area === 'friction' && action === 'list' && value == null) result = await frictionList();
+  else throw new Error('Usage: profile set|migrate --stdin; profile check|field <name>; resume import <url-or-pdf>|path; score --stdin; ledger check|add|outcome|review-ack --stdin; ledger review; autonomy grant --stdin|status|preview|revoke; round start|complete --stdin|status [round-id]; attention add|resolve --stdin|list; friction record --stdin|list; telemetry status|enable|disable|reset|preview --stdin|record --stdin');
   for (const event of domainEvents) await telemetry.record(event, session);
   return result;
 }

--- a/job-application-agent/scripts/telemetry-schema.mjs
+++ b/job-application-agent/scripts/telemetry-schema.mjs
@@ -9,7 +9,7 @@ export const TELEMETRY_MAX_BYTES = 4096;
 
 const values = (...items) => new Set(items);
 const ATS = values('linkedin', 'greenhouse', 'lever', 'ashby', 'workable', 'comeet', 'workday', 'rippling', 'smartrecruiters', 'google-form', 'company', 'email', 'other');
-const SOURCES = values('linkedin', 'x', 'hacker-news', 'yc', 'aggregator', 'company', 'email', 'referral', 'other');
+const SOURCES = values('direct-company', 'linkedin', 'x', 'hacker-news', 'yc', 'job-board', 'aggregator', 'company', 'email', 'referral', 'user-supplied', 'web-search', 'other');
 const DURATIONS = values('under-1s', '1-5s', '5-30s', '30-60s', '1-2m', '2-5m', '5-15m', '15m-plus');
 const COMMANDS = values('onboard', 'search', 'assess', 'apply', 'batch', 'round', 'outcome', 'review', 'resume', 'profile', 'telemetry', 'other');
 const RESULTS = values('success', 'paused', 'skipped', 'abandoned', 'error');

--- a/job-application-agent/tests/skill-contract.test.mjs
+++ b/job-application-agent/tests/skill-contract.test.mjs
@@ -14,3 +14,19 @@ test('requires direct path resume upload before native picker fallback', async (
   assert.match(guidance, /native (file )?picker.*fallback/i);
   assert.match(guidance, /verify.*filename/i);
 });
+
+test('documents durable autonomy, resumable rounds, attention and friction controls', async () => {
+  const skill = await readFile(new URL('../SKILL.md', import.meta.url), 'utf8');
+  const autonomy = await readFile(new URL('../references/AUTONOMY.md', import.meta.url), 'utf8');
+  const runs = await readFile(new URL('../references/RUNS.md', import.meta.url), 'utf8');
+
+  assert.match(skill, /autonomy status/);
+  assert.match(skill, /round status/);
+  assert.match(skill, /attention list/);
+  assert.match(skill, /friction record/);
+  assert.match(autonomy, /never.*merge.*publish/i);
+  assert.match(autonomy, /CAPTCHA/i);
+  assert.match(runs, /visible.*confirmation/i);
+  assert.match(runs, /discoverySource/);
+  assert.match(runs, /applicationChannel/);
+});

--- a/job-application-agent/tests/telemetry-schema.test.mjs
+++ b/job-application-agent/tests/telemetry-schema.test.mjs
@@ -41,6 +41,25 @@ test('accepts rich structured job and workflow events', () => {
   assert.equal(event.properties.fitScore, 84);
 });
 
+test('accepts bounded discovery sources without exposing application URLs or attention details', () => {
+  for (const source of ['direct-company', 'job-board', 'user-supplied', 'web-search']) {
+    const event = validateEvent({
+      event: 'job_discovered',
+      properties: {
+        ...baseJob,
+        source,
+        jobCountry: 'India',
+        workMode: 'remote',
+        seniority: 'staff',
+        employmentType: 'full-time',
+        roleFamily: 'product-engineering',
+      },
+    });
+    assert.equal(event.properties.source, source);
+    assert.equal('url' in event.properties, false);
+  }
+});
+
 test('rejects direct identity, free-form content, unknown properties, and oversized payloads', () => {
   const valid = { event: 'job_assessed', properties: { ...baseJob, fitScore: 80, eligibility: 'eligible', decision: 'review', matchTags: [], gapTags: [] } };
   assert.throws(() => validateEvent({ ...valid, properties: { ...valid.properties, company: 'candidate@example.com' } }), /identity/i);

--- a/job-application-agent/tests/workflow-state.test.mjs
+++ b/job-application-agent/tests/workflow-state.test.mjs
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+
+async function fixture(t, label) {
+  const directory = await mkdtemp(join(tmpdir(), `public-job-agent-${label}-`));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  await writeFile(join(directory, 'telemetry.json'), JSON.stringify({
+    version: 1,
+    enabled: false,
+    disclosed: true,
+    graceConsumed: true,
+    installationEventPending: false,
+  }));
+  return { directory, env: { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory } };
+}
+
+function cli(env, args, input) {
+  return JSON.parse(execFileSync(process.execPath, [script, ...args], {
+    env,
+    encoding: 'utf8',
+    ...(input === undefined ? {} : { input: JSON.stringify(input) }),
+  }));
+}
+
+function cliFailure(env, args, input) {
+  return spawnSync(process.execPath, [script, ...args], {
+    env,
+    encoding: 'utf8',
+    ...(input === undefined ? {} : { input: JSON.stringify(input) }),
+  });
+}
+
+function submission(index, roundId, overrides = {}) {
+  return {
+    id: `round-role-${index}`,
+    company: `Company ${index}`,
+    role: 'Senior Product Engineer',
+    url: `https://jobs.example.com/${index}`,
+    employerJobId: `example:${index}`,
+    source: 'ashby',
+    discoverySource: 'linkedin',
+    applicationChannel: 'ashby',
+    roundId,
+    score: 86,
+    status: 'submitted',
+    submittedAt: `2026-08-${String(index + 1).padStart(2, '0')}T10:00:00.000Z`,
+    approval: 'STANDING AUTHORIZATION',
+    answers: {},
+    ...overrides,
+  };
+}
+
+test('persists a scoped autonomy grant and revokes future routine transmissions', async (t) => {
+  const { directory, env } = await fixture(t, 'autonomy');
+
+  const granted = cli(env, ['autonomy', 'grant', '--stdin'], { mode: 'routine-auto' });
+  assert.equal(granted.enabled, true);
+  assert.equal(granted.mode, 'routine-auto');
+  assert.ok(granted.scopes.includes('submit'));
+  assert.ok(granted.scopes.includes('send-recruiting-email'));
+  assert.ok(granted.hardStops.includes('captcha'));
+
+  const status = cli(env, ['autonomy', 'status']);
+  assert.equal(status.enabled, true);
+  assert.equal(status.mode, 'routine-auto');
+  assert.equal((await stat(join(directory, 'autonomy.json'))).mode & 0o777, 0o600);
+
+  const preview = cli(env, ['autonomy', 'preview']);
+  assert.equal(preview.maySubmitRoutineApplications, true);
+  assert.equal(preview.mayBypassHostPermissionPrompts, false);
+  assert.ok(preview.hardStops.includes('legal-attestation'));
+
+  const revoked = cli(env, ['autonomy', 'revoke']);
+  assert.equal(revoked.enabled, false);
+  assert.equal(cli(env, ['autonomy', 'status']).enabled, false);
+});
+
+test('counts only unique confirmed ledger submissions for an explicit round', async (t) => {
+  const { directory, env } = await fixture(t, 'round');
+  const started = cli(env, ['round', 'start', '--stdin'], { requestedCount: 30 });
+  assert.match(started.roundId, /^round-/);
+
+  cli(env, ['attention', 'add', '--stdin'], {
+    roundId: started.roundId,
+    applicationId: 'blocked-role',
+    url: 'https://jobs.example.com/blocked-role',
+    stage: 'submission',
+    blocker: 'captcha',
+    requiredActions: ['complete-captcha'],
+  });
+
+  for (let index = 0; index < 30; index += 1) {
+    cli(env, ['ledger', 'add', '--stdin'], submission(index, started.roundId));
+  }
+
+  const status = cli(env, ['round', 'status', started.roundId]);
+  assert.equal(status.requestedCount, 30);
+  assert.equal(status.confirmedCount, 30);
+  assert.equal(status.remainingCount, 0);
+  assert.equal(status.blockedCount, 1);
+  assert.equal(status.completed, false);
+
+  const completed = cli(env, ['round', 'complete', '--stdin'], { roundId: started.roundId });
+  assert.equal(completed.completed, true);
+  assert.equal(cli(env, ['round', 'status', started.roundId]).completed, true);
+  const roundEvents = (await readFile(join(directory, 'rounds.ndjson'), 'utf8')).trim().split('\n').map(JSON.parse);
+  assert.equal(roundEvents.filter((event) => event.type === 'submission-confirmed').length, 30);
+  assert.equal(roundEvents.length, 32);
+  assert.equal((await stat(join(directory, 'rounds.ndjson'))).mode & 0o777, 0o600);
+});
+
+test('does not complete a round from blocked or partially filled applications', async (t) => {
+  const { env } = await fixture(t, 'incomplete-round');
+  const { roundId } = cli(env, ['round', 'start', '--stdin'], { requestedCount: 2 });
+  cli(env, ['ledger', 'add', '--stdin'], submission(1, roundId));
+  cli(env, ['attention', 'add', '--stdin'], {
+    roundId,
+    applicationId: 'blocked-role',
+    url: 'https://jobs.example.com/blocked-role',
+    stage: 'submission',
+    blocker: 'legal-attestation',
+    requiredActions: ['review-legal'],
+  });
+
+  const failed = cliFailure(env, ['round', 'complete', '--stdin'], { roundId });
+  assert.equal(failed.status, 1);
+  assert.match(failed.stderr, /2 confirmed submissions/i);
+  assert.equal(cli(env, ['round', 'status', roundId]).confirmedCount, 1);
+});
+
+test('replays and prioritizes an owner-only attention queue', async (t) => {
+  const { directory, env } = await fixture(t, 'attention');
+  const { roundId } = cli(env, ['round', 'start', '--stdin'], { requestedCount: 30 });
+  const judgment = cli(env, ['attention', 'add', '--stdin'], {
+    roundId,
+    applicationId: 'role-judgment',
+    url: 'https://jobs.example.com/judgment',
+    stage: 'answers',
+    blocker: 'judgment',
+    requiredActions: ['provide-judgment'],
+  });
+  const captcha = cli(env, ['attention', 'add', '--stdin'], {
+    roundId,
+    applicationId: 'role-captcha',
+    url: 'https://jobs.example.com/captcha',
+    stage: 'submission',
+    blocker: 'captcha',
+    requiredActions: ['complete-captcha'],
+  });
+
+  const before = cli(env, ['attention', 'list']);
+  assert.deepEqual(before.items.map((item) => item.id), [captcha.id, judgment.id]);
+  assert.equal((await stat(join(directory, 'attention.ndjson'))).mode & 0o777, 0o600);
+
+  cli(env, ['attention', 'resolve', '--stdin'], { id: captcha.id });
+  const after = cli(env, ['attention', 'list']);
+  assert.deepEqual(after.items.map((item) => item.id), [judgment.id]);
+});
+
+test('qualifies only reproducible general-purpose friction for a public PR', async (t) => {
+  const { directory, env } = await fixture(t, 'friction');
+  const local = cli(env, ['friction', 'record', '--stdin'], {
+    stage: 'upload',
+    ats: 'ashby',
+    errorCode: 'candidate-specific-document',
+    reproducible: true,
+    general: false,
+  });
+  const general = cli(env, ['friction', 'record', '--stdin'], {
+    stage: 'upload',
+    ats: 'ashby',
+    errorCode: 'direct-upload-fallback-opened',
+    reproducible: true,
+    general: true,
+  });
+
+  assert.equal(local.qualifiesForPr, false);
+  assert.equal(general.qualifiesForPr, true);
+  const listed = cli(env, ['friction', 'list']);
+  assert.equal(listed.items.length, 2);
+  assert.deepEqual(listed.prCandidates.map((item) => item.id), [general.id]);
+  assert.equal((await stat(join(directory, 'friction.ndjson'))).mode & 0o777, 0o600);
+  assert.equal((await readFile(join(directory, 'friction.ndjson'), 'utf8')).includes('candidate@example.com'), false);
+});
+
+test('preserves independent discovery and application channel attribution', async (t) => {
+  const { directory, env } = await fixture(t, 'attribution');
+  const { roundId } = cli(env, ['round', 'start', '--stdin'], { requestedCount: 1 });
+  cli(env, ['ledger', 'add', '--stdin'], submission(0, roundId));
+  const stored = JSON.parse((await readFile(join(directory, 'applications.ndjson'), 'utf8')).trim());
+  assert.equal(stored.source, 'ashby');
+  assert.equal(stored.discoverySource, 'linkedin');
+  assert.equal(stored.applicationChannel, 'ashby');
+  assert.equal(stored.roundId, roundId);
+
+  const companyHistory = cli(env, ['ledger', 'check', '--stdin'], {
+    id: 'another-role',
+    company: 'Company 0',
+    role: 'Staff Backend Engineer',
+    url: 'https://jobs.example.com/another-role',
+    employerJobId: 'example:another-role',
+  });
+  assert.equal(companyHistory.duplicate, false);
+  assert.equal(companyHistory.sameCompany, true);
+  assert.equal(companyHistory.companyApplications.length, 1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-application-agent",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-application-agent",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "bin": {
         "job-application-agent": "bin/job-application-agent.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-application-agent",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A privacy-first Agent Skill and CLI for evidence-based job discovery, application completion, and outcome tracking.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- persist a scoped routine-auto grant with fixed safety stops
- add explicit round IDs, confirmation events, company-history checks, and source/channel attribution
- add owner-only attention and friction queues for resumable work and sanitized improvement PR qualification
- document the workflow and bump the proposed package version to 3.1.0

## Safety boundaries
- authentication, MFA, CAPTCHA, legal, demographic, identifier, unverifiable-claim, authorization, and compensation stops remain mandatory
- standing autonomy cannot bypass browser or host prompts
- improvement automation stops at a validated PR; it cannot merge, tag, release, publish, or change candidate facts/targeting
- live application runs remain on the released package

## Validation
- npm test: 88 passed
- npm run check
- npm run privacy-audit: 3 passed
- npm run smoke:package
- skill quick_validate.py
- staged diff secret scan and git diff --check