### PR TITLE
chore: release 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-application-agent",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-application-agent",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "bin": {
         "job-application-agent": "bin/job-application-agent.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-application-agent",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A privacy-first Agent Skill and CLI for evidence-based job discovery, application completion, and outcome tracking.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump the npm package to 3.1.1
- publish the simplified README in a new immutable npm package version

## Verification

- npm run check
- npm test (89 tests)
- npm run privacy-audit
- npm run smoke:package
- verified the packed README exactly matches the repository README