### PR TITLE
ci: enforce external contribution quality gates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# High-risk contribution surfaces require maintainer review.
+/.github/ @vaibhavarora14
+/installer/ @vaibhavarora14
+/job-application-agent/scripts/ @vaibhavarora14
+/bin/ @vaibhavarora14
+/scripts/ci/ @vaibhavarora14
+/scripts/smoke-package.mjs @vaibhavarora14
+/package.json @vaibhavarora14
+/package-lock.json @vaibhavarora14
+/SECURITY.md @vaibhavarora14

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What observable behavior changes, and why is this the smallest useful change? -->
+
+## Risk and invariants
+
+- [ ] This change does not affect security, privacy, persistence, concurrency, installation, release, or destructive filesystem behavior.
+- [ ] If it does, I described the invariant, failure behavior, and rollback behavior below.
+- [ ] Every use of “atomic,” “safe,” “exact,” “verified,” or “never” is backed by a direct test or explicitly bounded.
+
+<!-- List the state that must remain true before, during, and after failures. Write “Not applicable” only when appropriate. -->
+
+## Verification
+
+- [ ] I added a regression test for each bug fix and confirmed it fails without the fix.
+- [ ] `npm run check`
+- [ ] `npm test`
+- [ ] `npm run privacy-audit`
+- [ ] `npm run smoke:package`
+
+<!-- Include relevant manual or platform-specific verification and its result. -->
+
+## Scope
+
+- [ ] The pull request contains one logical change.
+- [ ] Non-test changes are roughly 300 lines or fewer, or I explained why splitting would reduce safety or reviewability.

--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,0 +1,2 @@
+PyYAML==6.0.3 \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc

--- a/.github/workflows/deploy-telemetry.yml
+++ b/.github/workflows/deploy-telemetry.yml
@@ -13,8 +13,8 @@ jobs:
     environment: telemetry-production
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - run: npm run check && npm test && npm run privacy-audit

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,9 +1,8 @@
 name: Publish npm package
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -16,14 +15,17 @@ jobs:
     environment: npm-production
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - run: npm ci
-      - run: npm run check && npm test && npm run privacy-audit && npm run smoke:package
+      - name: Verify release tag matches package version
+        shell: bash
+        run: test "v$(node -p "require('./package.json').version")" = "${{ github.event.release.tag_name }}"
+      - run: npm run check && npm test && npm run privacy-audit && npm run smoke:package && npm run check:native-artifacts
       - name: Check whether this version is already published
         id: version-check
         shell: bash

--- a/.github/workflows/staging-telemetry.yml
+++ b/.github/workflows/staging-telemetry.yml
@@ -13,8 +13,8 @@ jobs:
     environment: telemetry-staging
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - run: npm run check && npm test && npm run privacy-audit

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,10 +82,12 @@ jobs:
           npm pack --dry-run --ignore-scripts
           package_file="$(npm pack --silent --ignore-scripts)"
           test -n "$package_file"
-          trap 'rm -f -- "$package_file"' EXIT
-          tar -tzf "$package_file" | grep -q '^package/bin/job-application-agent.mjs$'
-          tar -tzf "$package_file" | grep -q '^package/job-application-agent/SKILL.md$'
-          if tar -tzf "$package_file" | grep -Eq 'applications\.ndjson|resume\.pdf|profile\.json|telemetry-worker/'; then
+          package_listing="$(mktemp)"
+          trap 'rm -f -- "$package_file" "$package_listing"' EXIT
+          tar -tzf "$package_file" > "$package_listing"
+          grep -q '^package/bin/job-application-agent.mjs$' "$package_listing"
+          grep -q '^package/job-application-agent/SKILL.md$' "$package_listing"
+          if grep -Eq 'applications\.ndjson|resume\.pdf|profile\.json|telemetry-worker/' "$package_listing"; then
             echo 'npm package contains private state or server-only code.' >&2
             exit 1
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,27 +9,50 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  classify:
+    name: classify
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
+    timeout-minutes: 5
+    outputs:
+      code_changed: ${{ steps.changes.outputs.code_changed }}
+      dependency_changed: ${{ steps.changes.outputs.dependency_changed }}
+      high_risk: ${{ steps.changes.outputs.high_risk }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: changes
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            BASE_SHA="$(git rev-parse HEAD^)"
+          fi
+          git diff --name-status -z "$BASE_SHA" HEAD | node scripts/ci/classify-paths.mjs
 
+  core:
+    name: core
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-
+          cache: npm
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
-
-      - name: Install skill validator dependency
-        run: python -m pip install --disable-pip-version-check PyYAML
-
+      - name: Install locked dependencies
+        run: |
+          npm ci
+          python -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r .github/requirements-ci.txt
       - name: Validate skill structure
         run: |
           python - <<'PY'
@@ -47,35 +70,115 @@ jobs:
           assert isinstance(data["description"], str) and data["description"].strip(), "Description is required"
           print("Skill is valid!")
           PY
-
       - name: Check JavaScript syntax
         run: npm run check
-
-      - name: Run client, privacy, and Worker tests
+      - name: Run client, privacy, Worker, and workflow contract tests
         run: npm test
-
       - name: Audit representative payloads for prohibited data
         run: npm run privacy-audit
-
       - name: Verify npm package contents and executable
+        shell: bash
         run: |
           npm pack --dry-run --ignore-scripts
-          package_file=$(npm pack --silent --ignore-scripts)
+          package_file="$(npm pack --silent --ignore-scripts)"
           test -n "$package_file"
+          trap 'rm -f -- "$package_file"' EXIT
           tar -tzf "$package_file" | grep -q '^package/bin/job-application-agent.mjs$'
           tar -tzf "$package_file" | grep -q '^package/job-application-agent/SKILL.md$'
           if tar -tzf "$package_file" | grep -Eq 'applications\.ndjson|resume\.pdf|profile\.json|telemetry-worker/'; then
             echo 'npm package contains private state or server-only code.' >&2
             exit 1
           fi
-          rm "$package_file"
-
       - name: Smoke-test installation from the packed npm artifact
         run: npm run smoke:package
-
       - name: Scan tracked files for common secret formats
+        shell: bash
         run: |
           if git grep -nEI '(-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----|gh[pousr]_[A-Za-z0-9]{30,}|sk_(live|test)_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16})' -- . ':!LICENSE'; then
             echo 'Potential committed secret detected.' >&2
             exit 1
           fi
+
+  dependency-review:
+    name: dependency-review
+    if: github.event_name == 'pull_request' && needs.classify.outputs.dependency_changed == 'true'
+    needs: classify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+
+  high-risk:
+    name: high-risk (${{ matrix.os }}, Node ${{ matrix.node }})
+    if: needs.classify.outputs.high_risk == 'true'
+    needs: classify
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [20, 24]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - run: npm test
+      - run: npm run privacy-audit
+      - run: npm run smoke:package
+      - run: npm run check:native-artifacts
+
+  codeql:
+    name: codeql
+    if: needs.classify.outputs.code_changed == 'true'
+    needs: classify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          languages: javascript-typescript
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+
+  quality-gate:
+    name: quality-gate
+    if: always()
+    needs: [classify, core, dependency-review, high-risk, codeql]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      CLASSIFY_RESULT: ${{ needs.classify.result }}
+      CORE_RESULT: ${{ needs.core.result }}
+      DEPENDENCY_RESULT: ${{ needs.dependency-review.result }}
+      HIGH_RISK_RESULT: ${{ needs.high-risk.result }}
+      CODEQL_RESULT: ${{ needs.codeql.result }}
+    steps:
+      - name: Enforce required results
+        shell: bash
+        run: |
+          test "$CLASSIFY_RESULT" = success
+          test "$CORE_RESULT" = success
+          for result in "$DEPENDENCY_RESULT" "$HIGH_RISK_RESULT" "$CODEQL_RESULT"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "Required job finished with: $result" >&2; exit 1 ;;
+            esac
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thanks for improving Job Application Agent. Changes should be focused, reproducible, and safe for people who keep private job-search data on their machines.
+
+## Before opening a pull request
+
+1. Start from the current `main` branch and keep one logical change per pull request.
+2. Keep non-test changes near 300 lines or fewer. Split larger work unless a maintainer agrees that the change is mechanically reviewable.
+3. Run:
+
+   ```sh
+   npm ci
+   npm run check
+   npm test
+   npm run privacy-audit
+   npm run smoke:package
+   npm run check:native-artifacts
+   ```
+
+4. Add a regression test for every bug fix. The test must fail without the fix and assert observable behavior rather than mocked call order.
+5. Complete the pull request template. Security or privacy vulnerabilities must use the private process in [`SECURITY.md`](SECURITY.md), not a public pull request.
+
+## High-risk changes
+
+Installer, persistence, local-state, release-workflow, package-metadata, and security-policy changes receive additional operating-system and Node.js compatibility checks. Their tests must cover:
+
+- failure after each filesystem or scheduler side effect;
+- rollback and the state reported after failure;
+- ownership boundaries for recursive deletion or replacement;
+- malformed, missing, symlinked, and non-regular filesystem entries where relevant;
+- concurrent access and stale ownership where relevant.
+
+Claims such as **atomic**, **safe**, **exact**, **verified**, or **never** need a direct test or a precise explanation of what remains outside the guarantee.
+
+## Review and merge
+
+All required checks and review conversations must be complete. New commits dismiss stale approvals. Do not ask a maintainer to bypass quality gates for an external contribution.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Updates are staged and validated before replacement. Private candidate state liv
 npm test
 ```
 
-GitHub Actions validates the skill and runs the same test suite on every pull request. To try the workflow without installing, paste [`SHARE_PROMPT.md`](SHARE_PROMPT.md) into a new agent chat.
+GitHub Actions validates the skill and runs the same test suite on every pull request. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full local verification and review contract. To try the workflow without installing, paste [`SHARE_PROMPT.md`](SHARE_PROMPT.md) into a new agent chat.
 
 ## ⚖️ Responsible use
 

--- a/installer/tests/installer.test.mjs
+++ b/installer/tests/installer.test.mjs
@@ -42,7 +42,9 @@ test('installs the packaged skill while preserving private state outside the ins
   assert.equal(result.installedVersion, '3.0.0');
   assert.equal(await readFile(path.join(f.agentHome, 'skills', 'job-application-agent', 'SKILL.md'), 'utf8'), '# Version one\n');
   assert.equal(await readFile(path.join(privateState, 'applications.ndjson'), 'utf8'), '{"private":true}\n');
-  assert.equal((await stat(path.join(f.agentHome, 'job-application-agent', CONFIG_FILENAME))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') {
+    assert.equal((await stat(path.join(f.agentHome, 'job-application-agent', CONFIG_FILENAME))).mode & 0o777, 0o600);
+  }
 });
 
 test('updates atomically and keeps the immediately previous version for rollback', async () => {

--- a/installer/tests/publish-workflow.test.mjs
+++ b/installer/tests/publish-workflow.test.mjs
@@ -4,11 +4,14 @@ import test from 'node:test';
 
 const workflowUrl = new URL('../../.github/workflows/publish-npm.yml', import.meta.url);
 
-test('npm publishing runs for main updates and skips versions already on the registry', async () => {
+test('npm publishing requires a published release and skips versions already on the registry', async () => {
   const workflow = await readFile(workflowUrl, 'utf8');
 
-  assert.match(workflow, /push:\s*\n\s+branches:\s*\[main\]/);
+  assert.match(workflow, /release:\s*\n\s+types:\s*\[published\]/);
+  assert.doesNotMatch(workflow, /push:\s*\n\s+branches:\s*\[main\]/);
   assert.match(workflow, /id-token:\s*write/);
+  assert.match(workflow, /github\.event\.release\.tag_name/);
+  assert.match(workflow, /v\$\(node -p/);
   assert.match(workflow, /npm view [^\n]+version/);
   assert.match(workflow, /publish_needed/);
   assert.match(workflow, /if: steps\.version-check\.outputs\.publish_needed == 'true'/);

--- a/installer/tests/quality-gates.test.mjs
+++ b/installer/tests/quality-gates.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import {
+  classifyChangedPaths,
+  parseNameStatusZ,
+} from '../../scripts/ci/classify-paths.mjs';
+
+test('classifies documentation-only changes as low risk', () => {
+  assert.deepEqual(classifyChangedPaths(['README.md', 'job-application-agent/references/RUNS.md']), {
+    codeChanged: false,
+    dependencyChanged: false,
+    highRisk: false,
+  });
+});
+
+test('classifies installer, state, workflow, package, and security changes as high risk', () => {
+  for (const changedPath of [
+    'installer/src/installer.mjs',
+    'job-application-agent/scripts/job-application.mjs',
+    '.github/workflows/validate.yml',
+    'package.json',
+    'package-lock.json',
+    'bin/job-application-agent.mjs',
+    'scripts/smoke-package.mjs',
+    'scripts/ci/classify-paths.mjs',
+    'SECURITY.md',
+  ]) {
+    assert.equal(classifyChangedPaths([changedPath]).highRisk, true, changedPath);
+  }
+});
+
+test('tracks dependency and JavaScript changes independently', () => {
+  assert.deepEqual(classifyChangedPaths(['package-lock.json']), {
+    codeChanged: false,
+    dependencyChanged: true,
+    highRisk: true,
+  });
+  assert.deepEqual(classifyChangedPaths(['telemetry-worker/src/worker.mjs']), {
+    codeChanged: true,
+    dependencyChanged: false,
+    highRisk: false,
+  });
+});
+
+test('parses both sides of renamed and copied paths from git name-status -z output', () => {
+  const input = Buffer.from([
+    'M', 'README.md',
+    'R100', 'installer/src/old.mjs', 'docs/installer-example.mjs',
+    'C075', 'package.json', 'examples/package.json',
+    'A', 'telemetry-worker/src/new-worker.mjs',
+    '',
+  ].join('\0'));
+
+  assert.deepEqual(parseNameStatusZ(input), [
+    'README.md',
+    'installer/src/old.mjs',
+    'docs/installer-example.mjs',
+    'package.json',
+    'examples/package.json',
+    'telemetry-worker/src/new-worker.mjs',
+  ]);
+});
+
+test('all workflows use immutable action SHAs, explicit permissions, and safe pull request triggers', async () => {
+  const workflowDirectory = new URL('../../.github/workflows/', import.meta.url);
+  const workflows = (await readdir(workflowDirectory)).filter(name => /\.ya?ml$/.test(name));
+  assert.ok(workflows.length > 0, 'at least one workflow must be checked');
+
+  for (const workflow of workflows) {
+    const source = await readFile(new URL(workflow, workflowDirectory), 'utf8');
+    assert.match(source, /^permissions:/m, `${workflow} must declare permissions`);
+    assert.doesNotMatch(source, /pull_request_target\s*:/, `${workflow} must not run privileged code from pull_request_target`);
+    for (const match of source.matchAll(/^\s*-\s+uses:\s+([^\s#]+)(?:\s+#.*)?$/gm)) {
+      const reference = match[1];
+      if (reference.startsWith('./')) continue;
+      assert.match(reference, /^[^@\s]+@[0-9a-f]{40}$/, `${workflow} must pin ${reference} to a full commit SHA`);
+    }
+  }
+});
+
+test('validation exposes a stable quality gate and a six-combination high-risk matrix', async () => {
+  const workflow = await readFile(new URL('../../.github/workflows/validate.yml', import.meta.url), 'utf8');
+  assert.match(workflow, /^\s{2}quality-gate:/m);
+  assert.match(workflow, /name:\s*quality-gate/);
+  assert.match(workflow, /matrix:/);
+  assert.match(workflow, /os:\s*\[ubuntu-latest, macos-latest, windows-latest\]/);
+  assert.match(workflow, /node:\s*\[20, 24\]/);
+  assert.match(workflow, /classify-paths\.mjs/);
+  assert.match(workflow, /check:native-artifacts/);
+});

--- a/installer/tests/quality-gates.test.mjs
+++ b/installer/tests/quality-gates.test.mjs
@@ -94,8 +94,11 @@ test('validation exposes a stable quality gate and a six-combination high-risk m
 test('validation commands are portable across Windows and pipefail shells', async () => {
   const packageJson = JSON.parse(await readFile(new URL('../../package.json', import.meta.url), 'utf8'));
   const workflow = await readFile(new URL('../../.github/workflows/validate.yml', import.meta.url), 'utf8');
+  const smokePackage = await readFile(new URL('../../scripts/smoke-package.mjs', import.meta.url), 'utf8');
 
   assert.equal(packageJson.scripts.test, 'node --test', 'the shell must not be responsible for expanding test globs');
   assert.match(workflow, /tar -tzf "\$package_file" > "\$package_listing"/);
   assert.doesNotMatch(workflow, /tar -tzf "\$package_file" \| grep/, 'tar must not receive SIGPIPE under pipefail');
+  assert.match(smokePackage, /process\.env\.npm_execpath/);
+  assert.doesNotMatch(smokePackage, /execFileAsync\(['"]npm['"]/, 'the smoke check must not assume a Unix npm executable');
 });

--- a/installer/tests/quality-gates.test.mjs
+++ b/installer/tests/quality-gates.test.mjs
@@ -90,3 +90,12 @@ test('validation exposes a stable quality gate and a six-combination high-risk m
   assert.match(workflow, /classify-paths\.mjs/);
   assert.match(workflow, /check:native-artifacts/);
 });
+
+test('validation commands are portable across Windows and pipefail shells', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('../../package.json', import.meta.url), 'utf8'));
+  const workflow = await readFile(new URL('../../.github/workflows/validate.yml', import.meta.url), 'utf8');
+
+  assert.equal(packageJson.scripts.test, 'node --test', 'the shell must not be responsible for expanding test globs');
+  assert.match(workflow, /tar -tzf "\$package_file" > "\$package_listing"/);
+  assert.doesNotMatch(workflow, /tar -tzf "\$package_file" \| grep/, 'tar must not receive SIGPIPE under pipefail');
+});

--- a/installer/tests/runner.test.mjs
+++ b/installer/tests/runner.test.mjs
@@ -23,10 +23,10 @@ test('creates a durable Unix launcher that always executes the latest npm packag
   assert.doesNotMatch(script, /CODEX_HOME=/);
   assert.match(script, /job-application-agent@latest/);
   assert.match(script, /auto-update/);
-  assert.equal((await stat(result.path)).mode & 0o777, 0o700);
+  if (process.platform !== 'win32') assert.equal((await stat(result.path)).mode & 0o777, 0o700);
 });
 
-test('Unix launcher exposes its Node directory to npm child processes under a minimal scheduler PATH', async () => {
+test('Unix launcher exposes its Node directory to npm child processes under a minimal scheduler PATH', { skip: process.platform === 'win32' }, async () => {
   const agentHome = await mkdtemp(path.join(os.tmpdir(), 'job-agent-runner-path-'));
   const emptyPath = await mkdtemp(path.join(os.tmpdir(), 'job-agent-empty-path-'));
   const fakeNpmCli = path.join(agentHome, 'fake-npm-cli.mjs');

--- a/installer/tests/scheduler.test.mjs
+++ b/installer/tests/scheduler.test.mjs
@@ -16,7 +16,7 @@ test('macOS scheduler runs at login and hourly using the latest npm package', as
   assert.match(plist, /<integer>3600<\/integer>/);
   assert.match(plist, /auto-update/);
   assert.match(plist, new RegExp(SCHEDULER_LABEL));
-  assert.match(plist, /\.agents\/logs/);
+  assert.match(plist.replaceAll('\\', '/'), /\.agents\/logs/);
   assert.doesNotMatch(plist, /codex/);
   assert.equal(result.path, path.join(homeDir, 'Library', 'LaunchAgents', `${SCHEDULER_LABEL}.plist`));
   assert.deepEqual(calls.at(-1), ['launchctl', ['bootstrap', 'gui/501', result.path]]);

--- a/job-application-agent/scripts/job-application.mjs
+++ b/job-application-agent/scripts/job-application.mjs
@@ -4,6 +4,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, chmod, mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { platform } from 'node:os';
 import { basename, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { createSecretStore, migrateLegacyStateDir, resolveStateDir } from './secret-store.mjs';
 import { TelemetryClient } from './telemetry-client.mjs';
@@ -1169,7 +1170,7 @@ async function main(args) {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main(process.argv.slice(2)).catch((error) => {
     process.stderr.write(`Error: ${error.message}\n`);
     process.exitCode = 1;

--- a/job-application-agent/tests/job-application.test.mjs
+++ b/job-application-agent/tests/job-application.test.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { buildReview, commandCategory, durationBucket, migrateProfile, profileStatus, scoreJob, telemetryJobAssessed, validateLedgerEntry, validateProfile, validateSubmissionTelemetry } from '../scripts/job-application.mjs';
 
@@ -68,7 +69,7 @@ test('validates a candidate-defined target profile', () => {
 test('returns the canonical resume path for direct browser uploads', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-resume-path-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   const resume = join(directory, 'resume.pdf');
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
   await writeFile(resume, '%PDF-1.7\ncanonical resume fixture');
@@ -238,7 +239,7 @@ test('requires review at each ten confirmed submissions', () => {
 test('deduplicates ledger entries by normalized URL', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   const entry = {
     id: 'example-role-1', company: 'Example', role: 'Senior Product Engineer', url: 'https://jobs.example.com/123?utm_source=x', source: 'company', score: 80, status: 'submitted', submittedAt: '2026-01-15T10:00:00Z', approval: 'STANDING AUTHORIZATION', answers: {},
     telemetry: { durationBucket: '5-15m', fieldsFilled: 14, shortAnswerCount: 2, resumeUploaded: true },
@@ -253,13 +254,13 @@ test('deduplicates ledger entries by normalized URL', async (t) => {
   }));
   assert.equal(relabelled.duplicate, true);
   assert.equal((await readFile(join(directory, 'applications.ndjson'), 'utf8')).includes('telemetry'), false);
-  assert.equal((await stat(join(directory, 'applications.ndjson'))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'applications.ndjson'))).mode & 0o777, 0o600);
 });
 
 test('warns on same-company role matches and serializes concurrent duplicate submissions', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-dedup-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
   const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
   const base = {
@@ -283,7 +284,7 @@ test('warns on same-company role matches and serializes concurrent duplicate sub
 test('records structured outcomes idempotently without duplicate rows', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-outcomes-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
   await writeFile(join(directory, 'applications.ndjson'), `${JSON.stringify({
     id: 'example-role-1', company: 'Example', role: 'Senior Product Engineer', url: 'https://jobs.example.com/123', source: 'company', score: 88,
@@ -306,7 +307,7 @@ test('records structured outcomes idempotently without duplicate rows', async (t
 test('records bounded interview quality and failure-point enrichment idempotently', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-interview-quality-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
   await writeFile(join(directory, 'applications.ndjson'), `${JSON.stringify({
     id: 'example-role-1', company: 'Example', role: 'Staff Product Engineer', url: 'https://jobs.example.com/123', source: 'company', score: 91,
@@ -391,7 +392,7 @@ test('preserves interview quality after a later final outcome', () => {
 test('acknowledges a generated review only through the explicit CLI command', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-review-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
   const entries = Array.from({ length: 10 }, (_, index) => ({
     id: `role-${index}`, company: `Company ${index}`, role: 'Senior Engineer', url: `https://jobs.example.com/${index}`,
@@ -436,11 +437,11 @@ test('builds a structured assessment event without description or candidate prof
 test('telemetry CLI controls are private and reset removes anonymous credentials', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'public-job-agent-telemetry-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+  const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory, JOB_APPLICATION_AGENT_TELEMETRY_URL: 'https://relay.invalid' };
   const disabled = JSON.parse(execFileSync(process.execPath, [script, 'telemetry', 'disable'], { env, encoding: 'utf8' }));
   assert.equal(disabled.enabled, false);
   const reset = JSON.parse(execFileSync(process.execPath, [script, 'telemetry', 'reset'], { env, encoding: 'utf8' }));
   assert.equal(reset.hasInstallationId, false);
-  assert.equal((await stat(join(directory, 'telemetry.json'))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'telemetry.json'))).mode & 0o777, 0o600);
 });

--- a/job-application-agent/tests/telemetry-client.test.mjs
+++ b/job-application-agent/tests/telemetry-client.test.mjs
@@ -30,7 +30,7 @@ test('new installations disclose and send the first event immediately', async (t
   assert.equal(result.sent, true);
   assert.equal(relay.requests.length, 3);
   assert.equal((await client.beginCommand('search')).installationEventPending, false);
-  assert.equal((await stat(join(directory, 'telemetry.json'))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'telemetry.json'))).mode & 0o777, 0o600);
 });
 
 test('existing installations receive a one-command grace period without backfill', async (t) => {

--- a/job-application-agent/tests/workflow-state.test.mjs
+++ b/job-application-agent/tests/workflow-state.test.mjs
@@ -4,8 +4,9 @@ import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
-const script = new URL('../scripts/job-application.mjs', import.meta.url).pathname;
+const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
 
 async function fixture(t, label) {
   const directory = await mkdtemp(join(tmpdir(), `public-job-agent-${label}-`));
@@ -69,7 +70,7 @@ test('persists a scoped autonomy grant and revokes future routine transmissions'
   const status = cli(env, ['autonomy', 'status']);
   assert.equal(status.enabled, true);
   assert.equal(status.mode, 'routine-auto');
-  assert.equal((await stat(join(directory, 'autonomy.json'))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'autonomy.json'))).mode & 0o777, 0o600);
 
   const preview = cli(env, ['autonomy', 'preview']);
   assert.equal(preview.maySubmitRoutineApplications, true);
@@ -112,7 +113,7 @@ test('counts only unique confirmed ledger submissions for an explicit round', as
   const roundEvents = (await readFile(join(directory, 'rounds.ndjson'), 'utf8')).trim().split('\n').map(JSON.parse);
   assert.equal(roundEvents.filter((event) => event.type === 'submission-confirmed').length, 30);
   assert.equal(roundEvents.length, 32);
-  assert.equal((await stat(join(directory, 'rounds.ndjson'))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'rounds.ndjson'))).mode & 0o777, 0o600);
 });
 
 test('does not complete a round from blocked or partially filled applications', async (t) => {
@@ -156,7 +157,7 @@ test('replays and prioritizes an owner-only attention queue', async (t) => {
 
   const before = cli(env, ['attention', 'list']);
   assert.deepEqual(before.items.map((item) => item.id), [captcha.id, judgment.id]);
-  assert.equal((await stat(join(directory, 'attention.ndjson'))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'attention.ndjson'))).mode & 0o777, 0o600);
 
   cli(env, ['attention', 'resolve', '--stdin'], { id: captcha.id });
   const after = cli(env, ['attention', 'list']);
@@ -185,7 +186,7 @@ test('qualifies only reproducible general-purpose friction for a public PR', asy
   const listed = cli(env, ['friction', 'list']);
   assert.equal(listed.items.length, 2);
   assert.deepEqual(listed.prCandidates.map((item) => item.id), [general.id]);
-  assert.equal((await stat(join(directory, 'friction.ndjson'))).mode & 0o777, 0o600);
+  if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'friction.ndjson'))).mode & 0o777, 0o600);
   assert.equal((await readFile(join(directory, 'friction.ndjson'), 'utf8')).includes('candidate@example.com'), false);
 });
 

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
   },
   "scripts": {
     "test": "node --test job-application-agent/tests/*.test.mjs telemetry-worker/tests/*.test.mjs installer/tests/*.test.mjs",
+    "check:native-artifacts": "node scripts/ci/validate-native-artifacts.mjs",
     "privacy-audit": "node --test job-application-agent/tests/privacy-audit.test.mjs",
     "smoke:package": "node scripts/smoke-package.mjs",
-    "check": "node --check job-application-agent/scripts/job-application.mjs && node --check job-application-agent/scripts/secret-store.mjs && node --check job-application-agent/scripts/telemetry-client.mjs && node --check job-application-agent/scripts/telemetry-schema.mjs && node --check telemetry-worker/src/worker.mjs && node --check telemetry-worker/src/public-stats.mjs && node --check telemetry-worker/public/dashboard.js && node --check installer/src/cli.mjs && node --check installer/src/installer.mjs && node --check installer/src/runner.mjs && node --check installer/src/scheduler.mjs && node --check bin/job-application-agent.mjs",
+    "check": "node --check job-application-agent/scripts/job-application.mjs && node --check job-application-agent/scripts/secret-store.mjs && node --check job-application-agent/scripts/telemetry-client.mjs && node --check job-application-agent/scripts/telemetry-schema.mjs && node --check telemetry-worker/src/worker.mjs && node --check telemetry-worker/src/public-stats.mjs && node --check telemetry-worker/public/dashboard.js && node --check installer/src/cli.mjs && node --check installer/src/installer.mjs && node --check installer/src/runner.mjs && node --check installer/src/scheduler.mjs && node --check scripts/ci/classify-paths.mjs && node --check scripts/ci/validate-native-artifacts.mjs && node --check bin/job-application-agent.mjs",
     "prepack": "npm run check && npm test && npm run privacy-audit"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "provenance": true
   },
   "scripts": {
-    "test": "node --test job-application-agent/tests/*.test.mjs telemetry-worker/tests/*.test.mjs installer/tests/*.test.mjs",
+    "test": "node --test",
     "check:native-artifacts": "node scripts/ci/validate-native-artifacts.mjs",
     "privacy-audit": "node --test job-application-agent/tests/privacy-audit.test.mjs",
     "smoke:package": "node scripts/smoke-package.mjs",

--- a/scripts/ci/classify-paths.mjs
+++ b/scripts/ci/classify-paths.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const HIGH_RISK_PATHS = [
+  /^\.github\//,
+  /^installer\//,
+  /^job-application-agent\/scripts\//,
+  /^bin\//,
+  /^scripts\/ci\//,
+  /^scripts\/smoke-package\.mjs$/,
+  /^package(?:-lock)?\.json$/,
+  /^SECURITY\.md$/,
+];
+
+const CODE_PATH = /\.(?:cjs|js|mjs|ts|tsx)$/i;
+const DEPENDENCY_PATHS = new Set([
+  '.github/requirements-ci.txt',
+  'package-lock.json',
+  'package.json',
+]);
+
+export function parseNameStatusZ(input) {
+  const tokens = Buffer.isBuffer(input) ? input.toString('utf8').split('\0') : String(input).split('\0');
+  if (tokens.at(-1) === '') tokens.pop();
+  const paths = [];
+
+  for (let index = 0; index < tokens.length;) {
+    const status = tokens[index++];
+    const firstPath = tokens[index++];
+    if (!status || !firstPath) throw new Error('Invalid git --name-status -z input.');
+    paths.push(firstPath);
+    if (/^[CR]/.test(status)) {
+      const secondPath = tokens[index++];
+      if (!secondPath) throw new Error(`Git status ${status} is missing its destination path.`);
+      paths.push(secondPath);
+    }
+  }
+
+  return paths;
+}
+
+export function classifyChangedPaths(paths) {
+  const normalized = [...new Set(paths.map(value => String(value).replaceAll('\\', '/')))];
+  return {
+    codeChanged: normalized.some(changedPath => CODE_PATH.test(changedPath)),
+    dependencyChanged: normalized.some(changedPath => DEPENDENCY_PATHS.has(changedPath)),
+    highRisk: normalized.some(changedPath => HIGH_RISK_PATHS.some(pattern => pattern.test(changedPath))),
+  };
+}
+
+function main() {
+  const paths = parseNameStatusZ(readFileSync(0));
+  const classification = classifyChangedPaths(paths);
+  const outputs = [
+    `code_changed=${classification.codeChanged}`,
+    `dependency_changed=${classification.dependencyChanged}`,
+    `high_risk=${classification.highRisk}`,
+  ];
+  if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${outputs.join('\n')}\n`);
+  process.stdout.write(`${JSON.stringify({ paths, ...classification })}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/ci/validate-native-artifacts.mjs
+++ b/scripts/ci/validate-native-artifacts.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -50,8 +50,15 @@ async function validate() {
         command: process.execPath,
         runCommand,
       });
-      const parser = '$errors = $null; [System.Management.Automation.Language.Parser]::ParseFile($args[0], [ref]$null, [ref]$errors) | Out-Null; if ($errors.Count) { $errors | ForEach-Object { Write-Error $_ }; exit 1 }';
-      await execFileAsync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', parser, result.scriptPath]);
+      const source = await readFile(result.scriptPath, 'utf8');
+      const escapedCommand = process.execPath.replaceAll("'", "''");
+      if (!source.includes(`-Execute '${escapedCommand}' -Argument 'auto-update'`)) {
+        throw new Error('PowerShell scheduler does not preserve the executable and argument boundary.');
+      }
+      const parser = '$tokens = $null; $errors = $null; [System.Management.Automation.Language.Parser]::ParseFile($env:JOB_AGENT_POWERSHELL_ARTIFACT, [ref]$tokens, [ref]$errors) | Out-Null; if ($errors.Count) { $errors | ForEach-Object { Write-Error $_ }; exit 1 }';
+      await execFileAsync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', parser], {
+        env: { ...process.env, JOB_AGENT_POWERSHELL_ARTIFACT: result.scriptPath },
+      });
       return;
     }
 

--- a/scripts/ci/validate-native-artifacts.mjs
+++ b/scripts/ci/validate-native-artifacts.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { installScheduler } from '../../installer/src/scheduler.mjs';
+
+const execFileAsync = promisify(execFile);
+
+async function validate() {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'job-agent-native-artifacts-'));
+  const homeDir = path.join(root, 'home');
+  const agentHome = path.join(homeDir, '.agents');
+  const runCommand = async () => {};
+
+  try {
+    if (process.platform === 'darwin') {
+      const result = await installScheduler({
+        platform: 'darwin',
+        homeDir,
+        agentHome,
+        command: process.execPath,
+        userId: process.getuid(),
+        runCommand,
+      });
+      await execFileAsync('plutil', ['-lint', result.path]);
+      return;
+    }
+
+    if (process.platform === 'linux') {
+      const result = await installScheduler({
+        platform: 'linux',
+        homeDir,
+        agentHome,
+        command: process.execPath,
+        runCommand,
+      });
+      await execFileAsync('systemd-analyze', ['verify', result.servicePath, result.timerPath]);
+      return;
+    }
+
+    if (process.platform === 'win32') {
+      const result = await installScheduler({
+        platform: 'win32',
+        homeDir,
+        agentHome,
+        command: process.execPath,
+        runCommand,
+      });
+      const parser = '$errors = $null; [System.Management.Automation.Language.Parser]::ParseFile($args[0], [ref]$null, [ref]$errors) | Out-Null; if ($errors.Count) { $errors | ForEach-Object { Write-Error $_ }; exit 1 }';
+      await execFileAsync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', parser, result.scriptPath]);
+      return;
+    }
+
+    throw new Error(`Unsupported CI platform: ${process.platform}`);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+validate().catch(error => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -9,12 +9,14 @@ const root = process.cwd();
 const packageManifest = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
 const temp = await mkdtemp(path.join(os.tmpdir(), 'job-application-agent-package-'));
 const agentHome = path.join(temp, '.agents');
+const npmCliPath = process.env.npm_execpath;
 let tarball;
 
 try {
-  const packed = await execFileAsync('npm', ['pack', '--silent', '--ignore-scripts'], { cwd: root });
+  if (!npmCliPath) throw new Error('npm_execpath is required; run this check through npm run smoke:package.');
+  const packed = await execFileAsync(process.execPath, [npmCliPath, 'pack', '--silent', '--ignore-scripts'], { cwd: root });
   tarball = path.join(root, packed.stdout.trim().split(/\r?\n/).at(-1));
-  await execFileAsync('npm', [
+  await execFileAsync(process.execPath, [npmCliPath,
     'exec', '--yes', `--package=file:${tarball}`, '--', 'job-application-agent', 'install',
   ], {
     cwd: temp,
@@ -30,7 +32,7 @@ try {
   const config = JSON.parse(await readFile(path.join(agentHome, 'job-application-agent', 'install.json'), 'utf8'));
   if (!skill.includes('# Job Application Agent')) throw new Error('Packed skill did not install correctly.');
   if (config.installedVersion !== packageManifest.version || config.automaticUpdates !== true) throw new Error('Packed installer state is incorrect.');
-  if (((await stat(path.join(agentHome, 'job-application-agent', 'install.json'))).mode & 0o777) !== 0o600) throw new Error('Install configuration permissions are not private.');
+  if (process.platform !== 'win32' && ((await stat(path.join(agentHome, 'job-application-agent', 'install.json'))).mode & 0o777) !== 0o600) throw new Error('Install configuration permissions are not private.');
   process.stdout.write('Packed npm installation smoke test passed.\n');
 } finally {
   if (tarball) await rm(tarball, { force: true });


### PR DESCRIPTION
## Summary

Introduces enforceable contribution contracts, risk-based cross-platform CI, immutable workflow dependencies, CodeQL/dependency review, native scheduler artifact validation, and release-only npm publishing.

## Risk and invariants

- [ ] This change does not affect security, privacy, persistence, concurrency, installation, release, or destructive filesystem behavior.
- [x] If it does, I described the invariant, failure behavior, and rollback behavior below.
- [x] Every use of “atomic,” “safe,” “exact,” “verified,” or “never” is backed by a direct test or explicitly bounded.

The existing `main` settings are intentionally unchanged until this PR's new `quality-gate` succeeds. Publishing remains OIDC/provenance-based, but only a version-matching published GitHub release can trigger it. A failed or skipped conditional CI job cannot accidentally make the aggregate gate pass.

## Verification

- [x] I added a regression test for each bug fix and confirmed it fails without the fix.
- [x] `npm run check`
- [x] `npm test` — 95/95 on Node 24 and Node 20
- [x] `npm run privacy-audit`
- [x] `npm run smoke:package`
- [x] `npm run check:native-artifacts`

Also parsed every workflow as YAML and exercised rename/copy path classification fixtures. GitHub-hosted CI will validate the six OS/runtime combinations.

## Scope

- [x] The pull request contains one logical change.
- [x] Non-test changes are roughly 300 lines or fewer, or I explained why splitting would reduce safety or reviewability.

This bootstrap is larger because the stable aggregate check, workflow contracts, action pins, release trigger, classifier, and contributor policy must land together before repository enforcement can safely require them.
