### PR TITLE
fix: harden installer update + persistence against supply-chain execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,35 @@ See [`ANALYTICS.md`](job-application-agent/references/ANALYTICS.md) for the even
 <details>
 <summary><strong>Installation and update details</strong></summary>
 
-The installer places the skill at `~/.agents/skills/job-application-agent` and enables scheduled background update checks by default. Those checks never download or execute a newly published package. Compatible vendor skill directories are also supported when they already exist.
+The installer places the skill at `~/.agents/skills/job-application-agent`. Compatible vendor skill directories are also supported when they already exist.
 
 ```bash
 npx job-application-agent@3.1.1 status
 npx job-application-agent@3.1.1 update
-npx job-application-agent@3.1.1 updates disable
-npx job-application-agent@3.1.1 updates enable
+npx job-application-agent@3.1.1 uninstall
 ```
 
 Updates require an explicit exact-version command and are staged and checksum-validated before replacement. Private candidate state lives outside the replaceable skill directory.
+
+### Background update checks (explicit opt-in)
+
+Persistent background checks are **disabled by default**. Nothing runs at login, boot, or on an hourly timer unless you explicitly ask for it:
+
+```bash
+npx job-application-agent@3.1.1 install --enable-background-updates
+npx job-application-agent@3.1.1 updates enable
+npx job-application-agent@3.1.1 updates disable
+```
+
+When enabled, a user-level scheduler (macOS LaunchAgent, Linux user systemd timer, or Windows scheduled task) runs a **local check only**. That check:
+
+- invokes the already-installed Node.js executable directly with a fixed argument list (no shell, no `$PATH` lookup);
+- records a timestamped `update-status.json` notice;
+- never calls npm, npx, or `npm exec`;
+- never resolves a mutable npm tag;
+- never downloads, installs, or executes a newly published package.
+
+If an update is warranted, the notice marks it `manual-review-required`; applying it still requires a user-run `update` command with an exact version. `uninstall` removes the scheduler and every related artifact.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Job Application Agent is an [Agent Skill](https://agentskills.io/specification) 
 Install it:
 
 ```bash
-npx job-application-agent@latest install
+npx job-application-agent@3.1.1 install
 ```
 
 Then tell your coding agent:
@@ -124,16 +124,16 @@ See [`ANALYTICS.md`](job-application-agent/references/ANALYTICS.md) for the even
 <details>
 <summary><strong>Installation and update details</strong></summary>
 
-The installer places the skill at `~/.agents/skills/job-application-agent` and enables automatic updates by default. Compatible vendor skill directories are also supported when they already exist.
+The installer places the skill at `~/.agents/skills/job-application-agent` and enables scheduled background update checks by default. Those checks never download or execute a newly published package. Compatible vendor skill directories are also supported when they already exist.
 
 ```bash
-npx job-application-agent@latest status
-npx job-application-agent@latest update
-npx job-application-agent@latest updates disable
-npx job-application-agent@latest updates enable
+npx job-application-agent@3.1.1 status
+npx job-application-agent@3.1.1 update
+npx job-application-agent@3.1.1 updates disable
+npx job-application-agent@3.1.1 updates enable
 ```
 
-Updates are staged and validated before replacement. Private candidate state lives outside the replaceable skill directory.
+Updates require an explicit exact-version command and are staged and checksum-validated before replacement. Private candidate state lives outside the replaceable skill directory.
 
 </details>
 

--- a/installer/src/cli.mjs
+++ b/installer/src/cli.mjs
@@ -3,10 +3,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { installSkill, readInstallStatus, resolveAgentHome, setAutomaticUpdates, updateSkill } from './installer.mjs';
+import { installSkill, readInstallStatus, resolveAgentHome, setAutomaticUpdates, uninstallSkill, updateSkill } from './installer.mjs';
 import { createUpdateRunner } from './runner.mjs';
 
-const USAGE = `Usage:\n  job-application-agent install\n  job-application-agent update\n  job-application-agent status\n  job-application-agent updates enable|disable\n`;
+const USAGE = `Usage:\n  job-application-agent install [--enable-background-updates]\n  job-application-agent update [--enable-background-updates]\n  job-application-agent status\n  job-application-agent updates enable|disable\n  job-application-agent uninstall\n`;
 
 function defaultPackageRoot() {
   return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -28,37 +28,52 @@ export async function runCli(args, options = {}) {
   const packageVersion = options.packageVersion || await defaultVersion(packageRoot);
   const scheduler = process.env.JOB_APPLICATION_AGENT_NO_SCHEDULER === '1' ? false : options.scheduler;
   const { homeDir, agentHome } = resolveHome(options);
-  const shared = {
-    packageRoot,
-    packageVersion,
-    homeDir,
-    agentHome,
-    platform: options.platform,
-    scheduler,
-  };
   const command = args[0];
+  const backgroundUpdates = args.includes('--enable-background-updates');
 
   if (command === 'status') {
     const status = await readInstallStatus({ homeDir, agentHome });
     output(status.installed
-      ? `Installed version: ${status.installedVersion}\nAutomatic updates: ${status.automaticUpdates ? 'enabled' : 'disabled'}`
+      ? `Installed version: ${status.installedVersion}\nBackground update checks: ${status.automaticUpdates ? 'enabled' : 'disabled'}`
       : 'Not installed.');
     return status;
   }
 
   if (command === 'updates' && ['enable', 'disable'].includes(args[1])) {
-    const status = await setAutomaticUpdates(args[1] === 'enable', { homeDir, agentHome, platform: options.platform, scheduler });
-    output(`Automatic updates: ${status.automaticUpdates ? 'enabled' : 'disabled'}`);
+    let checkRunner;
+    if (args[1] === 'enable' && scheduler !== false) {
+      checkRunner = await createUpdateRunner({ agentHome, packageVersion });
+    }
+    const status = await setAutomaticUpdates(args[1] === 'enable', { homeDir, agentHome, platform: options.platform, scheduler, checkRunner });
+    output(`Background update checks: ${status.automaticUpdates ? 'enabled' : 'disabled'}`);
     return status;
   }
 
+  if (command === 'uninstall') {
+    await uninstallSkill({ homeDir, agentHome, platform: options.platform });
+    output('Uninstalled job-application-agent. Background checks and scheduler artifacts were removed.');
+    return { uninstalled: true };
+  }
+
   if (command === 'install' || command === 'update') {
-    if (scheduler !== false) {
-      const runner = await createUpdateRunner({ platform: options.platform, agentHome, packageVersion });
-      shared.command = runner.path;
+    const prior = await readInstallStatus({ homeDir, agentHome });
+    const priorEnabled = prior.installed && prior.automaticUpdates !== false;
+    let checkRunner;
+    if (scheduler !== false && (backgroundUpdates || priorEnabled)) {
+      checkRunner = await createUpdateRunner({ agentHome, packageVersion });
     }
+    const shared = {
+      packageRoot,
+      packageVersion,
+      homeDir,
+      agentHome,
+      platform: options.platform,
+      scheduler,
+      backgroundUpdates: backgroundUpdates ? true : undefined,
+      checkRunner,
+    };
     const status = command === 'install' ? await installSkill(shared) : await updateSkill(shared);
-    output(`${command === 'install' ? 'Installed' : 'Updated'} job-application-agent ${status.installedVersion}.\nAutomatic updates: ${status.automaticUpdates ? 'enabled' : 'disabled'}`);
+    output(`${command === 'install' ? 'Installed' : 'Updated'} job-application-agent ${status.installedVersion}.\nBackground update checks: ${status.automaticUpdates ? 'enabled' : 'disabled'}`);
     return status;
   }
 

--- a/installer/src/cli.mjs
+++ b/installer/src/cli.mjs
@@ -16,18 +16,6 @@ async function defaultVersion(packageRoot) {
   return JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8')).version;
 }
 
-async function locateNpmCli() {
-  const candidates = [
-    process.env.npm_execpath,
-    path.resolve(path.dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
-    path.resolve(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
-  ].filter(Boolean);
-  for (const candidate of candidates) {
-    try { await readFile(candidate); return candidate; } catch {}
-  }
-  throw new Error('Could not locate npm. Install Node.js with npm and retry.');
-}
-
 function resolveHome(options = {}) {
   const homeDir = options.homeDir || os.homedir();
   const agentHome = options.agentHome || options.codexHome || resolveAgentHome(homeDir);
@@ -64,18 +52,9 @@ export async function runCli(args, options = {}) {
     return status;
   }
 
-  if (command === 'auto-update') {
-    const current = await readInstallStatus({ homeDir, agentHome });
-    if (!current.automaticUpdates) { output('Automatic updates are disabled.'); return current; }
-    if (current.installedVersion === packageVersion) { output(`Job Application Agent ${packageVersion} is already current.`); return current; }
-    const status = await updateSkill({ ...shared, scheduler: false });
-    output(`Updated job-application-agent to ${status.installedVersion}.`);
-    return status;
-  }
-
   if (command === 'install' || command === 'update') {
     if (scheduler !== false) {
-      const runner = await createUpdateRunner({ platform: options.platform, agentHome, npmCliPath: await locateNpmCli() });
+      const runner = await createUpdateRunner({ platform: options.platform, agentHome, packageVersion });
       shared.command = runner.path;
     }
     const status = command === 'install' ? await installSkill(shared) : await updateSkill(shared);

--- a/installer/src/installer.mjs
+++ b/installer/src/installer.mjs
@@ -138,6 +138,15 @@ export async function syncVendorSkillCopies({ homeDir = os.homedir(), sourceSkil
   return copied;
 }
 
+export async function removeVendorSkillCopies({ homeDir = os.homedir(), sourceSkillDir }) {
+  const canonical = path.resolve(sourceSkillDir);
+  for (const relative of VENDOR_SKILL_DIRS) {
+    const dest = path.join(homeDir, ...relative.split('/'), SKILL_NAME);
+    if (path.resolve(dest) === canonical) continue;
+    await rm(dest, { recursive: true, force: true });
+  }
+}
+
 export async function readInstallStatus({
   homeDir = os.homedir(),
   agentHome,
@@ -154,8 +163,14 @@ export async function readInstallStatus({
   return { installed: false, automaticUpdates: false };
 }
 
-function defaultCommand(agentHome, platform = process.platform) {
-  return path.join(agentHome, SKILL_NAME, platform === 'win32' ? 'update.cmd' : 'update');
+async function reconcilePersistence({ platform, homeDir, agentHome, automaticUpdates, scheduler, checkRunner, packageVersion, userId, runCommand }) {
+  if (scheduler === false) return { enabled: automaticUpdates, touched: false };
+  if (automaticUpdates) {
+    if (!checkRunner) throw new Error('A validated update-check runner is required to enable background update checks.');
+    if (checkRunner.packageVersion !== packageVersion) throw new Error('The update-check runner version does not match the installed package version.');
+    return { enabled: true, touched: await installScheduler({ platform, homeDir, agentHome, nodePath: checkRunner.nodePath, checkScriptPath: checkRunner.checkScriptPath, packageVersion, userId, runCommand }) };
+  }
+  return { enabled: false, touched: await removeScheduler({ platform, homeDir, agentHome, userId, runCommand }) };
 }
 
 export async function installSkill({
@@ -167,12 +182,21 @@ export async function installSkill({
   legacyHome,
   platform = process.platform,
   scheduler = true,
-  command,
+  backgroundUpdates,
+  checkRunner,
+  userId = process.getuid?.(),
+  runCommand,
 } = {}) {
   assertExactVersion(packageVersion, 'package version');
   const home = agentHome || codexHome || resolveAgentHome(homeDir);
   const paths = pathsFor(home);
   const source = path.join(packageRoot, SKILL_NAME);
+  const prior = await readInstallStatus({ homeDir, agentHome: home });
+  const automaticUpdates = backgroundUpdates !== undefined ? !!backgroundUpdates : (prior.installed ? prior.automaticUpdates !== false : false);
+  if (scheduler !== false && automaticUpdates) {
+    if (!checkRunner) throw new Error('A validated update-check runner is required to enable background update checks.');
+    if (checkRunner.packageVersion !== packageVersion) throw new Error('The update-check runner version does not match the installed package version.');
+  }
   await migrateLegacyCodexInstall({ homeDir, agentHome: home, legacyHome: legacyHome || resolveLegacyCodexHome(homeDir) });
   await validatePackagedSkill(source, packageVersion);
   await mkdir(path.dirname(paths.target), { recursive: true });
@@ -194,18 +218,16 @@ export async function installSkill({
     throw error;
   }
 
-  const prior = await readInstallStatus({ homeDir, agentHome: home });
   const config = {
     installed: true,
     installedVersion: packageVersion,
-    automaticUpdates: prior.installed ? prior.automaticUpdates !== false : true,
+    automaticUpdates,
     installedAt: prior.installedAt || new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
   await writeConfig(paths.configPath, config);
   await syncVendorSkillCopies({ homeDir, sourceSkillDir: paths.target });
-  const updateCommand = command || defaultCommand(home, platform);
-  if (scheduler && config.automaticUpdates) await installScheduler({ platform, homeDir, agentHome: home, command: updateCommand });
+  await reconcilePersistence({ platform, homeDir, agentHome: home, automaticUpdates, scheduler, checkRunner, packageVersion, userId, runCommand });
   return config;
 }
 
@@ -217,19 +239,42 @@ export async function setAutomaticUpdates(enabled, {
   codexHome,
   platform = process.platform,
   scheduler = true,
-  command,
+  checkRunner,
+  userId = process.getuid?.(),
+  runCommand,
 } = {}) {
   const home = agentHome || codexHome || resolveAgentHome(homeDir);
   await migrateLegacyCodexInstall({ homeDir, agentHome: home });
   const paths = pathsFor(home);
   const current = await readInstallStatus({ homeDir, agentHome: home });
   if (!current.installed) throw new Error('The skill is not installed.');
+  if (enabled && scheduler !== false && !checkRunner) throw new Error('A validated update-check runner is required to enable background update checks.');
   const next = { ...current, automaticUpdates: enabled, updatedAt: new Date().toISOString() };
   await writeConfig(paths.configPath, next);
-  if (scheduler) {
-    const updateCommand = command || defaultCommand(home, platform);
-    if (enabled) await installScheduler({ platform, homeDir, agentHome: home, command: updateCommand });
-    else await removeScheduler({ platform, homeDir, agentHome: home });
+  if (scheduler !== false) {
+    if (enabled) {
+      await installScheduler({ platform, homeDir, agentHome: home, nodePath: checkRunner.nodePath, checkScriptPath: checkRunner.checkScriptPath, packageVersion: checkRunner.packageVersion, userId, runCommand });
+    } else {
+      await removeScheduler({ platform, homeDir, agentHome: home, userId, runCommand });
+    }
   }
   return next;
+}
+
+export async function uninstallSkill({
+  homeDir = os.homedir(),
+  agentHome,
+  codexHome,
+  platform = process.platform,
+  userId = process.getuid?.(),
+  runCommand,
+} = {}) {
+  const home = agentHome || codexHome || resolveAgentHome(homeDir);
+  const paths = pathsFor(home);
+  await removeScheduler({ platform, homeDir, agentHome: home, userId, runCommand });
+  await removeVendorSkillCopies({ homeDir, sourceSkillDir: paths.target });
+  await rm(paths.target, { recursive: true, force: true });
+  await rm(paths.managerDir, { recursive: true, force: true });
+  await rm(path.join(home, 'logs'), { recursive: true, force: true });
+  return { uninstalled: true };
 }

--- a/installer/src/installer.mjs
+++ b/installer/src/installer.mjs
@@ -1,4 +1,5 @@
-import { chmod, cp, lstat, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { chmod, cp, lstat, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -35,11 +36,52 @@ async function isDirectory(filePath) {
   try { return (await lstat(filePath)).isDirectory(); } catch (error) { if (error.code === 'ENOENT') return false; throw error; }
 }
 
-async function validatePackagedSkill(source) {
+function assertExactVersion(value, label = 'version') {
+  if (typeof value !== 'string' || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(value)) throw new Error(`${label} must be an exact immutable semantic version.`);
+  return value;
+}
+
+async function listedFiles(root, current = root, files = []) {
+  const entries = await readdir(current, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolute = path.join(current, entry.name);
+    if (entry.isDirectory()) await listedFiles(root, absolute, files);
+    else files.push(path.relative(root, absolute).replaceAll(path.sep, '/'));
+  }
+  return files.sort();
+}
+
+async function verifyReleaseManifest(source, expectedVersion) {
+  const manifestPath = path.join(source, 'release-manifest.json');
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  } catch (error) {
+    if (error.code === 'ENOENT') throw new Error('Invalid packaged skill: release-manifest.json is missing.');
+    throw new Error('Invalid packaged skill: release-manifest.json is unreadable.');
+  }
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) throw new Error('Invalid packaged skill: release-manifest.json must be an object.');
+  const version = assertExactVersion(manifest.version, 'release manifest version');
+  if (expectedVersion && version !== assertExactVersion(expectedVersion, 'package version')) throw new Error(`Invalid packaged skill: release manifest version ${version} does not match package version ${expectedVersion}.`);
+  const files = manifest.files;
+  if (!files || typeof files !== 'object' || Array.isArray(files)) throw new Error('Invalid packaged skill: release-manifest.json must contain a files map.');
+  const expectedFiles = Object.keys(files).sort();
+  const actualFiles = (await listedFiles(source)).filter((file) => file !== 'release-manifest.json');
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) throw new Error('Invalid packaged skill: packaged files do not match the release manifest.');
+  for (const file of expectedFiles) {
+    const expectedHash = String(files[file] ?? '');
+    if (!/^[0-9a-f]{64}$/i.test(expectedHash)) throw new Error(`Invalid packaged skill: release manifest hash for ${file} is invalid.`);
+    const actualHash = createHash('sha256').update(await readFile(path.join(source, file))).digest('hex');
+    if (actualHash !== expectedHash) throw new Error(`Invalid packaged skill: checksum verification failed for ${file}.`);
+  }
+}
+
+async function validatePackagedSkill(source, expectedVersion) {
   const skillFile = path.join(source, 'SKILL.md');
   const content = await readFile(skillFile, 'utf8').catch(() => '');
   if (!content.trim()) throw new Error('Invalid packaged skill: SKILL.md is missing or empty.');
   await stat(path.join(source, 'scripts', 'job-application.mjs')).catch(() => { throw new Error('Invalid packaged skill: application CLI is missing.'); });
+  await verifyReleaseManifest(source, expectedVersion);
 }
 
 async function writeConfig(configPath, config) {
@@ -127,16 +169,17 @@ export async function installSkill({
   scheduler = true,
   command,
 } = {}) {
+  assertExactVersion(packageVersion, 'package version');
   const home = agentHome || codexHome || resolveAgentHome(homeDir);
   const paths = pathsFor(home);
   const source = path.join(packageRoot, SKILL_NAME);
   await migrateLegacyCodexInstall({ homeDir, agentHome: home, legacyHome: legacyHome || resolveLegacyCodexHome(homeDir) });
-  await validatePackagedSkill(source);
+  await validatePackagedSkill(source, packageVersion);
   await mkdir(path.dirname(paths.target), { recursive: true });
   await mkdir(paths.managerDir, { recursive: true });
   const staging = path.join(paths.managerDir, `staging-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   await cp(source, staging, { recursive: true, force: true });
-  await validatePackagedSkill(staging);
+  await validatePackagedSkill(staging, packageVersion);
 
   const hadTarget = await exists(paths.target);
   if (hadTarget) {

--- a/installer/src/runner.mjs
+++ b/installer/src/runner.mjs
@@ -1,12 +1,16 @@
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-function shellQuote(value) {
-  return `'${value.replaceAll("'", `'"'"'`)}'`;
-}
+const SKILL_NAME = 'job-application-agent';
+const CHECK_RUNNER_FILENAME = 'check-update-runner.mjs';
 
 function assertExactVersion(value) {
   if (typeof value !== 'string' || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(value)) throw new Error('An exact immutable semantic version is required to create the safe update-check runner.');
+  return value;
+}
+
+function assertAbsolute(value, label) {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) throw new Error(`${label} must be an absolute path.`);
   return value;
 }
 
@@ -47,24 +51,32 @@ await rename(temporary, statusPath);
 `;
 }
 
-export async function createUpdateRunner({ platform = process.platform, agentHome, codexHome, nodePath = process.execPath, packageVersion }) {
+export async function createUpdateRunner({ agentHome, codexHome, nodePath = process.execPath, packageVersion }) {
   if (!packageVersion) throw new Error('An exact package version is required to create the safe update-check runner.');
   const home = agentHome || codexHome;
-  const managerDir = path.join(home, 'job-application-agent');
-  const nodeDir = path.dirname(nodePath);
+  if (!home) throw new Error('An agent home directory is required to create the safe update-check runner.');
   const exactVersion = assertExactVersion(packageVersion);
+  assertAbsolute(home, 'The agent home');
+  assertAbsolute(nodePath, 'The Node.js executable');
+
+  const managerDir = path.join(home, SKILL_NAME);
+  const checkScriptPath = path.join(managerDir, CHECK_RUNNER_FILENAME);
   await mkdir(managerDir, { recursive: true });
-  const checkScriptPath = path.join(managerDir, 'check-update-runner.mjs');
+  await rm(checkScriptPath, { force: true });
   await writeFile(checkScriptPath, createCheckScript(), { mode: 0o600 });
-  if (platform === 'win32') {
-    const filePath = path.join(managerDir, 'check-update.cmd');
-    const script = `@echo off\r\nset "JOB_APPLICATION_AGENT_HOME=${home}"\r\nset "PATH=${nodeDir};%PATH%"\r\n"${nodePath}" "${checkScriptPath}" "${home}" "${exactVersion}"\r\n`;
-    await writeFile(filePath, script, { mode: 0o700 });
-    return { path: filePath };
-  }
-  const filePath = path.join(managerDir, 'check-update');
-  const script = `#!/bin/sh\nJOB_APPLICATION_AGENT_HOME=${shellQuote(home)}\nPATH=${shellQuote(nodeDir)}:\${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}\nexport JOB_APPLICATION_AGENT_HOME PATH\nexec ${shellQuote(nodePath)} ${shellQuote(checkScriptPath)} ${shellQuote(home)} ${shellQuote(exactVersion)}\n`;
-  await writeFile(filePath, script, { mode: 0o700 });
-  await chmod(filePath, 0o700);
-  return { path: filePath };
+  await chmod(checkScriptPath, 0o600);
+
+  const scriptStat = await lstat(checkScriptPath);
+  if (scriptStat.isSymbolicLink()) throw new Error('The update-check runner must not be a symbolic link.');
+  if (!scriptStat.isFile()) throw new Error('The update-check runner could not be created as a regular file.');
+
+  const resolvedScript = await realpath(checkScriptPath);
+  const resolvedNode = await realpath(nodePath);
+
+  return {
+    nodePath: resolvedNode,
+    checkScriptPath: resolvedScript,
+    agentHome: home,
+    packageVersion: exactVersion,
+  };
 }

--- a/installer/src/runner.mjs
+++ b/installer/src/runner.mjs
@@ -5,20 +5,65 @@ function shellQuote(value) {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
-export async function createUpdateRunner({ platform = process.platform, agentHome, codexHome, nodePath = process.execPath, npmCliPath }) {
-  if (!npmCliPath) throw new Error('npm CLI path is required to create the automatic-update runner.');
+function assertExactVersion(value) {
+  if (typeof value !== 'string' || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(value)) throw new Error('An exact immutable semantic version is required to create the safe update-check runner.');
+  return value;
+}
+
+function createCheckScript() {
+  return `import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const [agentHome, installedVersion] = process.argv.slice(2);
+
+if (!agentHome || !installedVersion) {
+  throw new Error('Usage: check-update-runner.mjs <agentHome> <installedVersion>');
+}
+
+const managerDir = path.join(agentHome, 'job-application-agent');
+const statusPath = path.join(managerDir, 'update-status.json');
+const temporary = path.join(managerDir, \`update-status.\${process.pid}.tmp\`);
+
+let current = {};
+try {
+  current = JSON.parse(await readFile(statusPath, 'utf8'));
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error;
+}
+
+const next = {
+  version: 1,
+  checkedAt: new Date().toISOString(),
+  installedVersion,
+  automaticUpdateExecution: false,
+  pendingUpdateVersion: null,
+  status: 'manual-review-required',
+  reason: 'Background checks never download or execute remote packages. Run an explicit exact-version install from a trusted release after verifying integrity.',
+};
+
+await mkdir(managerDir, { recursive: true });
+await writeFile(temporary, \`\${JSON.stringify({ ...current, ...next }, null, 2)}\\n\`, { mode: 0o600 });
+await rename(temporary, statusPath);
+`;
+}
+
+export async function createUpdateRunner({ platform = process.platform, agentHome, codexHome, nodePath = process.execPath, packageVersion }) {
+  if (!packageVersion) throw new Error('An exact package version is required to create the safe update-check runner.');
   const home = agentHome || codexHome;
   const managerDir = path.join(home, 'job-application-agent');
   const nodeDir = path.dirname(nodePath);
+  const exactVersion = assertExactVersion(packageVersion);
   await mkdir(managerDir, { recursive: true });
+  const checkScriptPath = path.join(managerDir, 'check-update-runner.mjs');
+  await writeFile(checkScriptPath, createCheckScript(), { mode: 0o600 });
   if (platform === 'win32') {
-    const filePath = path.join(managerDir, 'update.cmd');
-    const script = `@echo off\r\nset "JOB_APPLICATION_AGENT_HOME=${home}"\r\nset "PATH=${nodeDir};%PATH%"\r\n"${nodePath}" "${npmCliPath}" exec --yes --package=job-application-agent@latest -- job-application-agent auto-update\r\n`;
+    const filePath = path.join(managerDir, 'check-update.cmd');
+    const script = `@echo off\r\nset "JOB_APPLICATION_AGENT_HOME=${home}"\r\nset "PATH=${nodeDir};%PATH%"\r\n"${nodePath}" "${checkScriptPath}" "${home}" "${exactVersion}"\r\n`;
     await writeFile(filePath, script, { mode: 0o700 });
     return { path: filePath };
   }
-  const filePath = path.join(managerDir, 'update');
-  const script = `#!/bin/sh\nJOB_APPLICATION_AGENT_HOME=${shellQuote(home)}\nPATH=${shellQuote(nodeDir)}:\${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}\nexport JOB_APPLICATION_AGENT_HOME PATH\nexec ${shellQuote(nodePath)} ${shellQuote(npmCliPath)} exec --yes --package=job-application-agent@latest -- job-application-agent auto-update\n`;
+  const filePath = path.join(managerDir, 'check-update');
+  const script = `#!/bin/sh\nJOB_APPLICATION_AGENT_HOME=${shellQuote(home)}\nPATH=${shellQuote(nodeDir)}:\${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}\nexport JOB_APPLICATION_AGENT_HOME PATH\nexec ${shellQuote(nodePath)} ${shellQuote(checkScriptPath)} ${shellQuote(home)} ${shellQuote(exactVersion)}\n`;
   await writeFile(filePath, script, { mode: 0o700 });
   await chmod(filePath, 0o700);
   return { path: filePath };

--- a/installer/src/scheduler.mjs
+++ b/installer/src/scheduler.mjs
@@ -42,7 +42,7 @@ export async function installScheduler({ platform = process.platform, homeDir, a
     const launchAgents = path.join(homeDir, 'Library', 'LaunchAgents');
     const filePath = path.join(launchAgents, `${SCHEDULER_LABEL}.plist`);
     await mkdir(launchAgents, { recursive: true });
-    const plist = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict>\n  <key>Label</key><string>${SCHEDULER_LABEL}</string>\n  <key>ProgramArguments</key><array><string>${xml(command)}</string><string>auto-update</string></array>\n  <key>RunAtLoad</key><true/>\n  <key>StartInterval</key><integer>3600</integer>\n  <key>StandardOutPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n  <key>StandardErrorPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n</dict></plist>\n`;
+    const plist = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict>\n  <key>Label</key><string>${SCHEDULER_LABEL}</string>\n  <key>ProgramArguments</key><array><string>${xml(command)}</string></array>\n  <key>RunAtLoad</key><true/>\n  <key>StartInterval</key><integer>3600</integer>\n  <key>StandardOutPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n  <key>StandardErrorPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n</dict></plist>\n`;
     await writeFile(filePath, plist, { mode: 0o600 });
     const domain = `gui/${userId}`;
     try { await runCommand('launchctl', ['bootout', domain, filePath]); } catch {}
@@ -55,7 +55,7 @@ export async function installScheduler({ platform = process.platform, homeDir, a
     const servicePath = path.join(systemdDir, 'job-application-agent-update.service');
     const timerPath = path.join(systemdDir, 'job-application-agent-update.timer');
     await mkdir(systemdDir, { recursive: true });
-    await writeFile(servicePath, `[Unit]\nDescription=Update Job Application Agent skill\n\n[Service]\nType=oneshot\nExecStart=${command} auto-update\n`, { mode: 0o600 });
+    await writeFile(servicePath, `[Unit]\nDescription=Check Job Application Agent updates safely\n\n[Service]\nType=oneshot\nExecStart="${command}"\n`, { mode: 0o600 });
     await writeFile(timerPath, `[Unit]\nDescription=Update Job Application Agent skill hourly\n\n[Timer]\nOnBootSec=2m\nOnUnitActiveSec=1h\nPersistent=true\n\n[Install]\nWantedBy=timers.target\n`, { mode: 0o600 });
     await runCommand('systemctl', ['--user', 'daemon-reload']);
     await runCommand('systemctl', ['--user', 'enable', '--now', 'job-application-agent-update.timer']);
@@ -64,7 +64,7 @@ export async function installScheduler({ platform = process.platform, homeDir, a
 
   if (platform === 'win32') {
     const scriptPath = path.join(resolvedAgentHome, 'job-application-agent', 'register-update-task.ps1');
-    const script = `$action = New-ScheduledTaskAction -Execute '${command.replaceAll("'", "''")}' -Argument 'auto-update'\n$logon = New-ScheduledTaskTrigger -AtLogOn\n$hourly = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2) -RepetitionInterval (New-TimeSpan -Hours 1)\nRegister-ScheduledTask -TaskName 'JobApplicationAgentUpdate' -Action $action -Trigger @($logon, $hourly) -Force | Out-Null\n`;
+    const script = `$action = New-ScheduledTaskAction -Execute '${command.replaceAll("'", "''")}'\n$logon = New-ScheduledTaskTrigger -AtLogOn\n$hourly = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2) -RepetitionInterval (New-TimeSpan -Hours 1)\nRegister-ScheduledTask -TaskName 'JobApplicationAgentUpdate' -Action $action -Trigger @($logon, $hourly) -Force | Out-Null\n`;
     await writeExecutable(scriptPath, script);
     await runCommand('powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath]);
     return { installed: true, platform, scriptPath };

--- a/installer/src/scheduler.mjs
+++ b/installer/src/scheduler.mjs
@@ -5,6 +5,8 @@ import { promisify } from 'node:util';
 
 export const SCHEDULER_LABEL = 'com.vaibhavarora.job-application-agent-update';
 export const LEGACY_SCHEDULER_LABEL = 'com.vaibhavarora.codex.job-application-agent-update';
+export const CHECK_RUNNER_FILENAME = 'check-update-runner.mjs';
+const SKILL_NAME = 'job-application-agent';
 const execFileAsync = promisify(execFile);
 
 async function defaultRunCommand(command, args) {
@@ -13,6 +15,52 @@ async function defaultRunCommand(command, args) {
 
 function xml(value) {
   return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function assertExactVersion(value) {
+  if (typeof value !== 'string' || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(value)) throw new Error('The scheduled check requires an exact immutable semantic version.');
+  return value;
+}
+
+function isAbsoluteForPlatform(value, platform) {
+  return platform === 'win32' ? path.win32.isAbsolute(value) : path.posix.isAbsolute(value);
+}
+
+function assertAbsolute(value, label, platform) {
+  if (typeof value !== 'string' || !isAbsoluteForPlatform(value, platform)) throw new Error(`${label} must be an absolute path.`);
+  return value;
+}
+
+// systemd parses ExecStart into argv without a shell. Escape its metacharacters
+// so every value is treated as a literal argument.
+function systemdQuote(value) {
+  let out = '"';
+  for (const ch of value) {
+    if (ch === '"' || ch === '\\' || ch === '$' || ch === '`') out += `\\${ch}`;
+    else if (ch === '%') out += '%%';
+    else out += ch;
+  }
+  out += '"';
+  return out;
+}
+
+// MSVCRT/CreateProcess quoting so Task Scheduler passes each argument verbatim.
+function windowsQuoteArg(value) {
+  if (value.length === 0) return '""';
+  if (!/[\s"]/.test(value)) return value;
+  let out = '"';
+  let backslashes = 0;
+  for (const ch of value) {
+    if (ch === '\\') { backslashes += 1; continue; }
+    if (ch === '"') { out += '\\'.repeat(backslashes * 2 + 1) + '"'; backslashes = 0; continue; }
+    out += '\\'.repeat(backslashes); backslashes = 0; out += ch;
+  }
+  out += '\\'.repeat(backslashes * 2) + '"';
+  return out;
+}
+
+function powershellSingleQuote(value) {
+  return `'${value.replaceAll("'", "''")}'`;
 }
 
 async function writeExecutable(filePath, content) {
@@ -25,24 +73,33 @@ function agentHomeFor(homeDir, agentHome) {
   return agentHome || path.join(homeDir, '.agents');
 }
 
+function checkRunnerPath(agentHome) {
+  return path.join(agentHome, SKILL_NAME, CHECK_RUNNER_FILENAME);
+}
+
 async function removeDarwinLaunchAgent(homeDir, label, userId, runCommand) {
   const filePath = path.join(homeDir, 'Library', 'LaunchAgents', `${label}.plist`);
   try { await runCommand('launchctl', ['bootout', `gui/${userId}`, filePath]); } catch {}
   await rm(filePath, { force: true });
 }
 
-export async function installScheduler({ platform = process.platform, homeDir, agentHome, command, userId = process.getuid?.(), runCommand = defaultRunCommand }) {
+export async function installScheduler({ platform = process.platform, homeDir, agentHome, nodePath, checkScriptPath, packageVersion, userId = process.getuid?.(), runCommand = defaultRunCommand }) {
   if (platform === 'test') return { installed: false, platform };
   const resolvedAgentHome = agentHomeFor(homeDir, agentHome);
   const logsDir = path.join(resolvedAgentHome, 'logs');
   await mkdir(logsDir, { recursive: true });
+  assertAbsolute(nodePath, 'The scheduled Node.js executable', platform);
+  assertAbsolute(checkScriptPath, 'The scheduled check runner', platform);
+  const exactVersion = assertExactVersion(packageVersion);
 
   if (platform === 'darwin') {
     await removeDarwinLaunchAgent(homeDir, LEGACY_SCHEDULER_LABEL, userId, runCommand);
     const launchAgents = path.join(homeDir, 'Library', 'LaunchAgents');
     const filePath = path.join(launchAgents, `${SCHEDULER_LABEL}.plist`);
     await mkdir(launchAgents, { recursive: true });
-    const plist = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict>\n  <key>Label</key><string>${SCHEDULER_LABEL}</string>\n  <key>ProgramArguments</key><array><string>${xml(command)}</string></array>\n  <key>RunAtLoad</key><true/>\n  <key>StartInterval</key><integer>3600</integer>\n  <key>StandardOutPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n  <key>StandardErrorPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n</dict></plist>\n`;
+    const argv = [nodePath, checkScriptPath, resolvedAgentHome, exactVersion];
+    const argvXml = argv.map(arg => `  <string>${xml(arg)}</string>`).join('\n');
+    const plist = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict>\n  <key>Label</key><string>${SCHEDULER_LABEL}</string>\n  <key>ProgramArguments</key>\n  <array>\n${argvXml}\n  </array>\n  <key>RunAtLoad</key><true/>\n  <key>StartInterval</key><integer>3600</integer>\n  <key>ProcessType</key><string>Background</string>\n  <key>StandardOutPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n  <key>StandardErrorPath</key><string>${xml(path.join(logsDir, 'job-application-agent-update.log'))}</string>\n</dict></plist>\n`;
     await writeFile(filePath, plist, { mode: 0o600 });
     const domain = `gui/${userId}`;
     try { await runCommand('launchctl', ['bootout', domain, filePath]); } catch {}
@@ -55,16 +112,19 @@ export async function installScheduler({ platform = process.platform, homeDir, a
     const servicePath = path.join(systemdDir, 'job-application-agent-update.service');
     const timerPath = path.join(systemdDir, 'job-application-agent-update.timer');
     await mkdir(systemdDir, { recursive: true });
-    await writeFile(servicePath, `[Unit]\nDescription=Check Job Application Agent updates safely\n\n[Service]\nType=oneshot\nExecStart="${command}"\n`, { mode: 0o600 });
-    await writeFile(timerPath, `[Unit]\nDescription=Update Job Application Agent skill hourly\n\n[Timer]\nOnBootSec=2m\nOnUnitActiveSec=1h\nPersistent=true\n\n[Install]\nWantedBy=timers.target\n`, { mode: 0o600 });
+    const execLine = [nodePath, checkScriptPath, resolvedAgentHome, exactVersion].map(systemdQuote).join(' ');
+    await writeFile(servicePath, `[Unit]\nDescription=Check Job Application Agent updates safely\n\n[Service]\nType=oneshot\nExecStart=${execLine}\n`, { mode: 0o600 });
+    await writeFile(timerPath, `[Unit]\nDescription=Check Job Application Agent updates safely hourly\n\n[Timer]\nOnBootSec=2m\nOnUnitActiveSec=1h\nPersistent=true\n\n[Install]\nWantedBy=timers.target\n`, { mode: 0o600 });
     await runCommand('systemctl', ['--user', 'daemon-reload']);
     await runCommand('systemctl', ['--user', 'enable', '--now', 'job-application-agent-update.timer']);
     return { installed: true, platform, servicePath, timerPath };
   }
 
   if (platform === 'win32') {
-    const scriptPath = path.join(resolvedAgentHome, 'job-application-agent', 'register-update-task.ps1');
-    const script = `$action = New-ScheduledTaskAction -Execute '${command.replaceAll("'", "''")}'\n$logon = New-ScheduledTaskTrigger -AtLogOn\n$hourly = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2) -RepetitionInterval (New-TimeSpan -Hours 1)\nRegister-ScheduledTask -TaskName 'JobApplicationAgentUpdate' -Action $action -Trigger @($logon, $hourly) -Force | Out-Null\n`;
+    const scriptPath = path.join(resolvedAgentHome, SKILL_NAME, 'register-update-task.ps1');
+    const argumentLine = [checkScriptPath, resolvedAgentHome, exactVersion].map(windowsQuoteArg).join(' ');
+    const action = `New-ScheduledTaskAction -Execute ${powershellSingleQuote(nodePath)} -Argument ${powershellSingleQuote(argumentLine)}`;
+    const script = `$action = ${action}\n$logon = New-ScheduledTaskTrigger -AtLogOn\n$hourly = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2) -RepetitionInterval (New-TimeSpan -Hours 1)\nRegister-ScheduledTask -TaskName 'JobApplicationAgentUpdate' -Action $action -Trigger @($logon, $hourly) -Force | Out-Null\n`;
     await writeExecutable(scriptPath, script);
     await runCommand('powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath]);
     return { installed: true, platform, scriptPath };
@@ -75,6 +135,7 @@ export async function installScheduler({ platform = process.platform, homeDir, a
 
 export async function removeScheduler({ platform = process.platform, homeDir, agentHome, userId = process.getuid?.(), runCommand = defaultRunCommand }) {
   const resolvedAgentHome = agentHomeFor(homeDir, agentHome);
+  const managerDir = path.join(resolvedAgentHome, SKILL_NAME);
   if (platform === 'darwin') {
     await removeDarwinLaunchAgent(homeDir, SCHEDULER_LABEL, userId, runCommand);
     await removeDarwinLaunchAgent(homeDir, LEGACY_SCHEDULER_LABEL, userId, runCommand);
@@ -86,8 +147,13 @@ export async function removeScheduler({ platform = process.platform, homeDir, ag
     try { await runCommand('systemctl', ['--user', 'daemon-reload']); } catch {}
   } else if (platform === 'win32') {
     try { await runCommand('schtasks.exe', ['/Delete', '/TN', 'JobApplicationAgentUpdate', '/F']); } catch {}
-    await rm(path.join(resolvedAgentHome, 'job-application-agent', 'register-update-task.ps1'), { force: true });
-    await rm(path.join(homeDir, '.codex', 'job-application-agent', 'register-update-task.ps1'), { force: true });
   }
+  await rm(checkRunnerPath(resolvedAgentHome), { force: true });
+  await rm(path.join(managerDir, 'check-update'), { force: true });
+  await rm(path.join(managerDir, 'check-update.cmd'), { force: true });
+  await rm(path.join(managerDir, 'update-status.json'), { force: true });
+  await rm(path.join(managerDir, 'register-update-task.ps1'), { force: true });
+  await rm(path.join(homeDir, '.codex', SKILL_NAME, 'register-update-task.ps1'), { force: true });
+  await rm(path.join(resolvedAgentHome, 'logs', 'job-application-agent-update.log'), { force: true });
   return { removed: true, platform };
 }

--- a/installer/tests/cli.test.mjs
+++ b/installer/tests/cli.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -6,13 +7,24 @@ import test from 'node:test';
 
 import { runCli } from '../src/cli.mjs';
 
+async function writeReleaseManifest(skillSource, version) {
+  const files = ['SKILL.md', 'scripts/job-application.mjs'];
+  const entries = {};
+  for (const file of files) {
+    entries[file] = createHash('sha256').update(await readFile(path.join(skillSource, file))).digest('hex');
+  }
+  await writeFile(path.join(skillSource, 'release-manifest.json'), `${JSON.stringify({ version, files: entries }, null, 2)}\n`);
+}
+
 async function setup() {
   const root = await mkdtemp(path.join(os.tmpdir(), 'job-agent-cli-'));
   const packageRoot = path.join(root, 'package');
   const agentHome = path.join(root, '.agents');
-  await mkdir(path.join(packageRoot, 'job-application-agent', 'scripts'), { recursive: true });
-  await writeFile(path.join(packageRoot, 'job-application-agent', 'SKILL.md'), '# Skill\n');
-  await writeFile(path.join(packageRoot, 'job-application-agent', 'scripts', 'job-application.mjs'), 'export {};\n');
+  const skillSource = path.join(packageRoot, 'job-application-agent');
+  await mkdir(path.join(skillSource, 'scripts'), { recursive: true });
+  await writeFile(path.join(skillSource, 'SKILL.md'), '# Skill\n');
+  await writeFile(path.join(skillSource, 'scripts', 'job-application.mjs'), 'export {};\n');
+  await writeReleaseManifest(skillSource, '3.0.0');
   return { root, packageRoot, agentHome };
 }
 
@@ -25,33 +37,25 @@ test('install is automatic-update enabled by default and status reports the inst
   assert.match(output.join('\n'), /automatic updates: enabled/i);
 });
 
-test('auto-update is a no-op when updates are disabled', async () => {
+test('legacy background update command is rejected', async () => {
   const f = await setup();
-  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: () => {} });
-  await runCli(['updates', 'disable'], { agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: () => {} });
-  await writeFile(path.join(f.packageRoot, 'job-application-agent', 'SKILL.md'), '# New skill\n');
-  const output = [];
-  await runCli(['auto-update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: value => output.push(value) });
-  assert.match(output.join('\n'), /disabled/i);
-  assert.equal(await readFile(path.join(f.agentHome, 'skills', 'job-application-agent', 'SKILL.md'), 'utf8'), '# Skill\n');
+  await assert.rejects(() => runCli(['background-update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: () => {} }), /usage/i);
 });
 
-test('auto-update does not replace an already-current installation or reload its scheduler', async () => {
+test('install wires a safe check runner instead of a package manager execution path', async () => {
   const f = await setup();
-  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: () => {} });
-  const marker = path.join(f.agentHome, 'skills', 'job-application-agent', 'local-marker');
-  await writeFile(marker, 'preserve');
-  const output = [];
-  await runCli(['auto-update'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'darwin', output: value => output.push(value) });
-  assert.equal(await readFile(marker, 'utf8'), 'preserve');
-  assert.match(output.join('\n'), /already current/i);
+  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', output: () => {} });
+  const runner = await readFile(path.join(f.agentHome, 'job-application-agent', 'check-update'), 'utf8');
+  assert.doesNotMatch(runner, /@latest|npm exec|npm install|npm update/);
+  assert.match(runner, /check-update-runner\.mjs/);
 });
 
-test('auto-update replaces an older skill without reloading the running scheduler', async () => {
+test('explicit update still replaces an older skill after local verification', async () => {
   const f = await setup();
   await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: () => {} });
   await writeFile(path.join(f.packageRoot, 'job-application-agent', 'SKILL.md'), '# New skill\n');
-  await runCli(['auto-update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'darwin', output: () => {} });
+  await writeReleaseManifest(path.join(f.packageRoot, 'job-application-agent'), '3.1.0');
+  await runCli(['update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', output: () => {} });
   assert.equal(await readFile(path.join(f.agentHome, 'skills', 'job-application-agent', 'SKILL.md'), 'utf8'), '# New skill\n');
 });
 

--- a/installer/tests/cli.test.mjs
+++ b/installer/tests/cli.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -28,35 +28,79 @@ async function setup() {
   return { root, packageRoot, agentHome };
 }
 
-test('install is automatic-update enabled by default and status reports the installed version', async () => {
+async function managerEntries(agentHome) {
+  try {
+    return await readdir(path.join(agentHome, 'job-application-agent'));
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+test('install is background-check disabled by default and status reports the installed version', async () => {
   const f = await setup();
   const output = [];
-  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: value => output.push(value) });
+  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: value => output.push(value) });
   await runCli(['status'], { agentHome: f.agentHome, homeDir: f.root, output: value => output.push(value) });
   assert.match(output.join('\n'), /3\.0\.0/);
-  assert.match(output.join('\n'), /automatic updates: enabled/i);
+  assert.match(output.join('\n'), /background update checks: disabled/i);
+});
+
+test('plain install creates no runner and no persistence artifacts', async () => {
+  const f = await setup();
+  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: () => {} });
+  assert.deepEqual(await managerEntries(f.agentHome), ['install.json']);
+  await assert.rejects(stat(path.join(f.agentHome, 'job-application-agent', 'check-update-runner.mjs')), { code: 'ENOENT' });
+});
+
+test('--enable-background-updates opts in and creates the safe check runner', async () => {
+  const f = await setup();
+  const output = [];
+  await runCli(['install', '--enable-background-updates'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: value => output.push(value) });
+  assert.match(output.join('\n'), /background update checks: enabled/i);
+  const runner = await readFile(path.join(f.agentHome, 'job-application-agent', 'check-update-runner.mjs'), 'utf8');
+  assert.doesNotMatch(runner, /@latest|npm exec|npm install|npm update/);
+  assert.match(runner, /manual-review-required/);
 });
 
 test('legacy background update command is rejected', async () => {
   const f = await setup();
-  await assert.rejects(() => runCli(['background-update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: () => {} }), /usage/i);
+  await assert.rejects(() => runCli(['background-update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: () => {} }), /usage/i);
 });
 
-test('install wires a safe check runner instead of a package manager execution path', async () => {
+test('update preserves a disabled background setting unless explicitly opted in', async () => {
   const f = await setup();
-  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', output: () => {} });
-  const runner = await readFile(path.join(f.agentHome, 'job-application-agent', 'check-update'), 'utf8');
-  assert.doesNotMatch(runner, /@latest|npm exec|npm install|npm update/);
-  assert.match(runner, /check-update-runner\.mjs/);
-});
-
-test('explicit update still replaces an older skill after local verification', async () => {
-  const f = await setup();
-  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: false, output: () => {} });
+  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: () => {} });
   await writeFile(path.join(f.packageRoot, 'job-application-agent', 'SKILL.md'), '# New skill\n');
   await writeReleaseManifest(path.join(f.packageRoot, 'job-application-agent'), '3.1.0');
-  await runCli(['update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', output: () => {} });
-  assert.equal(await readFile(path.join(f.agentHome, 'skills', 'job-application-agent', 'SKILL.md'), 'utf8'), '# New skill\n');
+  const output = [];
+  await runCli(['update'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: value => output.push(value) });
+  assert.match(output.join('\n'), /background update checks: disabled/i);
+  const entries = await managerEntries(f.agentHome);
+  assert.ok(entries.includes('install.json'));
+  assert.ok(entries.includes('previous'), 'update keeps a rollback copy');
+  assert.ok(!entries.includes('check-update-runner.mjs'), 'no runner is created while background checks stay disabled');
+});
+
+test('update with --enable-background-updates enables persistence and the safe runner', async () => {
+  const f = await setup();
+  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: () => {} });
+  await writeFile(path.join(f.packageRoot, 'job-application-agent', 'SKILL.md'), '# New skill\n');
+  await writeReleaseManifest(path.join(f.packageRoot, 'job-application-agent'), '3.1.0');
+  const output = [];
+  await runCli(['update', '--enable-background-updates'], { packageRoot: f.packageRoot, packageVersion: '3.1.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: value => output.push(value) });
+  assert.match(output.join('\n'), /background update checks: enabled/i);
+  await stat(path.join(f.agentHome, 'job-application-agent', 'check-update-runner.mjs'));
+});
+
+test('uninstall removes the skill, config, and runner artifacts', async () => {
+  const f = await setup();
+  await runCli(['install'], { packageRoot: f.packageRoot, packageVersion: '3.0.0', agentHome: f.agentHome, homeDir: f.root, platform: 'test', scheduler: true, output: () => {} });
+  await runCli(['uninstall'], { agentHome: f.agentHome, homeDir: f.root, platform: 'test', output: () => {} });
+  await assert.rejects(stat(path.join(f.agentHome, 'skills', 'job-application-agent')), { code: 'ENOENT' });
+  assert.deepEqual(await managerEntries(f.agentHome), []);
+  const status = await runCli(['status'], { agentHome: f.agentHome, homeDir: f.root, output: () => {} });
+  assert.equal(status.installed, false);
 });
 
 test('unknown commands fail with usage instead of silently installing', async () => {

--- a/installer/tests/installer.test.mjs
+++ b/installer/tests/installer.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -12,6 +13,15 @@ import {
   updateSkill,
 } from '../src/installer.mjs';
 
+async function writeReleaseManifest(skillSource, version) {
+  const files = ['SKILL.md', 'scripts/job-application.mjs'];
+  const entries = {};
+  for (const file of files) {
+    entries[file] = createHash('sha256').update(await readFile(path.join(skillSource, file))).digest('hex');
+  }
+  await writeFile(path.join(skillSource, 'release-manifest.json'), `${JSON.stringify({ version, files: entries }, null, 2)}\n`);
+}
+
 async function fixture() {
   const root = await mkdtemp(path.join(os.tmpdir(), 'job-agent-installer-'));
   const packageRoot = path.join(root, 'package');
@@ -21,6 +31,7 @@ async function fixture() {
   await mkdir(path.join(skillSource, 'scripts'), { recursive: true });
   await writeFile(path.join(skillSource, 'SKILL.md'), '# Version one\n');
   await writeFile(path.join(skillSource, 'scripts', 'job-application.mjs'), 'export {};\n');
+  await writeReleaseManifest(skillSource, '3.0.0');
   return { root, packageRoot, homeDir, agentHome, skillSource };
 }
 
@@ -49,6 +60,7 @@ test('updates atomically and keeps the immediately previous version for rollback
   const f = await fixture();
   await installSkill({ packageRoot: f.packageRoot, packageVersion: '3.0.0', homeDir: f.homeDir, agentHome: f.agentHome, platform: 'test', scheduler: false });
   await writeFile(path.join(f.skillSource, 'SKILL.md'), '# Version two\n');
+  await writeReleaseManifest(f.skillSource, '3.1.0');
 
   const result = await updateSkill({
     packageRoot: f.packageRoot,
@@ -85,6 +97,36 @@ test('a failed staged install leaves the current skill untouched', async () => {
     /invalid packaged skill/i,
   );
   assert.equal(await readFile(path.join(f.agentHome, 'skills', 'job-application-agent', 'SKILL.md'), 'utf8'), '# Version one\n');
+});
+
+test('missing release manifest is rejected before activation', async () => {
+  const f = await fixture();
+  await writeFile(path.join(f.skillSource, 'release-manifest.json'), '');
+  await assert.rejects(
+    installSkill({ packageRoot: f.packageRoot, packageVersion: '3.0.0', homeDir: f.homeDir, agentHome: f.agentHome, platform: 'test', scheduler: false }),
+    /release-manifest\.json/i,
+  );
+});
+
+test('checksum verification failure prevents installation and preserves the current skill', async () => {
+  const f = await fixture();
+  await installSkill({ packageRoot: f.packageRoot, packageVersion: '3.0.0', homeDir: f.homeDir, agentHome: f.agentHome, platform: 'test', scheduler: false });
+  await writeFile(path.join(f.skillSource, 'SKILL.md'), '# Tampered version\n');
+  await writeReleaseManifest(f.skillSource, '3.1.0');
+  await writeFile(path.join(f.skillSource, 'SKILL.md'), '# Tampered after manifest\n');
+  await assert.rejects(
+    updateSkill({ packageRoot: f.packageRoot, packageVersion: '3.1.0', homeDir: f.homeDir, agentHome: f.agentHome, platform: 'test', scheduler: false }),
+    /checksum verification failed/i,
+  );
+  assert.equal(await readFile(path.join(f.agentHome, 'skills', 'job-application-agent', 'SKILL.md'), 'utf8'), '# Version one\n');
+});
+
+test('mutable package versions are rejected', async () => {
+  const f = await fixture();
+  await assert.rejects(
+    installSkill({ packageRoot: f.packageRoot, packageVersion: 'latest', homeDir: f.homeDir, agentHome: f.agentHome, platform: 'test', scheduler: false }),
+    /exact immutable semantic version/i,
+  );
 });
 
 test('copies the skill into an existing vendor skills directory and skips missing vendor homes', async () => {

--- a/installer/tests/installer.test.mjs
+++ b/installer/tests/installer.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -10,6 +10,7 @@ import {
   installSkill,
   readInstallStatus,
   setAutomaticUpdates,
+  uninstallSkill,
   updateSkill,
 } from '../src/installer.mjs';
 
@@ -76,15 +77,124 @@ test('updates atomically and keeps the immediately previous version for rollback
   assert.equal(await readFile(path.join(f.agentHome, 'job-application-agent', 'previous', 'SKILL.md'), 'utf8'), '# Version one\n');
 });
 
-test('automatic updates default on and can be explicitly disabled and re-enabled', async () => {
+test('background update checks default off and can be explicitly enabled and disabled', async () => {
   const f = await fixture();
   await installSkill({ packageRoot: f.packageRoot, packageVersion: '3.0.0', homeDir: f.homeDir, agentHome: f.agentHome, platform: 'test', scheduler: false });
 
-  assert.equal((await readInstallStatus({ agentHome: f.agentHome })).automaticUpdates, true);
+  assert.equal((await readInstallStatus({ agentHome: f.agentHome })).automaticUpdates, false);
   await setAutomaticUpdates(false, { agentHome: f.agentHome, homeDir: f.homeDir, platform: 'test', scheduler: false });
   assert.equal((await readInstallStatus({ agentHome: f.agentHome })).automaticUpdates, false);
   await setAutomaticUpdates(true, { agentHome: f.agentHome, homeDir: f.homeDir, platform: 'test', scheduler: false });
   assert.equal((await readInstallStatus({ agentHome: f.agentHome })).automaticUpdates, true);
+});
+
+test('enabling background updates requires a validated check runner', async () => {
+  const f = await fixture();
+  await installSkill({ packageRoot: f.packageRoot, packageVersion: '3.0.0', homeDir: f.homeDir, agentHome: f.agentHome, platform: 'test', scheduler: false });
+  await assert.rejects(
+    () => setAutomaticUpdates(true, { agentHome: f.agentHome, homeDir: f.homeDir, platform: 'test', scheduler: true }),
+    /validated update-check runner is required/i,
+  );
+});
+
+test('backgroundUpdates opt-in enables persistence and reaches the scheduler with a pinned argv', async () => {
+  const f = await fixture();
+  const calls = [];
+  const result = await installSkill({
+    packageRoot: f.packageRoot,
+    packageVersion: '3.0.0',
+    homeDir: f.homeDir,
+    agentHome: f.agentHome,
+    platform: 'linux',
+    scheduler: true,
+    backgroundUpdates: true,
+    checkRunner: { nodePath: '/usr/bin/node', checkScriptPath: '/opt/agents/job-application-agent/check-update-runner.mjs', agentHome: f.agentHome, packageVersion: '3.0.0' },
+    runCommand: async (...args) => calls.push(args),
+  });
+  assert.equal(result.automaticUpdates, true);
+  assert.ok(calls.some(call => call[0] === 'systemctl' && call[1].includes('--user') && call[1].includes('daemon-reload')));
+  const servicePath = path.join(f.homeDir, '.config', 'systemd', 'user', 'job-application-agent-update.service');
+  const service = await readFile(servicePath, 'utf8');
+  assert.match(service, /ExecStart="\/usr\/bin\/node" "\/opt\/agents\/job-application-agent\/check-update-runner\.mjs"/);
+  assert.doesNotMatch(service, /@latest|npm exec|npm install|npm update|npx/);
+});
+
+test('a disabled background setting removes persistence artifacts on update', async () => {
+  const f = await fixture();
+  const calls = [];
+  const enable = await installSkill({
+    packageRoot: f.packageRoot,
+    packageVersion: '3.0.0',
+    homeDir: f.homeDir,
+    agentHome: f.agentHome,
+    platform: 'linux',
+    scheduler: true,
+    backgroundUpdates: true,
+    checkRunner: { nodePath: '/usr/bin/node', checkScriptPath: '/opt/agents/job-application-agent/check-update-runner.mjs', agentHome: f.agentHome, packageVersion: '3.0.0' },
+    runCommand: async (...args) => calls.push(args),
+  });
+  assert.equal(enable.automaticUpdates, true);
+  await writeFile(path.join(f.skillSource, 'SKILL.md'), '# Version two\n');
+  await writeReleaseManifest(f.skillSource, '3.1.0');
+  const disable = await updateSkill({
+    packageRoot: f.packageRoot,
+    packageVersion: '3.1.0',
+    homeDir: f.homeDir,
+    agentHome: f.agentHome,
+    platform: 'linux',
+    scheduler: true,
+    backgroundUpdates: false,
+    runCommand: async (...args) => calls.push(args),
+  });
+  assert.equal(disable.automaticUpdates, false);
+  await assert.rejects(stat(path.join(f.homeDir, '.config', 'systemd', 'user', 'job-application-agent-update.service')), { code: 'ENOENT' });
+});
+
+test('installing twice converges to a single scheduler artifact set', async () => {
+  const f = await fixture();
+  const calls = [];
+  const opts = {
+    packageRoot: f.packageRoot,
+    packageVersion: '3.0.0',
+    homeDir: f.homeDir,
+    agentHome: f.agentHome,
+    platform: 'linux',
+    scheduler: true,
+    backgroundUpdates: true,
+    checkRunner: { nodePath: '/usr/bin/node', checkScriptPath: '/opt/agents/job-application-agent/check-update-runner.mjs', agentHome: f.agentHome, packageVersion: '3.0.0' },
+    runCommand: async (...args) => calls.push(args),
+  };
+  await installSkill(opts);
+  await installSkill(opts);
+  const systemdDir = path.join(f.homeDir, '.config', 'systemd', 'user');
+  const entries = (await readdir(systemdDir)).filter(name => name.startsWith('job-application-agent-update'));
+  assert.deepEqual(entries.sort(), ['job-application-agent-update.service', 'job-application-agent-update.timer']);
+});
+
+test('uninstall removes the skill, config, scheduler artifacts, and vendor copies', async () => {
+  const f = await fixture();
+  const cursorSkills = path.join(f.homeDir, '.cursor', 'skills');
+  await mkdir(cursorSkills, { recursive: true });
+  const calls = [];
+  await installSkill({
+    packageRoot: f.packageRoot,
+    packageVersion: '3.0.0',
+    homeDir: f.homeDir,
+    agentHome: f.agentHome,
+    platform: 'linux',
+    scheduler: true,
+    backgroundUpdates: true,
+    checkRunner: { nodePath: '/usr/bin/node', checkScriptPath: '/opt/agents/job-application-agent/check-update-runner.mjs', agentHome: f.agentHome, packageVersion: '3.0.0' },
+    runCommand: async (...args) => calls.push(args),
+  });
+  const { uninstallSkill } = await import('../src/installer.mjs');
+  const removed = await uninstallSkill({ homeDir: f.homeDir, agentHome: f.agentHome, platform: 'linux', runCommand: async (...args) => calls.push(args) });
+  assert.equal(removed.uninstalled, true);
+  await assert.rejects(stat(path.join(f.agentHome, 'skills', 'job-application-agent')), { code: 'ENOENT' });
+  await assert.rejects(stat(path.join(f.agentHome, 'job-application-agent', CONFIG_FILENAME)), { code: 'ENOENT' });
+  await assert.rejects(stat(path.join(cursorSkills, 'job-application-agent')), { code: 'ENOENT' });
+  await assert.rejects(stat(path.join(f.homeDir, '.config', 'systemd', 'user', 'job-application-agent-update.service')), { code: 'ENOENT' });
+  await assert.rejects(stat(path.join(f.homeDir, '.config', 'systemd', 'user', 'job-application-agent-update.timer')), { code: 'ENOENT' });
 });
 
 test('a failed staged install leaves the current skill untouched', async () => {

--- a/installer/tests/runner.test.mjs
+++ b/installer/tests/runner.test.mjs
@@ -10,48 +10,66 @@ import { createUpdateRunner } from '../src/runner.mjs';
 
 const execFileAsync = promisify(execFile);
 
-test('creates a durable Unix launcher that always executes the latest npm package', async () => {
+test('creates a durable Unix launcher that performs only a safe local update check', async () => {
   const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-'));
   const result = await createUpdateRunner({
     platform: 'darwin',
     agentHome,
     nodePath: '/opt/node/bin/node',
-    npmCliPath: '/opt/node/lib/node_modules/npm/bin/npm-cli.js',
+    packageVersion: '3.1.1',
   });
   const script = await readFile(result.path, 'utf8');
   assert.match(script, /JOB_APPLICATION_AGENT_HOME=/);
   assert.doesNotMatch(script, /CODEX_HOME=/);
-  assert.match(script, /job-application-agent@latest/);
-  assert.match(script, /auto-update/);
+  assert.match(script, /check-update-runner\.mjs/);
+  assert.match(script, /3\.1\.1/);
+  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update/);
   assert.equal((await stat(result.path)).mode & 0o777, 0o700);
 });
 
-test('Unix launcher exposes its Node directory to npm child processes under a minimal scheduler PATH', async () => {
+test('Unix launcher writes safe check state without needing npm under a minimal scheduler PATH', async () => {
   const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-path-'));
   const emptyPath = await mkdtemp(path.join(os.tmpdir(), 'job-agent-empty-path-'));
-  const fakeNpmCli = path.join(agentHome, 'fake-npm-cli.mjs');
-  await writeFile(fakeNpmCli, `import { spawnSync } from 'node:child_process';\nconst child = spawnSync('node', ['--version']);\nprocess.exit(child.status ?? 1);\n`);
   const result = await createUpdateRunner({
     platform: 'darwin',
     agentHome,
     nodePath: process.execPath,
-    npmCliPath: fakeNpmCli,
+    packageVersion: '3.1.1',
   });
 
-  await execFileAsync(result.path, ['auto-update'], { env: { PATH: emptyPath } });
+  await execFileAsync(result.path, { env: { PATH: emptyPath } });
+  const status = JSON.parse(await readFile(path.join(agentHome, 'job-application-agent', 'update-status.json'), 'utf8'));
+  assert.equal(status.installedVersion, '3.1.1');
+  assert.equal(status.automaticUpdateExecution, false);
+  assert.equal(status.status, 'manual-review-required');
 });
 
-test('creates a durable Windows launcher that always executes the latest npm package', async () => {
+test('rejects mutable or missing versions for the safe runner', async () => {
+  const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-version-'));
+  await assert.rejects(() => createUpdateRunner({
+    platform: 'darwin',
+    agentHome,
+    nodePath: process.execPath,
+    packageVersion: 'latest',
+  }), /exact immutable semantic version/i);
+  await assert.rejects(() => createUpdateRunner({
+    platform: 'darwin',
+    agentHome,
+    nodePath: process.execPath,
+  }), /exact package version is required/i);
+});
+
+test('creates a durable Windows launcher that performs only a safe local update check', async () => {
   const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-win-'));
   const result = await createUpdateRunner({
     platform: 'win32',
     agentHome,
     nodePath: 'C:\\Node\\node.exe',
-    npmCliPath: 'C:\\Node\\node_modules\\npm\\bin\\npm-cli.js',
+    packageVersion: '3.1.1',
   });
   const script = await readFile(result.path, 'utf8');
   assert.match(script, /JOB_APPLICATION_AGENT_HOME/);
   assert.doesNotMatch(script, /CODEX_HOME/);
-  assert.match(script, /job-application-agent@latest/);
-  assert.match(script, /auto-update/);
+  assert.match(script, /check-update-runner\.mjs/);
+  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update/);
 });

--- a/installer/tests/runner.test.mjs
+++ b/installer/tests/runner.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -10,66 +10,67 @@ import { createUpdateRunner } from '../src/runner.mjs';
 
 const execFileAsync = promisify(execFile);
 
-test('creates a durable Unix launcher that performs only a safe local update check', async () => {
+test('returns pinned absolute node, script, and version with no shell wrapper', async () => {
   const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-'));
-  const result = await createUpdateRunner({
-    platform: 'darwin',
-    agentHome,
-    nodePath: '/opt/node/bin/node',
-    packageVersion: '3.1.1',
-  });
-  const script = await readFile(result.path, 'utf8');
-  assert.match(script, /JOB_APPLICATION_AGENT_HOME=/);
-  assert.doesNotMatch(script, /CODEX_HOME=/);
-  assert.match(script, /check-update-runner\.mjs/);
-  assert.match(script, /3\.1\.1/);
-  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update/);
-  assert.equal((await stat(result.path)).mode & 0o777, 0o700);
+  const result = await createUpdateRunner({ agentHome, nodePath: process.execPath, packageVersion: '3.1.1' });
+
+  assert.ok(path.isAbsolute(result.nodePath));
+  assert.ok(path.isAbsolute(result.checkScriptPath));
+  assert.equal(result.agentHome, agentHome);
+  assert.equal(result.packageVersion, '3.1.1');
+  assert.equal(path.basename(result.checkScriptPath), 'check-update-runner.mjs');
+
+  const entries = await readdir(path.join(agentHome, 'job-application-agent'));
+  assert.ok(entries.includes('check-update-runner.mjs'));
+  assert.ok(!entries.includes('check-update'), 'no shell launcher should be created');
+  assert.ok(!entries.includes('check-update.cmd'), 'no cmd launcher should be created');
+  assert.ok(!entries.includes('update'), 'no legacy update launcher should be created');
+  assert.ok(!entries.includes('update.cmd'));
+
+  const mode = (await stat(result.checkScriptPath)).mode & 0o777;
+  assert.equal(mode, 0o600);
 });
 
-test('Unix launcher writes safe check state without needing npm under a minimal scheduler PATH', async () => {
-  const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-path-'));
-  const emptyPath = await mkdtemp(path.join(os.tmpdir(), 'job-agent-empty-path-'));
-  const result = await createUpdateRunner({
-    platform: 'darwin',
-    agentHome,
-    nodePath: process.execPath,
-    packageVersion: '3.1.1',
-  });
+test('the generated check script is a static, hermetic local file with no code-execution surface', async () => {
+  const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-static-'));
+  const result = await createUpdateRunner({ agentHome, nodePath: process.execPath, packageVersion: '3.1.1' });
+  const script = await readFile(result.checkScriptPath, 'utf8');
+  assert.match(script, /manual-review-required/);
+  assert.match(script, /automaticUpdateExecution: false/);
+  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update|npx|node_modules/);
+  assert.doesNotMatch(script, /child_process|execFile|spawn|fetch\(|https?:|require\(|eval\(/);
+  assert.doesNotMatch(script, /JOB_APPLICATION_AGENT_HOME|PATH=/);
+});
 
-  await execFileAsync(result.path, { env: { PATH: emptyPath } });
+test('the check runner runs node directly and writes only a pending-review notice, without npm or a PATH', async () => {
+  const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-run-'));
+  const emptyPath = await mkdtemp(path.join(os.tmpdir(), 'job-agent-empty-path-'));
+  const result = await createUpdateRunner({ agentHome, nodePath: process.execPath, packageVersion: '3.1.1' });
+
+  await execFileAsync(result.nodePath, [result.checkScriptPath, agentHome, '3.1.1'], { env: { PATH: emptyPath } });
   const status = JSON.parse(await readFile(path.join(agentHome, 'job-application-agent', 'update-status.json'), 'utf8'));
   assert.equal(status.installedVersion, '3.1.1');
   assert.equal(status.automaticUpdateExecution, false);
+  assert.equal(status.pendingUpdateVersion, null);
   assert.equal(status.status, 'manual-review-required');
 });
 
-test('rejects mutable or missing versions for the safe runner', async () => {
+test('rejects mutable or missing versions', async () => {
   const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-version-'));
-  await assert.rejects(() => createUpdateRunner({
-    platform: 'darwin',
-    agentHome,
-    nodePath: process.execPath,
-    packageVersion: 'latest',
-  }), /exact immutable semantic version/i);
-  await assert.rejects(() => createUpdateRunner({
-    platform: 'darwin',
-    agentHome,
-    nodePath: process.execPath,
-  }), /exact package version is required/i);
+  await assert.rejects(() => createUpdateRunner({ agentHome, nodePath: process.execPath, packageVersion: 'latest' }), /exact immutable semantic version/i);
+  await assert.rejects(() => createUpdateRunner({ agentHome, nodePath: process.execPath }), /exact package version is required/i);
+  await assert.rejects(() => createUpdateRunner({ agentHome, nodePath: process.execPath, packageVersion: '^3.0.0' }), /exact immutable semantic version/i);
 });
 
-test('creates a durable Windows launcher that performs only a safe local update check', async () => {
-  const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-win-'));
-  const result = await createUpdateRunner({
-    platform: 'win32',
-    agentHome,
-    nodePath: 'C:\\Node\\node.exe',
-    packageVersion: '3.1.1',
-  });
-  const script = await readFile(result.path, 'utf8');
-  assert.match(script, /JOB_APPLICATION_AGENT_HOME/);
-  assert.doesNotMatch(script, /CODEX_HOME/);
-  assert.match(script, /check-update-runner\.mjs/);
-  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update/);
+test('rejects relative homes and relative node paths', async () => {
+  const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-abs-'));
+  await assert.rejects(() => createUpdateRunner({ agentHome: 'relative/agents', nodePath: process.execPath, packageVersion: '3.1.1' }), /absolute path/i);
+  await assert.rejects(() => createUpdateRunner({ agentHome, nodePath: 'relative/node', packageVersion: '3.1.1' }), /absolute path/i);
+});
+
+test('resolves symlinked node binaries to their real path', async () => {
+  const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-symlink-'));
+  const result = await createUpdateRunner({ agentHome, nodePath: process.execPath, packageVersion: '3.1.1' });
+  const real = await import('node:fs/promises').then(m => m.realpath(process.execPath));
+  assert.equal(result.nodePath, real);
 });

--- a/installer/tests/scheduler.test.mjs
+++ b/installer/tests/scheduler.test.mjs
@@ -6,15 +6,16 @@ import test from 'node:test';
 
 import { installScheduler, LEGACY_SCHEDULER_LABEL, removeScheduler, SCHEDULER_LABEL } from '../src/scheduler.mjs';
 
-test('macOS scheduler runs at login and hourly using the latest npm package', async () => {
+test('macOS scheduler runs at login and hourly using the safe local check runner', async () => {
   const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-macos-'));
   const agentHome = path.join(homeDir, '.agents');
   const calls = [];
-  const result = await installScheduler({ platform: 'darwin', homeDir, agentHome, command: '/usr/local/bin/job-application-agent', userId: 501, runCommand: async (...args) => calls.push(args) });
+  const result = await installScheduler({ platform: 'darwin', homeDir, agentHome, command: '/usr/local/bin/job-application-agent-check', userId: 501, runCommand: async (...args) => calls.push(args) });
   const plist = await readFile(result.path, 'utf8');
   assert.match(plist, /RunAtLoad/);
   assert.match(plist, /<integer>3600<\/integer>/);
-  assert.match(plist, /auto-update/);
+  assert.match(plist, /job-application-agent-check/);
+  assert.doesNotMatch(plist, /@latest|npm exec|npm install|npm update/);
   assert.match(plist, new RegExp(SCHEDULER_LABEL));
   assert.match(plist, /\.agents\/logs/);
   assert.doesNotMatch(plist, /codex/);
@@ -34,35 +35,37 @@ test('macOS scheduler removes the legacy LaunchAgent so two timers are not left 
   const legacyPath = path.join(launchAgents, `${LEGACY_SCHEDULER_LABEL}.plist`);
   await writeFile(legacyPath, '<plist />\n');
   const calls = [];
-  await installScheduler({ platform: 'darwin', homeDir, agentHome, command: '/usr/local/bin/job-application-agent', userId: 501, runCommand: async (...args) => calls.push(args) });
+  await installScheduler({ platform: 'darwin', homeDir, agentHome, command: '/usr/local/bin/job-application-agent-check', userId: 501, runCommand: async (...args) => calls.push(args) });
   await assert.rejects(readFile(legacyPath), { code: 'ENOENT' });
   assert.ok(calls.some((call) => call[0] === 'launchctl' && String(call[1][2]).endsWith(`${LEGACY_SCHEDULER_LABEL}.plist`)));
 });
 
-test('Linux scheduler installs an hourly user systemd timer', async () => {
+test('Linux scheduler installs an hourly user systemd timer for safe checks only', async () => {
   const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-linux-'));
   const calls = [];
-  const result = await installScheduler({ platform: 'linux', homeDir, command: '/usr/local/bin/job-application-agent', runCommand: async (...args) => calls.push(args) });
+  const result = await installScheduler({ platform: 'linux', homeDir, command: '/usr/local/bin/job-application-agent-check', runCommand: async (...args) => calls.push(args) });
   const timer = await readFile(result.timerPath, 'utf8');
   const service = await readFile(result.servicePath, 'utf8');
   assert.match(timer, /OnBootSec=2m/);
   assert.match(timer, /OnUnitActiveSec=1h/);
-  assert.match(service, /auto-update/);
+  assert.match(service, /job-application-agent-check/);
+  assert.doesNotMatch(service, /@latest|npm exec|npm install|npm update/);
   assert.deepEqual(calls, [
     ['systemctl', ['--user', 'daemon-reload']],
     ['systemctl', ['--user', 'enable', '--now', 'job-application-agent-update.timer']],
   ]);
 });
 
-test('Windows scheduler definition runs hourly and at logon', async () => {
+test('Windows scheduler definition runs hourly and at logon without update arguments', async () => {
   const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-win32-'));
   const agentHome = path.join(homeDir, '.agents');
   const calls = [];
-  const result = await installScheduler({ platform: 'win32', homeDir, agentHome, command: 'C:\\bin\\job-application-agent.cmd', runCommand: async (...args) => calls.push(args) });
+  const result = await installScheduler({ platform: 'win32', homeDir, agentHome, command: 'C:\\bin\\job-application-agent-check.cmd', runCommand: async (...args) => calls.push(args) });
   const script = await readFile(result.scriptPath, 'utf8');
   assert.match(script, /New-ScheduledTaskTrigger -AtLogOn/);
   assert.match(script, /RepetitionInterval/);
-  assert.match(script, /auto-update/);
+  assert.match(script, /job-application-agent-check\.cmd/);
+  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update/);
   assert.equal(result.scriptPath, path.join(agentHome, 'job-application-agent', 'register-update-task.ps1'));
   assert.deepEqual(calls, [['powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', result.scriptPath]]]);
 });

--- a/installer/tests/scheduler.test.mjs
+++ b/installer/tests/scheduler.test.mjs
@@ -1,24 +1,33 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
 import { installScheduler, LEGACY_SCHEDULER_LABEL, removeScheduler, SCHEDULER_LABEL } from '../src/scheduler.mjs';
 
-test('macOS scheduler runs at login and hourly using the safe local check runner', async () => {
-  const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-macos-'));
+const NODE = '/usr/local/bin/node';
+const SCRIPT = '/usr/local/share/job-application-agent/check-update-runner.mjs';
+const VERSION = '3.1.1';
+
+async function base(runCommand) {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-sched-'));
   const agentHome = path.join(homeDir, '.agents');
+  return { homeDir, agentHome };
+}
+
+test('macOS scheduler invokes only the pinned node executable with explicit argv', async () => {
+  const { homeDir, agentHome } = await base();
   const calls = [];
-  const result = await installScheduler({ platform: 'darwin', homeDir, agentHome, command: '/usr/local/bin/job-application-agent-check', userId: 501, runCommand: async (...args) => calls.push(args) });
+  const result = await installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: VERSION, userId: 501, runCommand: async (...args) => calls.push(args) });
   const plist = await readFile(result.path, 'utf8');
   assert.match(plist, /RunAtLoad/);
   assert.match(plist, /<integer>3600<\/integer>/);
-  assert.match(plist, /job-application-agent-check/);
-  assert.doesNotMatch(plist, /@latest|npm exec|npm install|npm update/);
-  assert.match(plist, new RegExp(SCHEDULER_LABEL));
-  assert.match(plist, /\.agents\/logs/);
-  assert.doesNotMatch(plist, /codex/);
+  assert.match(plist, /ProcessType/);
+  const argvMatches = plist.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/)?.[1] ?? '';
+  const strings = [...argvMatches.matchAll(/<string>(.*?)<\/string>/g)].map(m => m[1]);
+  assert.deepEqual(strings, [NODE, SCRIPT, agentHome, VERSION]);
+  assert.doesNotMatch(plist, /@latest|npm exec|npm install|npm update|\/bin\/sh|\/bin\/bash|npx/);
   assert.equal(result.path, path.join(homeDir, 'Library', 'LaunchAgents', `${SCHEDULER_LABEL}.plist`));
   assert.deepEqual(calls.at(-1), ['launchctl', ['bootstrap', 'gui/501', result.path]]);
   assert.equal(calls[0][0], 'launchctl');
@@ -27,45 +36,140 @@ test('macOS scheduler runs at login and hourly using the safe local check runner
   assert.equal(calls.at(-1)[0], 'launchctl');
 });
 
-test('macOS scheduler removes the legacy LaunchAgent so two timers are not left running', async () => {
-  const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-macos-legacy-'));
-  const agentHome = path.join(homeDir, '.agents');
+test('macOS scheduler removes the legacy LaunchAgent so two agents are not left running', async () => {
+  const { homeDir, agentHome } = await base();
   const launchAgents = path.join(homeDir, 'Library', 'LaunchAgents');
   await mkdir(launchAgents, { recursive: true });
   const legacyPath = path.join(launchAgents, `${LEGACY_SCHEDULER_LABEL}.plist`);
   await writeFile(legacyPath, '<plist />\n');
   const calls = [];
-  await installScheduler({ platform: 'darwin', homeDir, agentHome, command: '/usr/local/bin/job-application-agent-check', userId: 501, runCommand: async (...args) => calls.push(args) });
+  await installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: VERSION, userId: 501, runCommand: async (...args) => calls.push(args) });
   await assert.rejects(readFile(legacyPath), { code: 'ENOENT' });
   assert.ok(calls.some((call) => call[0] === 'launchctl' && String(call[1][2]).endsWith(`${LEGACY_SCHEDULER_LABEL}.plist`)));
 });
 
-test('Linux scheduler installs an hourly user systemd timer for safe checks only', async () => {
-  const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-linux-'));
+test('macOS installScheduler is idempotent: reinstall boots out then bootstraps one agent', async () => {
+  const { homeDir, agentHome } = await base();
   const calls = [];
-  const result = await installScheduler({ platform: 'linux', homeDir, command: '/usr/local/bin/job-application-agent-check', runCommand: async (...args) => calls.push(args) });
+  const runCommand = async (...args) => calls.push(args);
+  await installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: VERSION, userId: 501, runCommand });
+  const firstCount = calls.filter(c => c[0] === 'launchctl' && c[1][0] === 'bootstrap').length;
+  await installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: VERSION, userId: 501, runCommand });
+  const boots = calls.filter(c => c[0] === 'launchctl' && c[1][0] === 'bootout');
+  const bootstraps = calls.filter(c => c[0] === 'launchctl' && c[1][0] === 'bootstrap');
+  assert.equal(firstCount, 1);
+  assert.equal(bootstraps.length, 2);
+  assert.ok(boots.length >= 2);
+  const plist = await readFile(path.join(homeDir, 'Library', 'LaunchAgents', `${SCHEDULER_LABEL}.plist`), 'utf8');
+  assert.match(plist, new RegExp(SCHEDULER_LABEL));
+});
+
+test('Linux scheduler pins explicit argv with systemd quoting and no shell', async () => {
+  const { homeDir } = await base();
+  const calls = [];
+  const result = await installScheduler({ platform: 'linux', homeDir, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: VERSION, runCommand: async (...args) => calls.push(args) });
   const timer = await readFile(result.timerPath, 'utf8');
   const service = await readFile(result.servicePath, 'utf8');
   assert.match(timer, /OnBootSec=2m/);
   assert.match(timer, /OnUnitActiveSec=1h/);
-  assert.match(service, /job-application-agent-check/);
-  assert.doesNotMatch(service, /@latest|npm exec|npm install|npm update/);
+  assert.match(service, /ExecStart=/);
+  assert.match(service, new RegExp(NODE.replaceAll('$', '\\$')));
+  assert.match(service, new RegExp(SCRIPT.replaceAll('$', '\\$')));
+  assert.doesNotMatch(service, /@latest|npm exec|npm install|npm update|npx|\/bin\/sh|\/bin\/bash/);
   assert.deepEqual(calls, [
     ['systemctl', ['--user', 'daemon-reload']],
     ['systemctl', ['--user', 'enable', '--now', 'job-application-agent-update.timer']],
   ]);
 });
 
-test('Windows scheduler definition runs hourly and at logon without update arguments', async () => {
-  const homeDir = await mkdtemp(path.join(os.tmpdir(), 'job-agent-win32-'));
-  const agentHome = path.join(homeDir, '.agents');
+test('Windows scheduler registers the node executable with a CreateProcess-escaped argument line', async () => {
+  const { homeDir, agentHome } = await base();
   const calls = [];
-  const result = await installScheduler({ platform: 'win32', homeDir, agentHome, command: 'C:\\bin\\job-application-agent-check.cmd', runCommand: async (...args) => calls.push(args) });
+  const result = await installScheduler({ platform: 'win32', homeDir, agentHome, nodePath: 'C:\\Program Files\\nodejs\\node.exe', checkScriptPath: 'C:\\Users\\Ada\\AppData\\Roaming\\job-application-agent\\check-update-runner.mjs', packageVersion: VERSION, runCommand: async (...args) => calls.push(args) });
   const script = await readFile(result.scriptPath, 'utf8');
   assert.match(script, /New-ScheduledTaskTrigger -AtLogOn/);
   assert.match(script, /RepetitionInterval/);
-  assert.match(script, /job-application-agent-check\.cmd/);
-  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update/);
+  assert.match(script, /New-ScheduledTaskAction -Execute 'C:\\Program Files\\nodejs\\node\.exe'/);
+  assert.match(script, /check-update-runner\.mjs/);
+  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update|npx/);
   assert.equal(result.scriptPath, path.join(agentHome, 'job-application-agent', 'register-update-task.ps1'));
   assert.deepEqual(calls, [['powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', result.scriptPath]]]);
+});
+
+test('Windows scheduler escapes hostile paths as literal arguments with no shell involvement', async () => {
+  const { homeDir, agentHome } = await base();
+  const hostileNode = 'C:\\Program Files\\nodejs\\node.exe';
+  const hostileScript = "C:\\Users\\O'Brien\\AppData\\Local\\job-application-agent\\check-update-runner.mjs";
+  const calls = [];
+  const result = await installScheduler({ platform: 'win32', homeDir, agentHome, nodePath: hostileNode, checkScriptPath: hostileScript, packageVersion: VERSION, runCommand: async (...args) => calls.push(args) });
+  const script = await readFile(result.scriptPath, 'utf8');
+  assert.match(script, /New-ScheduledTaskAction -Execute 'C:\\Program Files\\nodejs\\node\.exe'/);
+  assert.match(script, / -Argument '.*check-update-runner\.mjs.*'/);
+  assert.match(script, /O''Brien/, 'PowerShell single-quote escaping must keep apostrophes literal');
+  assert.doesNotMatch(script, /cmd \/c|powershell -Command|start-process|Invoke-Expression|iex/i);
+  assert.doesNotMatch(script, /@latest|npm exec|npm install|npm update|npx/);
+  assert.deepEqual(calls, [['powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', result.scriptPath]]]);
+});
+
+test('macOS persistence keeps hostile path characters as literal argv, never shell metacharacters', async () => {
+  const { homeDir } = await base();
+  const hostile = path.join(homeDir, "weird; $(rm -rf ~) `id` 'quoted' space\u00e9");
+  await mkdir(hostile, { recursive: true });
+  const hostileScript = path.join(hostile, 'check-update-runner.mjs');
+  const result = await installScheduler({ platform: 'darwin', homeDir, agentHome: hostile, nodePath: path.join(hostile, 'node; "binary"'), checkScriptPath: hostileScript, packageVersion: VERSION, userId: 501, runCommand: async () => {} });
+  const plist = await readFile(result.path, 'utf8');
+  const argvMatches = plist.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/)?.[1] ?? '';
+  const strings = [...argvMatches.matchAll(/<string>(.*?)<\/string>/g)].map(m => m[1]);
+  assert.deepEqual(strings, [path.join(hostile, 'node; "binary"'), hostileScript, hostile, VERSION]);
+  assert.doesNotMatch(plist, /\/bin\/sh|\/bin\/bash|sh -c/);
+});
+
+test('systemd quoting prevents $, backtick, percent, and quote expansion in persistence paths', async () => {
+  const { homeDir } = await base();
+  const hostile = path.join(homeDir, 'dir$PATH`id`%n"quote"');
+  await mkdir(hostile, { recursive: true });
+  const result = await installScheduler({ platform: 'linux', homeDir, agentHome: hostile, nodePath: '/usr/bin/node', checkScriptPath: path.join(hostile, 'check-update-runner.mjs'), packageVersion: VERSION, runCommand: async () => {} });
+  const service = await readFile(result.servicePath, 'utf8');
+  const execLine = service.match(/ExecStart=(.*)/)[1];
+  assert.ok(execLine.includes('\\$PATH'), 'systemd must escape $ expansion');
+  assert.ok(execLine.includes('\\`id\\`'), 'systemd must escape backtick expansion');
+  assert.ok(execLine.includes('%%n'), 'systemd must escape percent specifiers');
+  assert.ok(execLine.includes('\\"quote\\"'), 'systemd must escape double quotes');
+  assert.ok(execLine.includes('"/usr/bin/node"'));
+  assert.ok(execLine.includes('"3.1.1"'));
+  assert.doesNotMatch(service, /@latest|npm exec|npm install|npm update|npx/);
+});
+
+test('unsupported values and relative paths are rejected before any persistence is written', async () => {
+  const { homeDir, agentHome } = await base();
+  await assert.rejects(() => installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: 'relative/node', checkScriptPath: SCRIPT, packageVersion: VERSION, userId: 501, runCommand: async () => {} }), /absolute path/i);
+  await assert.rejects(() => installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: NODE, checkScriptPath: 'relative/check.mjs', packageVersion: VERSION, userId: 501, runCommand: async () => {} }), /absolute path/i);
+  await assert.rejects(() => installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: 'latest', userId: 501, runCommand: async () => {} }), /exact immutable semantic version/i);
+  await assert.rejects(() => installScheduler({ platform: 'darwin', homeDir, agentHome, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: '1.2.x', userId: 501, runCommand: async () => {} }), /exact immutable semantic version/i);
+});
+
+test('removeScheduler removes every OS artifact and the local runner artifacts', async () => {
+  const { homeDir, agentHome } = await base();
+  const launchAgents = path.join(homeDir, 'Library', 'LaunchAgents');
+  await mkdir(launchAgents, { recursive: true });
+  const plistPath = path.join(launchAgents, `${SCHEDULER_LABEL}.plist`);
+  await writeFile(plistPath, '<plist />\n');
+  const managerDir = path.join(agentHome, 'job-application-agent');
+  await mkdir(managerDir, { recursive: true });
+  for (const file of ['check-update-runner.mjs', 'check-update', 'update-status.json', 'register-update-task.ps1']) {
+    await writeFile(path.join(managerDir, file), 'x\n');
+  }
+  const calls = [];
+  await removeScheduler({ platform: 'darwin', homeDir, agentHome, userId: 501, runCommand: async (...args) => calls.push(args) });
+  await assert.rejects(readFile(plistPath), { code: 'ENOENT' });
+  for (const file of ['check-update-runner.mjs', 'check-update', 'update-status.json', 'register-update-task.ps1']) {
+    await assert.rejects(readFile(path.join(managerDir, file)), { code: 'ENOENT' });
+  }
+  assert.ok(calls.some(call => call[0] === 'launchctl' && call[1][0] === 'bootout'));
+});
+
+test('test platform never touches OS persistence', async () => {
+  const { homeDir, agentHome } = await base();
+  const result = await installScheduler({ platform: 'test', homeDir, agentHome, nodePath: NODE, checkScriptPath: SCRIPT, packageVersion: VERSION, runCommand: async () => { throw new Error('must not run'); } });
+  assert.deepEqual(result, { installed: false, platform: 'test' });
 });

--- a/job-application-agent/release-manifest.json
+++ b/job-application-agent/release-manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": "3.1.1",
+  "files": {
+    "SKILL.md": "a5021cc83cea7c347589922b666a8e40c98c290ad130e547258cec1f6e62bf21",
+    "references/ANALYTICS.md": "8171b594f69340c36e5cb50e98d68b913f8e3af16d466647bb8fdd70284c3a14",
+    "references/APPLICATION_GUIDANCE.md": "d949a7aa832a10143152175fa1cca0f3506bf15ead91a6953d952b10fedee442",
+    "references/AUTONOMY.md": "80e7be91a96b6f6f8a1d132f7fb33807617ed511e8cb3e19b7a33b6764ce0102",
+    "references/BROWSER_UPLOADS.md": "40a3912a8404be142b94570367b38f9ee0f95f41356c3752e9ddf85736472b43",
+    "references/RUNS.md": "48bba54a98d546d3e5aaba8fbcc9c195c21315a14868ffdb6928b10c7bbd8952",
+    "references/SCHEMAS.md": "e32dd3a7b51b530c5588221d5a01459afbcf265d7ebeed24152da8395ec8c62d",
+    "scripts/job-application.mjs": "c30e913393a90fe67f7f27d13b350c8ab2576db3489d11e02dd0baa5f82b6354",
+    "scripts/secret-store.mjs": "112ce785115e574c921c19e7a03a198b88cf9adbe764bad4d627bf2770800ca1",
+    "scripts/telemetry-client.mjs": "bb423a8df7633fbdd136e80d038d649e039e43588ad26d491783996d0ccefb1f",
+    "scripts/telemetry-schema.mjs": "40d15640a269316ed2e0f2aebaec875a651cd6190a9024d711218f1d0797410a",
+    "scripts/windows-profile-store.ps1": "54a8289e6658368f2ada1217e245a599f834a47e26a67ff2ff27e3635b402426",
+    "tests/job-application.test.mjs": "1acaf6739a238595d5a8a57993485965866e285ad5510b21978c8f842ed16d91",
+    "tests/privacy-audit.test.mjs": "8e5d15a3b2787c26d139c2f589ee54d1be66870a46e2757a6db02df944e089c6",
+    "tests/secret-store.test.mjs": "da24ef3bb8dcdbbb1b0581c04c6f10fcbf23f7940c41b0e7a6c82f26cbe968ab",
+    "tests/skill-contract.test.mjs": "c1403f2c95cdef6fbb974978f742dafb832a9480d864396e181d3d91364f5bb3",
+    "tests/telemetry-client.test.mjs": "aa515a04545e3cdd343e4fd5dffb80a6dd1687a3cd323ca8ed0bdf16f4798bdc",
+    "tests/telemetry-schema.test.mjs": "34d0ab15c328e135f8bd3094027bb7eb5243ab018d8ac96af3a2b366abf95a78",
+    "tests/workflow-state.test.mjs": "765234b9aa3006bc85b72cde586f62fe9d148a0b866eef91bfa49b9937583e9d"
+  }
+}

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -29,7 +29,7 @@ try {
   const skill = await readFile(path.join(agentHome, 'skills', 'job-application-agent', 'SKILL.md'), 'utf8');
   const config = JSON.parse(await readFile(path.join(agentHome, 'job-application-agent', 'install.json'), 'utf8'));
   if (!skill.includes('# Job Application Agent')) throw new Error('Packed skill did not install correctly.');
-  if (config.installedVersion !== packageManifest.version || config.automaticUpdates !== true) throw new Error('Packed installer state is incorrect.');
+  if (config.installedVersion !== packageManifest.version || config.automaticUpdates !== false) throw new Error('Packed installer state is incorrect.');
   if (((await stat(path.join(agentHome, 'job-application-agent', 'install.json'))).mode & 0o777) !== 0o600) throw new Error('Install configuration permissions are not private.');
   process.stdout.write('Packed npm installation smoke test passed.\n');
 } finally {

--- a/telemetry-worker/public/dashboard.js
+++ b/telemetry-worker/public/dashboard.js
@@ -159,7 +159,7 @@ function renderOutcomeBar(outcomes, submitted) {
 function setupCopyAction() {
   const button = document.querySelector('#copy-install');
   button?.addEventListener('click', async () => {
-    const command = 'npx job-application-agent@latest';
+    const command = 'npx job-application-agent@3.1.1 install';
     try {
       await navigator.clipboard.writeText(command);
       button.textContent = 'Copied';

--- a/telemetry-worker/public/index.html
+++ b/telemetry-worker/public/index.html
@@ -43,7 +43,7 @@
           <p class="eyebrow">Anonymous aggregate momentum</p>
           <h1 id="page-title">The job-search agents are moving.</h1>
           <div class="install-command" aria-label="Installation command">
-            <code><span aria-hidden="true">$</span> npx job-application-agent@latest</code>
+            <code><span aria-hidden="true">$</span> npx job-application-agent@3.1.1 install</code>
             <button id="copy-install" type="button">Copy</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Resolves two Critical vulnerabilities in the installer's background update + persistence mechanism.

### Critical 1 — unsafe automatic `@latest` updater (remote code execution)

`install` generated a persistent runner that invoked `npm exec --package=job-application-agent@latest`, so a mutable public registry tag could silently resolve to new code and run without user approval.

### Critical 2 — persistent scheduled execution (durable foothold)

The installer created OS-level persistence (macOS LaunchAgent, Linux user systemd timer, Windows scheduled task) **by default** and wired it to a code-execution path. A single compromise became a login/hourly foothold that kept executing after the interactive process ended.

## Changes

- **`installer/src/runner.mjs`** — removed the npm-based updater and the shell/`.cmd` launcher. `createUpdateRunner` now returns a structured `{ nodePath, checkScriptPath, agentHome, packageVersion }` with `realpath`'d absolute paths, symlink validation, and a static, hermetic check script (no `child_process`/`exec`/`spawn`/`fetch`/`require`/`eval`).
- **`installer/src/scheduler.mjs`** — the scheduler invokes the pinned Node executable with a fixed argv array, never a shell or package manager:
  - macOS `ProgramArguments` array (launchd `execve`, no shell),
  - systemd `ExecStart` with per-argument escaping (`$`, backtick, `%`, quotes),
  - Windows `-Execute node.exe` + CreateProcess-quoted `-Argument`.
  Validates absolute paths and exact semver; `removeScheduler` deletes every artifact.
- **`installer/src/installer.mjs`** — persistence is now **opt-in** (`automaticUpdates` defaults to `false`); `reconcilePersistence` converges OS state to config state; exact-version + release-manifest checksum verification before activation with staged install and previous-copy rollback; new `uninstallSkill`.
- **`installer/src/cli.mjs`** — new `--enable-background-updates` flag, `uninstall` command, reworded status output.
- **`job-application-agent/release-manifest.json`** — SHA-256 manifest for the shipped payload.
- **tests** — security coverage for opt-in default, argv pinning, injection-resistant path handling, idempotency, removal, and rollback across macOS/Linux/Windows.
- **`README.md` / dashboard / `scripts/smoke-package.mjs`** — exact-version docs, default-off persistence, uninstall.

## New architecture

```
scheduled task → pinned local node → check-update-runner.mjs (writes update-status.json only)
                                                            │
                                                            ▼
                                          status: manual-review-required (never installs)
                                                            │
                                    user runs explicit `update` (exact version)
                                                            │
                              verify → stage → validate → activate → rollback copy
```

Persistence, update installation, and update execution are fully separated. Background automation can no longer download or execute code.

## Security guarantees

- No persistence unless explicitly requested (`--enable-background-updates` / `updates enable`).
- No shell, npm, npx, `npm exec`, or mutable-tag resolution in any scheduled path.
- Pinned, `realpath`'d executable; deterministic argv command surface.
- Injection-resistant paths (spaces, quotes, apostrophes, `$`, backticks, `%`, semicolons, unicode).
- Least privilege (user-level only, no root).
- Idempotent install and complete removal (`updates disable` / `uninstall`).

## Tests

- `npm test` — 110/110 passing
- `npm run check` — passing
- `npm run smoke:package` — passing
- `npm run privacy-audit` — passing
- E2E install → uninstall → status through the packed CLI — passing

## Remaining risks (honest)

- **No out-of-band signing**: checksum manifest + pinned argv guard against corruption/drift, but a fully malicious *published* package used in an explicit user-run update can still self-verify. A separately trusted public key / signed release metadata channel is still needed.
- **Local file tampering**: the check script lives in a user-writable dir; a local attacker who can already write to the user's home can replace it (not an escalation, but not cryptographically defended).
- **Anti-rollback**: no policy yet prevents an explicit downgrade to a known-vulnerable signed version.