### PR TITLE
fix: close release workflow trust gaps

### DIFF
--- a/.github/workflows/deploy-telemetry.yml
+++ b/.github/workflows/deploy-telemetry.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
+      - run: npm ci
       - run: npm run check && npm test && npm run privacy-audit
       - name: Apply aggregate database migrations
         run: npx --yes wrangler@4.122.0 d1 migrations apply job-application-agent-public-stats --remote --config telemetry-worker/wrangler.jsonc

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,17 +19,17 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+      - name: Verify release commit belongs to main
+        shell: bash
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - run: npm ci
-      - name: Verify release commit belongs to main
-        shell: bash
-        run: |
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
       - name: Verify release tag matches package version
         shell: bash
         env:

--- a/.github/workflows/staging-telemetry.yml
+++ b/.github/workflows/staging-telemetry.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
+      - run: npm ci
       - run: npm run check && npm test && npm run privacy-audit
       - name: Apply aggregate database migrations
         run: npx --yes wrangler@4.122.0 d1 migrations apply job-application-agent-public-stats-staging --remote --config telemetry-worker/wrangler.jsonc --env staging

--- a/installer/tests/publish-workflow.test.mjs
+++ b/installer/tests/publish-workflow.test.mjs
@@ -14,6 +14,11 @@ test('npm publishing requires a published release and skips versions already on 
   assert.match(workflow, /fetch-depth:\s*0/);
   assert.match(workflow, /git fetch --no-tags origin main:refs\/remotes\/origin\/main/);
   assert.match(workflow, /git merge-base --is-ancestor "\$GITHUB_SHA" (?:refs\/remotes\/)?origin\/main/);
+  const checkoutIndex = workflow.indexOf('uses: actions/checkout@');
+  const ancestryGuardIndex = workflow.indexOf('name: Verify release commit belongs to main');
+  const setupNodeIndex = workflow.indexOf('uses: actions/setup-node@');
+  assert.ok(checkoutIndex < ancestryGuardIndex, 'the ancestry guard must run after checkout');
+  assert.ok(ancestryGuardIndex < setupNodeIndex, 'the ancestry guard must run before setup and dependency installation');
   assert.match(workflow, /RELEASE_TAG:\s*\$\{\{ github\.event\.release\.tag_name \}\}/);
   assert.equal(workflow.match(/github\.event\.release\.tag_name/g)?.length, 1, 'release tag expressions belong only in env');
   assert.match(workflow, /"\$RELEASE_TAG"/);

--- a/installer/tests/quality-gates.test.mjs
+++ b/installer/tests/quality-gates.test.mjs
@@ -123,6 +123,28 @@ test('workflow pinning scans both step actions and job-level reusable workflows'
   ]);
 });
 
+test('workflows install lockfile dependencies before running repository tests', async () => {
+  const workflowDirectory = new URL('../../.github/workflows/', import.meta.url);
+  const workflows = (await readdir(workflowDirectory)).filter(name => /\.ya?ml$/.test(name));
+
+  for (const workflow of workflows) {
+    const source = await readFile(new URL(workflow, workflowDirectory), 'utf8');
+    const document = parse(source);
+    for (const [jobName, job] of Object.entries(document?.jobs ?? {})) {
+      const commands = (job?.steps ?? [])
+        .map(step => step?.run)
+        .filter(command => typeof command === 'string');
+      const testIndex = commands.findIndex(command => /\bnpm test\b/.test(command));
+      if (testIndex === -1) continue;
+      const installIndex = commands.findIndex(command => /\bnpm ci\b/.test(command));
+      assert.ok(
+        installIndex !== -1 && installIndex < testIndex,
+        `${workflow}:${jobName} must run npm ci before npm test`,
+      );
+    }
+  }
+});
+
 test('telemetry persistence and deployment paths require code-owner review', async () => {
   const codeowners = await readFile(new URL('../../.github/CODEOWNERS', import.meta.url), 'utf8');
   assert.match(codeowners, /^\/telemetry-worker\/migrations\/\s+@vaibhavarora14$/m);

--- a/installer/tests/quality-gates.test.mjs
+++ b/installer/tests/quality-gates.test.mjs
@@ -1,16 +1,28 @@
 import assert from 'node:assert/strict';
 import { readdir, readFile } from 'node:fs/promises';
 import test from 'node:test';
+import { parse } from 'yaml';
 
 import {
   classifyChangedPaths,
   parseNameStatusZ,
 } from '../../scripts/ci/classify-paths.mjs';
 
-const WORKFLOW_USES_PATTERN = /^\s*(?:-\s+)?uses:\s+([^\s#]+)(?:\s+#.*)?$/gm;
-
 function workflowUses(source) {
-  return [...source.matchAll(WORKFLOW_USES_PATTERN)].map(match => match[1]);
+  const workflow = parse(source);
+  const references = [];
+
+  for (const job of Object.values(workflow?.jobs ?? {})) {
+    if (!job || typeof job !== 'object' || Array.isArray(job)) continue;
+    if (typeof job.uses === 'string') references.push(job.uses);
+    for (const step of job.steps ?? []) {
+      if (step && typeof step === 'object' && typeof step.uses === 'string') {
+        references.push(step.uses);
+      }
+    }
+  }
+
+  return references;
 }
 
 test('classifies documentation-only changes as low risk', () => {
@@ -91,7 +103,12 @@ test('workflow pinning scans both step actions and job-level reusable workflows'
   const workflow = `jobs:
   reusable:
     uses: owner/automation/.github/workflows/check.yml@v1
-  steps:
+  spaced:
+    uses : owner/automation/.github/workflows/spaced.yml@v2
+  quoted:
+    "uses": owner/automation/.github/workflows/quoted.yml@v3
+  flow: { uses: owner/automation/.github/workflows/flow.yml@v4 }
+  action:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0123456789012345678901234567890123456789
@@ -99,6 +116,9 @@ test('workflow pinning scans both step actions and job-level reusable workflows'
 
   assert.deepEqual(workflowUses(workflow), [
     'owner/automation/.github/workflows/check.yml@v1',
+    'owner/automation/.github/workflows/spaced.yml@v2',
+    'owner/automation/.github/workflows/quoted.yml@v3',
+    'owner/automation/.github/workflows/flow.yml@v4',
     'actions/checkout@0123456789012345678901234567890123456789',
   ]);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,27 @@
       "bin": {
         "job-application-agent": "bin/job-application-agent.mjs"
       },
+      "devDependencies": {
+        "yaml": "2.9.0"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "devDependencies": {
+    "yaml": "2.9.0"
   }
 }


### PR DESCRIPTION
## Summary

- run the release ancestry guard immediately after checkout, before setup or dependency lifecycle scripts
- parse workflows as YAML before inspecting job-level and step-level `uses` references
- cover spaced keys, quoted keys, and flow mappings with regression fixtures
- pin the YAML parser as a dev-only dependency with lockfile integrity

## Review feedback addressed

Follow-up to the two unresolved findings on #18:

- [Run the ancestry check before installing dependencies](https://github.com/vaibhavarora14/job-application-agent/pull/18#discussion_r3808104320)
- [Parse YAML before validating reusable-workflow pins](https://github.com/vaibhavarora14/job-application-agent/pull/18#discussion_r3808104322)

## Verification

- `npm run check`
- `npm test` (98 tests)
- `npx --yes --package=node@20 node --test` (98 tests)
- `npm run privacy-audit`
- `npm run smoke:package`
- `npm run check:native-artifacts`
- `npm audit --audit-level=high` (0 vulnerabilities)

The original review threads remain unresolved for reviewer verification.
