### PR TITLE
fix: harden release and contribution gates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,8 @@
 /bin/ @vaibhavarora14
 /scripts/ci/ @vaibhavarora14
 /scripts/smoke-package.mjs @vaibhavarora14
+/telemetry-worker/migrations/ @vaibhavarora14
+/telemetry-worker/wrangler.jsonc @vaibhavarora14
 /package.json @vaibhavarora14
 /package-lock.json @vaibhavarora14
 /SECURITY.md @vaibhavarora14

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,21 +10,31 @@ permissions:
 
 jobs:
   publish:
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm-production
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - run: npm ci
+      - name: Verify release commit belongs to main
+        shell: bash
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
       - name: Verify release tag matches package version
         shell: bash
-        run: test "v$(node -p "require('./package.json').version")" = "${{ github.event.release.tag_name }}"
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: test "v$(node -p "require('./package.json').version")" = "$RELEASE_TAG"
       - run: npm run check && npm test && npm run privacy-audit && npm run smoke:package && npm run check:native-artifacts
       - name: Check whether this version is already published
         id: version-check

--- a/installer/tests/publish-workflow.test.mjs
+++ b/installer/tests/publish-workflow.test.mjs
@@ -10,7 +10,13 @@ test('npm publishing requires a published release and skips versions already on 
   assert.match(workflow, /release:\s*\n\s+types:\s*\[published\]/);
   assert.doesNotMatch(workflow, /push:\s*\n\s+branches:\s*\[main\]/);
   assert.match(workflow, /id-token:\s*write/);
-  assert.match(workflow, /github\.event\.release\.tag_name/);
+  assert.match(workflow, /if:\s*github\.event\.release\.prerelease == false/);
+  assert.match(workflow, /fetch-depth:\s*0/);
+  assert.match(workflow, /git fetch --no-tags origin main:refs\/remotes\/origin\/main/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$GITHUB_SHA" (?:refs\/remotes\/)?origin\/main/);
+  assert.match(workflow, /RELEASE_TAG:\s*\$\{\{ github\.event\.release\.tag_name \}\}/);
+  assert.equal(workflow.match(/github\.event\.release\.tag_name/g)?.length, 1, 'release tag expressions belong only in env');
+  assert.match(workflow, /"\$RELEASE_TAG"/);
   assert.match(workflow, /v\$\(node -p/);
   assert.match(workflow, /npm view [^\n]+version/);
   assert.match(workflow, /publish_needed/);

--- a/installer/tests/quality-gates.test.mjs
+++ b/installer/tests/quality-gates.test.mjs
@@ -7,6 +7,12 @@ import {
   parseNameStatusZ,
 } from '../../scripts/ci/classify-paths.mjs';
 
+const WORKFLOW_USES_PATTERN = /^\s*(?:-\s+)?uses:\s+([^\s#]+)(?:\s+#.*)?$/gm;
+
+function workflowUses(source) {
+  return [...source.matchAll(WORKFLOW_USES_PATTERN)].map(match => match[1]);
+}
+
 test('classifies documentation-only changes as low risk', () => {
   assert.deepEqual(classifyChangedPaths(['README.md', 'job-application-agent/references/RUNS.md']), {
     codeChanged: false,
@@ -25,6 +31,8 @@ test('classifies installer, state, workflow, package, and security changes as hi
     'bin/job-application-agent.mjs',
     'scripts/smoke-package.mjs',
     'scripts/ci/classify-paths.mjs',
+    'telemetry-worker/migrations/0002_add_index.sql',
+    'telemetry-worker/wrangler.jsonc',
     'SECURITY.md',
   ]) {
     assert.equal(classifyChangedPaths([changedPath]).highRisk, true, changedPath);
@@ -72,12 +80,33 @@ test('all workflows use immutable action SHAs, explicit permissions, and safe pu
     const source = await readFile(new URL(workflow, workflowDirectory), 'utf8');
     assert.match(source, /^permissions:/m, `${workflow} must declare permissions`);
     assert.doesNotMatch(source, /pull_request_target\s*:/, `${workflow} must not run privileged code from pull_request_target`);
-    for (const match of source.matchAll(/^\s*-\s+uses:\s+([^\s#]+)(?:\s+#.*)?$/gm)) {
-      const reference = match[1];
+    for (const reference of workflowUses(source)) {
       if (reference.startsWith('./')) continue;
       assert.match(reference, /^[^@\s]+@[0-9a-f]{40}$/, `${workflow} must pin ${reference} to a full commit SHA`);
     }
   }
+});
+
+test('workflow pinning scans both step actions and job-level reusable workflows', () => {
+  const workflow = `jobs:
+  reusable:
+    uses: owner/automation/.github/workflows/check.yml@v1
+  steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789012345678901234567890123456789
+`;
+
+  assert.deepEqual(workflowUses(workflow), [
+    'owner/automation/.github/workflows/check.yml@v1',
+    'actions/checkout@0123456789012345678901234567890123456789',
+  ]);
+});
+
+test('telemetry persistence and deployment paths require code-owner review', async () => {
+  const codeowners = await readFile(new URL('../../.github/CODEOWNERS', import.meta.url), 'utf8');
+  assert.match(codeowners, /^\/telemetry-worker\/migrations\/\s+@vaibhavarora14$/m);
+  assert.match(codeowners, /^\/telemetry-worker\/wrangler\.jsonc\s+@vaibhavarora14$/m);
 });
 
 test('validation exposes a stable quality gate and a six-combination high-risk matrix', async () => {

--- a/scripts/ci/classify-paths.mjs
+++ b/scripts/ci/classify-paths.mjs
@@ -10,6 +10,8 @@ const HIGH_RISK_PATHS = [
   /^bin\//,
   /^scripts\/ci\//,
   /^scripts\/smoke-package\.mjs$/,
+  /^telemetry-worker\/migrations\//,
+  /^telemetry-worker\/wrangler\.jsonc$/,
   /^package(?:-lock)?\.json$/,
   /^SECURITY\.md$/,
 ];


### PR DESCRIPTION
## Summary

- keep release tag data out of shell source and require the tagged commit to be contained in `main`
- prevent prerelease GitHub releases from publishing to npm
- classify telemetry migrations and deployment configuration as high risk and require code-owner review
- enforce immutable SHAs for both step actions and job-level reusable workflows
- add regression contracts for every corrected review finding

## Review feedback addressed

Follow-up to the six unresolved findings on #16.

## Verification

- `npm run check`
- `npm test` (98 tests)
- `npx --yes --package=node@20 node --test` (98 tests)
- `npm run privacy-audit`
- `npm run smoke:package`
- `npm run check:native-artifacts`
- parsed every workflow with Ruby YAML

The original review threads remain open so reviewers can verify these changes before resolving them.
