### PR TITLE
ci: publish new npm versions from main

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,8 +1,8 @@
 name: Publish npm package
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -23,8 +23,20 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - run: npm ci
-      - run: npm run check && npm test && npm run privacy-audit
-      - name: Verify release tag matches package version
-        if: github.event_name == 'release'
-        run: test "v$(node -p "require('./package.json').version")" = "${{ github.event.release.tag_name }}"
-      - run: npm publish --access public
+      - run: npm run check && npm test && npm run privacy-audit && npm run smoke:package
+      - name: Check whether this version is already published
+        id: version-check
+        shell: bash
+        run: |
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+          if npm view "${package_name}@${package_version}" version --json >/dev/null 2>&1; then
+            echo "publish_needed=false" >> "$GITHUB_OUTPUT"
+            echo "${package_name}@${package_version} is already published."
+          else
+            echo "publish_needed=true" >> "$GITHUB_OUTPUT"
+            echo "${package_name}@${package_version} will be published."
+          fi
+      - name: Publish new version
+        if: steps.version-check.outputs.publish_needed == 'true'
+        run: npm publish --access public

--- a/installer/tests/publish-workflow.test.mjs
+++ b/installer/tests/publish-workflow.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const workflowUrl = new URL('../../.github/workflows/publish-npm.yml', import.meta.url);
+
+test('npm publishing runs for main updates and skips versions already on the registry', async () => {
+  const workflow = await readFile(workflowUrl, 'utf8');
+
+  assert.match(workflow, /push:\s*\n\s+branches:\s*\[main\]/);
+  assert.match(workflow, /id-token:\s*write/);
+  assert.match(workflow, /npm view [^\n]+version/);
+  assert.match(workflow, /publish_needed/);
+  assert.match(workflow, /if: steps\.version-check\.outputs\.publish_needed == 'true'/);
+  assert.match(workflow, /npm publish --access public/);
+  assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/);
+});


### PR DESCRIPTION
## Summary

- run the trusted npm publisher after every push to main
- publish only when package.json contains a version not yet present on npm
- retain OIDC trusted publishing, npm-production environment protection, full validation, privacy audit, and package smoke test
- add a regression test covering the trigger, version gate, OIDC permission, and absence of long-lived npm tokens

## Verification

- workflow YAML parsed successfully
- npm run check
- npm test (89 tests)
- npm run privacy-audit
- npm run smoke:package
- tracked-file secret scan