### PR TITLE
Enforce 15-day company reapplication policy at ledger writes

### DIFF
--- a/job-application-agent/SKILL.md
+++ b/job-application-agent/SKILL.md
@@ -51,16 +51,17 @@ For batches, scheduled work, or resumable handoffs, read [references/RUNS.md](re
 
 1. Recheck employer, title, direct domain, posting status, eligibility, and `autoEligible` immediately before submission.
 2. Run `ledger check --stdin` with the internal ledger ID, canonical URL, employer job ID, company, and role when available. Review both requisition duplicate status and same-company history.
-3. Stop on a hard duplicate. Treat a same-company/same-role match without a shared job ID as a possible duplicate. Use `duplicateOverride: "NEW REQUISITION CONFIRMED"` only after verifying it is a distinct requisition.
-4. Keep authentication in the existing browser session. Never inspect cookies, local storage, passwords, or session files.
-5. Fill only explicit profile fields, candidate-provided answers, or facts verified in the canonical resume.
-6. Follow [references/APPLICATION_GUIDANCE.md](references/APPLICATION_GUIDANCE.md) for narrative answers.
-7. Upload only the canonical resume unless the candidate explicitly provides another attachment. Resolve its absolute path with `resume path`, then follow [references/BROWSER_UPLOADS.md](references/BROWSER_UPLOADS.md). Use the browser's privileged path-based upload capability first; treat a visible native file picker as a fallback.
-8. Do not answer demographic questions. Stop for login/SSO/MFA, CAPTCHA, legal attestations, unclear authorization or compensation, sensitive identifiers, and judgment-only questions.
-9. Verify every required field, answer, attachment, and disclosure. Submit when the current request or active autonomy grant authorizes it.
-10. Record `submitted` only after visible success confirmation, using independent `discoverySource`, `applicationChannel`, and `roundId` values. Record no submission when confirmation is missing or ambiguous.
-11. Record workflow telemetry with `telemetry record --stdin`. Let `ledger add` emit `application_submitted`; do not emit it twice. Pass job URLs and structured metrics only through documented transient fields.
-12. Queue hard stops with `attention add --stdin` and continue elsewhere. Record reproducible general-purpose failures with `friction record --stdin`; improvement work must never delay application work.
+3. Stop on a hard ledger-ID, canonical-URL, employer-job-ID, or requisition duplicate. Treat a same-company/same-role alias as a possible duplicate. Use `duplicateOverride: "NEW REQUISITION CONFIRMED"` only after verifying it is a distinct requisition.
+4. For a genuinely different role at a previously applied company, follow `companyReapply`: proceed automatically only when it returns `eligible-after-cooldown` (15 full days since the latest company application and no recorded outcome). `cooldown-active` and `follow-up-present` require the candidate's explicit approval and `companyReapplyOverride: "CANDIDATE APPROVED EARLY REAPPLICATION"`.
+5. Keep authentication in the existing browser session. Never inspect cookies, local storage, passwords, or session files.
+6. Fill only explicit profile fields, candidate-provided answers, or facts verified in the canonical resume.
+7. Follow [references/APPLICATION_GUIDANCE.md](references/APPLICATION_GUIDANCE.md) for narrative answers.
+8. Upload only the canonical resume unless the candidate explicitly provides another attachment. Resolve its absolute path with `resume path`, then follow [references/BROWSER_UPLOADS.md](references/BROWSER_UPLOADS.md). Use the browser's privileged path-based upload capability first; treat a visible native file picker as a fallback.
+9. Do not answer demographic questions. Stop for login/SSO/MFA, CAPTCHA, legal attestations, unclear authorization or compensation, sensitive identifiers, and judgment-only questions.
+10. Verify every required field, answer, attachment, and disclosure. Submit when the current request or active autonomy grant authorizes it.
+11. Record `submitted` only after visible success confirmation, using independent `discoverySource`, `applicationChannel`, and `roundId` values. Record no submission when confirmation is missing or ambiguous.
+12. Record workflow telemetry with `telemetry record --stdin`. Let `ledger add` emit `application_submitted`; do not emit it twice. Pass job URLs and structured metrics only through documented transient fields.
+13. Queue hard stops with `attention add --stdin` and continue elsewhere. Record reproducible general-purpose failures with `friction record --stdin`; improvement work must never delay application work.
 
 ## Outcomes and reviews
 

--- a/job-application-agent/references/RUNS.md
+++ b/job-application-agent/references/RUNS.md
@@ -14,7 +14,7 @@ Start input: `{ "requestedCount": 30 }`. Complete input: `{ "roundId": "round-..
 
 Count only unique applications with a visible employer/ATS confirmation or a verified sent recruiting email that were also added to the ledger with the same `roundId`. Filled forms, blockers, drafts, unsent email, and ambiguous confirmations never count. `round complete` rejects an under-target round.
 
-Run both company-level and requisition-level duplicate checks before filling and again immediately before transmission. A prior company application is a review signal, not by itself proof that a distinct requisition is a duplicate.
+Run both company-level and requisition-level duplicate checks before filling and again immediately before transmission. Hard ledger-ID, canonical-URL, employer-job-ID, and requisition duplicates always stop. Same-role aliases require a verified distinct requisition and `NEW REQUISITION CONFIRMED`. A genuinely different role at the same company may proceed automatically only when `companyReapply.decision` is `eligible-after-cooldown`: 15 full days have passed since the latest company application and no outcome has been recorded. `cooldown-active` and `follow-up-present` require explicit candidate approval.
 
 Resolve the canonical résumé with `resume path`, upload its absolute path through the browser’s privileged chooser first, and verify the filename and parsed fields. Use a visible native picker only as a fallback.
 

--- a/job-application-agent/references/SCHEMAS.md
+++ b/job-application-agent/references/SCHEMAS.md
@@ -94,6 +94,8 @@ Include as many identifiers as are known.
 
 The check removes fragments and non-job query parameters while retaining recognized job or requisition identifiers. Matching ledger ID, canonical URL, or same-company employer job ID is a hard duplicate. Same company and role without a shared job ID is a possible duplicate.
 
+`ledger check` also returns `companyReapply`. A genuinely different role is `eligible-after-cooldown` only when at least 15 full days have passed since the latest application to that company and no outcome has been recorded for that application. Hard duplicates are never eligible. Same-role matches, `cooldown-active`, and `follow-up-present` remain blocked at `ledger add` unless their exact documented override is present.
+
 ## Confirmed submission input
 
 Add only after visible success confirmation.
@@ -114,6 +116,7 @@ Add only after visible success confirmation.
   "submittedAt": "2026-01-15T10:00:00.000Z",
   "approval": "STANDING AUTHORIZATION",
   "duplicateOverride": "NEW REQUISITION CONFIRMED",
+  "companyReapplyOverride": "CANDIDATE APPROVED EARLY REAPPLICATION",
   "answers": { "Resume": "Canonical resume.pdf" },
   "telemetry": {
     "durationBucket": "5-15m",
@@ -124,9 +127,9 @@ Add only after visible success confirmation.
 }
 ```
 
-Use `duplicateOverride` only for a verified distinct requisition after a possible-duplicate warning. It and `telemetry` are transient and are not written to the application ledger. Use approval `APPROVE SUBMIT` for per-application approval or `STANDING AUTHORIZATION` when the current request authorizes routine batch submission.
+Use `duplicateOverride` only for a verified distinct requisition after a possible-duplicate warning. Use `companyReapplyOverride` only when the candidate explicitly approves a different-role reapplication during the cooldown or after a recorded outcome. Both override phrases and `telemetry` are transient. An accepted company reapplication override stores only `reapplicationApproval: "candidate-explicit"` in the private ledger. Use approval `APPROVE SUBMIT` for per-application approval or `STANDING AUTHORIZATION` when the current request authorizes routine batch submission.
 
-`discoverySource`, `applicationChannel`, and `roundId` are optional for backward compatibility and should be supplied for new resumable rounds. `ledger check` returns hard requisition/URL duplicate status plus bounded same-company history so a distinct role can be reviewed without conflating it with a duplicate.
+`discoverySource`, `applicationChannel`, and `roundId` are optional for backward compatibility and should be supplied for new resumable rounds. `ledger check` returns hard duplicate status, bounded same-company history, and the same `companyReapply` decision enforced by `ledger add` while holding the application lock.
 
 ## Autonomy grant input
 

--- a/job-application-agent/scripts/job-application.mjs
+++ b/job-application-agent/scripts/job-application.mjs
@@ -28,6 +28,8 @@ const AUTONOMY_HARD_STOPS = Object.freeze(['authentication', 'mfa', 'captcha', '
 const ATTENTION_STAGES = new Set(['discovery', 'assessment', 'application', 'contact', 'resume', 'questions', 'legal', 'demographic', 'review', 'submission', 'confirmation', 'outcome', 'answers', 'upload']);
 const ATTENTION_BLOCKERS = new Set(['authentication', 'mfa', 'captcha', 'legal-attestation', 'demographic', 'government-id', 'ambiguous-authorization', 'ambiguous-compensation', 'unverifiable-claim', 'judgment', 'video', 'upload', 'site-error', 'other']);
 const REQUIRED_ACTIONS = new Set(['sign-in', 'complete-mfa', 'complete-captcha', 'review-legal', 'choose-demographic', 'provide-government-id', 'provide-authorization', 'provide-compensation', 'verify-claim', 'provide-judgment', 'record-video', 'enable-upload', 'retry-site']);
+const COMPANY_REAPPLY_COOLDOWN_DAYS = 15;
+const COMPANY_REAPPLY_OVERRIDE = 'CANDIDATE APPROVED EARLY REAPPLICATION';
 const REQUIRED_PROFILE = ['name', 'email', 'phone', 'location', 'workAuthorization', 'roleFamilies', 'seniority', 'targetLocations', 'workModes', 'submissionMode', 'yearsExperience', 'autoSubmitMinScore', 'manualReviewMinScore', 'minMustHaveCoverage'];
 const STRING_PROFILE_FIELDS = new Set(['name', 'email', 'phone', 'location', 'workAuthorization', 'linkedin', 'github', 'portfolio', 'availability', 'currentCompensation', 'targetCompensation', 'submissionMode']);
 const ARRAY_PROFILE_FIELDS = new Set(['roleFamilies', 'seniority', 'skills', 'targetLocations', 'excludedLocations', 'workModes', 'industries', 'excludedCompanies']);
@@ -442,6 +444,27 @@ function normalizedText(value) {
   return String(value ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
 }
 
+function comparableRoleTokens(value) {
+  const normalized = normalizedText(value)
+    .replace(/\bsr\b/g, 'senior')
+    .replace(/\bjr\b/g, 'junior')
+    .replace(/\bfull stack\b/g, 'fullstack')
+    .replace(/\bfront end\b/g, 'frontend')
+    .replace(/\bback end\b/g, 'backend');
+  const ignored = new Set(['software', 'junior', 'mid', 'senior', 'staff', 'principal', 'lead', 'manager', 'director', 'founding']);
+  return new Set(normalized.split(' ')
+    .map((token) => token === 'developer' ? 'engineer' : token)
+    .filter((token) => token && !ignored.has(token)));
+}
+
+function rolesLikelySame(left, right) {
+  const leftTokens = comparableRoleTokens(left);
+  const rightTokens = comparableRoleTokens(right);
+  if (leftTokens.size === 0 || rightTokens.size === 0) return normalizedText(left) === normalizedText(right);
+  const shared = [...leftTokens].filter((token) => rightTokens.has(token)).length;
+  return shared / Math.min(leftTokens.size, rightTokens.size) >= 0.75;
+}
+
 function canonicalApplicationKey(entry, fallback = '') {
   if (entry.employerJobId) return `job:${normalizedText(entry.company)}:${String(entry.employerJobId).toLowerCase()}`;
   if (entry.company && entry.role) return `legacy-role:${normalizedText(entry.company)}:${normalizedText(entry.role)}`;
@@ -737,63 +760,105 @@ async function canonicalResumePath() {
   return { path: target };
 }
 
-function duplicateResult(entries, candidate) {
+function duplicateResult(entries, candidate, outcomes = [], now = new Date()) {
   const candidateCompany = normalizedText(candidate.company);
   const candidateRole = normalizedText(candidate.role);
   const candidateUrl = normalizeUrl(candidate.url);
-  const sameCompanyRole = (entry) => candidateCompany && candidateRole && normalizedText(entry.company) === candidateCompany && normalizedText(entry.role) === candidateRole;
-  const hard = entries.find((entry) => entry.id === candidate.id
-    || (candidate.employerJobId && entry.employerJobId && normalizedText(entry.company) === candidateCompany && entry.employerJobId.toLowerCase() === String(candidate.employerJobId).toLowerCase())
-    || normalizeUrl(entry.url) === candidateUrl);
+  const sameCompanyRole = (entry) => candidateCompany && candidateRole
+    && normalizedText(entry.company) === candidateCompany
+    && rolesLikelySame(entry.role, candidate.role);
+  const hardId = entries.find((entry) => entry.id === candidate.id);
+  const hardEmployerJobId = entries.find((entry) => candidate.employerJobId && entry.employerJobId
+    && normalizedText(entry.company) === candidateCompany
+    && entry.employerJobId.toLowerCase() === String(candidate.employerJobId).toLowerCase());
+  const hardUrl = entries.find((entry) => normalizeUrl(entry.url) === candidateUrl);
+  const hard = hardId ?? hardEmployerJobId ?? hardUrl;
+  const hardReason = hardId ? 'id' : hardEmployerJobId ? 'employer-job-id' : hardUrl ? 'url' : null;
   const possible = hard ? null : entries.find(sameCompanyRole);
   const match = hard ?? possible;
-  const companyApplications = candidateCompany
-    ? entries.filter((entry) => normalizedText(entry.company) === candidateCompany).slice(-20).map((entry) => ({
+  const sameCompanyEntries = candidateCompany
+    ? entries.filter((entry) => normalizedText(entry.company) === candidateCompany)
+    : [];
+  const companyApplications = sameCompanyEntries.slice(-20).map((entry) => ({
       id: entry.id,
       company: entry.company,
       role: entry.role,
       submittedAt: entry.submittedAt,
       ...(entry.employerJobId ? { employerJobId: entry.employerJobId } : {}),
-    }))
-    : [];
+    }));
+  const latestCompanyApplication = [...sameCompanyEntries]
+    .filter((entry) => !Number.isNaN(Date.parse(entry.submittedAt)))
+    .sort((left, right) => Date.parse(right.submittedAt) - Date.parse(left.submittedAt))[0] ?? null;
+  const daysSinceLatest = latestCompanyApplication
+    ? Math.max(0, Math.floor((now.getTime() - Date.parse(latestCompanyApplication.submittedAt)) / 86_400_000))
+    : null;
+  const hasFollowUp = latestCompanyApplication
+    ? outcomes.some((outcome) => outcome.id === latestCompanyApplication.id)
+    : false;
+  let companyReapplyDecision = 'fresh-company';
+  if (hard) companyReapplyDecision = 'hard-duplicate';
+  else if (possible) companyReapplyDecision = 'same-role-review';
+  else if (latestCompanyApplication && hasFollowUp) companyReapplyDecision = 'follow-up-present';
+  else if (latestCompanyApplication && daysSinceLatest < COMPANY_REAPPLY_COOLDOWN_DAYS) companyReapplyDecision = 'cooldown-active';
+  else if (latestCompanyApplication) companyReapplyDecision = 'eligible-after-cooldown';
   return {
     duplicate: Boolean(hard),
     possibleDuplicate: Boolean(possible),
-    reason: hard ? (hard.id === candidate.id ? 'id' : candidate.employerJobId && hard.employerJobId ? 'employer-job-id' : 'url') : possible ? 'company-role' : null,
+    reason: hardReason ?? (possible ? 'company-role' : null),
     match: match ? { id: match.id, company: match.company, role: match.role, submittedAt: match.submittedAt } : null,
     sameCompany: companyApplications.length > 0,
     companyApplications,
+    companyReapply: {
+      eligible: companyReapplyDecision === 'eligible-after-cooldown',
+      decision: companyReapplyDecision,
+      cooldownDays: COMPANY_REAPPLY_COOLDOWN_DAYS,
+      latestSubmittedAt: latestCompanyApplication?.submittedAt ?? null,
+      daysSinceLatest,
+      hasFollowUp,
+    },
   };
 }
 
 async function ledgerCheck(candidate) {
   object(candidate, 'candidate');
-  const entries = await jsonLines(join(await ensureStateDir(), 'applications.ndjson'));
+  const dir = await ensureStateDir();
+  const entries = await jsonLines(join(dir, 'applications.ndjson'));
+  const outcomes = await jsonLines(join(dir, 'outcomes.ndjson'));
   string(candidate.url, 'candidate.url', 2048);
-  return duplicateResult(entries, candidate);
+  return duplicateResult(entries, candidate, outcomes);
 }
 
-async function ledgerAdd(entryInput, duplicateOverride) {
+async function ledgerAdd(entryInput, duplicateOverride, companyReapplyOverride) {
   const entry = validateLedgerEntry(entryInput);
   return withStateLock('applications', async (dir) => {
     const file = join(dir, 'applications.ndjson');
     const entries = await jsonLines(file);
+    const outcomes = await jsonLines(join(dir, 'outcomes.ndjson'));
     if (entry.roundId) {
       const roundEvents = await jsonLines(join(dir, 'rounds.ndjson'));
       if (!roundEvents.some((event) => event.type === 'started' && event.roundId === entry.roundId)) throw new Error('entry.roundId does not identify a started round.');
       if (roundEvents.some((event) => event.type === 'completed' && event.roundId === entry.roundId)) throw new Error('entry.roundId identifies a completed round.');
     }
-    const duplicate = duplicateResult(entries, entry);
-    if (duplicate.duplicate) throw new Error('This application is already recorded.');
+    const duplicate = duplicateResult(entries, entry, outcomes);
+    if (duplicate.duplicate) throw new Error(`Hard duplicate blocked: matching ${duplicate.reason === 'employer-job-id' ? 'employer job ID or requisition' : duplicate.reason === 'url' ? 'canonical URL' : 'ledger ID'}.`);
     if (duplicate.possibleDuplicate && duplicateOverride !== 'NEW REQUISITION CONFIRMED') throw new Error('A possible same-company role duplicate requires NEW REQUISITION CONFIRMED.');
-    await appendFile(file, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+    if (!duplicate.possibleDuplicate && duplicate.companyReapply.decision === 'cooldown-active' && companyReapplyOverride !== COMPANY_REAPPLY_OVERRIDE) {
+      throw new Error(`Company reapplication cooldown is active for ${COMPANY_REAPPLY_COOLDOWN_DAYS} full days; use ${COMPANY_REAPPLY_OVERRIDE} only with explicit candidate approval.`);
+    }
+    if (!duplicate.possibleDuplicate && duplicate.companyReapply.decision === 'follow-up-present' && companyReapplyOverride !== COMPANY_REAPPLY_OVERRIDE) {
+      throw new Error(`Company reapplication blocked because the latest application has a recorded follow-up; use ${COMPANY_REAPPLY_OVERRIDE} only with explicit candidate approval.`);
+    }
+    const storedEntry = ['cooldown-active', 'follow-up-present'].includes(duplicate.companyReapply.decision)
+      ? { ...entry, reapplicationApproval: 'candidate-explicit' }
+      : entry;
+    await appendFile(file, `${JSON.stringify(storedEntry)}\n`, { mode: 0o600 });
     await chmod(file, 0o600);
     if (entry.roundId) {
       const roundsFile = join(dir, 'rounds.ndjson');
       await appendFile(roundsFile, `${JSON.stringify({ type: 'submission-confirmed', roundId: entry.roundId, applicationId: entry.id, occurredAt: entry.submittedAt })}\n`, { mode: 0o600 });
       await chmod(roundsFile, 0o600);
     }
-    return { recorded: entry.id, review: buildReview([...entries, entry]) };
+    return { recorded: storedEntry.id, review: buildReview([...entries, storedEntry]) };
   });
 }
 
@@ -1096,7 +1161,7 @@ async function executeCommand([area, action, value], telemetry, session) {
     const input = await jsonStdin();
     const telemetryDetails = validateSubmissionTelemetry(input.telemetry);
     const entry = validateLedgerEntry(input);
-    result = await ledgerAdd(entry, input.duplicateOverride);
+    result = await ledgerAdd(entry, input.duplicateOverride, input.companyReapplyOverride);
     domainEvents.push(await telemetryApplicationSubmitted(entry, telemetryDetails));
   } else if (area === 'ledger' && action === 'outcome' && value === '--stdin') {
     const outcome = await ledgerOutcome(await jsonStdin());

--- a/job-application-agent/tests/workflow-state.test.mjs
+++ b/job-application-agent/tests/workflow-state.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -34,6 +34,18 @@ function cliFailure(env, args, input) {
     env,
     encoding: 'utf8',
     ...(input === undefined ? {} : { input: JSON.stringify(input) }),
+  });
+}
+
+function cliConcurrent(env, args, input) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [script, ...args], { env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8').on('data', (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding('utf8').on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+    child.stdin.end(JSON.stringify(input));
   });
 }
 
@@ -114,6 +126,240 @@ test('counts only unique confirmed ledger submissions for an explicit round', as
   assert.equal(roundEvents.filter((event) => event.type === 'submission-confirmed').length, 30);
   assert.equal(roundEvents.length, 32);
   if (process.platform !== 'win32') assert.equal((await stat(join(directory, 'rounds.ndjson'))).mode & 0o777, 0o600);
+});
+
+test('blocks a different role at the same company during the 15-day cooldown', async (t) => {
+  const { env } = await fixture(t, 'company-cooldown-enforced');
+  const recent = new Date(Date.now() - (5 * 86_400_000)).toISOString();
+  const now = new Date().toISOString();
+  cli(env, ['ledger', 'add', '--stdin'], submission(100, undefined, {
+    id: 'example-backend-role',
+    company: 'Example',
+    role: 'Senior Backend Engineer',
+    url: 'https://jobs.example.com/backend-100',
+    employerJobId: 'example:backend-100',
+    submittedAt: recent,
+  }));
+
+  const check = cli(env, ['ledger', 'check', '--stdin'], {
+    id: 'example-product-role',
+    company: 'Example',
+    role: 'Staff Product Engineer',
+    url: 'https://jobs.example.com/product-101',
+    employerJobId: 'example:product-101',
+  });
+  assert.equal(check.companyReapply.decision, 'cooldown-active');
+  assert.equal(check.companyReapply.eligible, false);
+
+  const blocked = cliFailure(env, ['ledger', 'add', '--stdin'], submission(101, undefined, {
+    id: 'example-product-role',
+    company: 'Example',
+    role: 'Staff Product Engineer',
+    url: 'https://jobs.example.com/product-101',
+    employerJobId: 'example:product-101',
+    submittedAt: now,
+  }));
+
+  assert.equal(blocked.status, 1);
+  assert.match(blocked.stderr, /reapplication cooldown is active/i);
+  assert.match(blocked.stderr, /CANDIDATE APPROVED EARLY REAPPLICATION/);
+});
+
+test('records bounded evidence for an explicitly approved early reapplication', async (t) => {
+  const { directory, env } = await fixture(t, 'company-cooldown-override');
+  const recent = new Date(Date.now() - (5 * 86_400_000)).toISOString();
+  const now = new Date().toISOString();
+  cli(env, ['ledger', 'add', '--stdin'], submission(110, undefined, {
+    id: 'override-backend-role',
+    company: 'Override Co',
+    role: 'Senior Backend Engineer',
+    url: 'https://jobs.example.com/override-backend-110',
+    submittedAt: recent,
+  }));
+
+  const result = cli(env, ['ledger', 'add', '--stdin'], {
+    ...submission(111, undefined, {
+      id: 'override-product-role',
+      company: 'Override Co',
+      role: 'Staff Product Engineer',
+      url: 'https://jobs.example.com/override-product-111',
+      submittedAt: now,
+    }),
+    companyReapplyOverride: 'CANDIDATE APPROVED EARLY REAPPLICATION',
+  });
+
+  assert.equal(result.recorded, 'override-product-role');
+  const stored = (await readFile(join(directory, 'applications.ndjson'), 'utf8')).trim().split('\n').map(JSON.parse);
+  assert.equal(stored[1].reapplicationApproval, 'candidate-explicit');
+  assert.equal(JSON.stringify(stored).includes('CANDIDATE APPROVED EARLY REAPPLICATION'), false);
+  assert.equal('companyReapplyOverride' in stored[1], false);
+});
+
+test('requires explicit approval when the latest company application has a follow-up', async (t) => {
+  const { directory, env } = await fixture(t, 'company-follow-up-override');
+  const old = new Date(Date.now() - (30 * 86_400_000)).toISOString();
+  const followUp = new Date(Date.now() - (20 * 86_400_000)).toISOString();
+  const now = new Date().toISOString();
+  cli(env, ['ledger', 'add', '--stdin'], submission(120, undefined, {
+    id: 'follow-up-backend-role',
+    company: 'Follow Up Co',
+    role: 'Senior Backend Engineer',
+    url: 'https://jobs.example.com/follow-up-backend-120',
+    submittedAt: old,
+  }));
+  cli(env, ['ledger', 'outcome', '--stdin'], {
+    id: 'follow-up-backend-role',
+    status: 'rejected',
+    occurredAt: followUp,
+  });
+
+  const candidate = submission(121, undefined, {
+    id: 'follow-up-product-role',
+    company: 'Follow Up Co',
+    role: 'Staff Product Engineer',
+    url: 'https://jobs.example.com/follow-up-product-121',
+    submittedAt: now,
+  });
+  const blocked = cliFailure(env, ['ledger', 'add', '--stdin'], candidate);
+  assert.equal(blocked.status, 1);
+  assert.match(blocked.stderr, /recorded follow-up/i);
+
+  const result = cli(env, ['ledger', 'add', '--stdin'], {
+    ...candidate,
+    companyReapplyOverride: 'CANDIDATE APPROVED EARLY REAPPLICATION',
+  });
+  assert.equal(result.recorded, 'follow-up-product-role');
+  const stored = (await readFile(join(directory, 'applications.ndjson'), 'utf8')).trim().split('\n').map(JSON.parse);
+  assert.equal(stored[1].reapplicationApproval, 'candidate-explicit');
+});
+
+test('allows a genuinely different role after 15 full quiet days', async (t) => {
+  const { env } = await fixture(t, 'company-cooldown-complete');
+  const old = new Date(Date.now() - (16 * 86_400_000)).toISOString();
+  cli(env, ['ledger', 'add', '--stdin'], submission(130, undefined, {
+    id: 'quiet-backend-role',
+    company: 'Quiet Co',
+    role: 'Senior Backend Engineer',
+    url: 'https://jobs.example.com/quiet-backend-130',
+    submittedAt: old,
+  }));
+
+  const check = cli(env, ['ledger', 'check', '--stdin'], {
+    id: 'quiet-product-role',
+    company: 'Quiet Co',
+    role: 'Staff Product Engineer',
+    url: 'https://jobs.example.com/quiet-product-131',
+    employerJobId: 'example:quiet-product-131',
+  });
+  assert.equal(check.companyReapply.decision, 'eligible-after-cooldown');
+  assert.equal(check.companyReapply.eligible, true);
+
+  const result = cli(env, ['ledger', 'add', '--stdin'], submission(131, undefined, {
+    id: 'quiet-product-role',
+    company: 'Quiet Co',
+    role: 'Staff Product Engineer',
+    url: 'https://jobs.example.com/quiet-product-131',
+    employerJobId: 'example:quiet-product-131',
+    submittedAt: new Date().toISOString(),
+  }));
+  assert.equal(result.recorded, 'quiet-product-role');
+});
+
+test('requires the requisition override for same-role aliases', async (t) => {
+  const { directory, env } = await fixture(t, 'same-role-alias');
+  const recent = new Date(Date.now() - (2 * 86_400_000)).toISOString();
+  cli(env, ['ledger', 'add', '--stdin'], submission(140, undefined, {
+    id: 'alias-backend-original',
+    company: 'Alias Co',
+    role: 'Senior Backend Developer',
+    url: 'https://jobs.example.com/alias-backend-140',
+    employerJobId: 'alias:140',
+    submittedAt: recent,
+  }));
+  const candidate = submission(141, undefined, {
+    id: 'alias-backend-new',
+    company: 'Alias Co',
+    role: 'Sr Backend Engineer',
+    url: 'https://jobs.example.com/alias-backend-141',
+    employerJobId: 'alias:141',
+    submittedAt: new Date().toISOString(),
+  });
+
+  const blocked = cliFailure(env, ['ledger', 'add', '--stdin'], candidate);
+  assert.equal(blocked.status, 1);
+  assert.match(blocked.stderr, /NEW REQUISITION CONFIRMED/);
+  const result = cli(env, ['ledger', 'add', '--stdin'], {
+    ...candidate,
+    duplicateOverride: 'NEW REQUISITION CONFIRMED',
+  });
+  assert.equal(result.recorded, 'alias-backend-new');
+  const stored = (await readFile(join(directory, 'applications.ndjson'), 'utf8')).trim().split('\n').map(JSON.parse);
+  assert.equal('reapplicationApproval' in stored[1], false);
+});
+
+test('never permits hard duplicates even when both override phrases are supplied', async (t) => {
+  const { env } = await fixture(t, 'hard-duplicates');
+  const original = submission(150, undefined, {
+    id: 'hard-original',
+    company: 'Hard Duplicate Co',
+    role: 'Senior Backend Engineer',
+    url: 'https://jobs.example.com/hard-original',
+    employerJobId: 'hard:150',
+    submittedAt: new Date(Date.now() - (30 * 86_400_000)).toISOString(),
+  });
+  cli(env, ['ledger', 'add', '--stdin'], original);
+  const overrides = {
+    duplicateOverride: 'NEW REQUISITION CONFIRMED',
+    companyReapplyOverride: 'CANDIDATE APPROVED EARLY REAPPLICATION',
+    submittedAt: new Date().toISOString(),
+  };
+  const candidates = [
+    { ...submission(151, undefined), ...overrides, id: original.id, company: original.company },
+    { ...submission(152, undefined), ...overrides, company: original.company, url: original.url },
+    { ...submission(153, undefined), ...overrides, company: original.company, employerJobId: original.employerJobId },
+  ];
+
+  const messages = [/matching ledger ID/, /matching canonical URL/, /matching employer job ID or requisition/];
+  for (const [index, candidate] of candidates.entries()) {
+    const blocked = cliFailure(env, ['ledger', 'add', '--stdin'], candidate);
+    assert.equal(blocked.status, 1);
+    assert.match(blocked.stderr, /Hard duplicate blocked/);
+    assert.match(blocked.stderr, messages[index]);
+  }
+});
+
+test('serializes concurrent company writes so the cooldown cannot be bypassed', async (t) => {
+  const { directory, env } = await fixture(t, 'concurrent-company-cooldown');
+  cli(env, ['ledger', 'add', '--stdin'], submission(160, undefined, {
+    id: 'concurrent-backend-role',
+    company: 'Concurrent Co',
+    role: 'Senior Backend Engineer',
+    url: 'https://jobs.example.com/concurrent-backend-160',
+    submittedAt: new Date(Date.now() - (16 * 86_400_000)).toISOString(),
+  }));
+  const first = submission(161, undefined, {
+    id: 'concurrent-product-role',
+    company: 'Concurrent Co',
+    role: 'Staff Product Engineer',
+    url: 'https://jobs.example.com/concurrent-product-161',
+    submittedAt: new Date().toISOString(),
+  });
+  const second = submission(162, undefined, {
+    id: 'concurrent-data-role',
+    company: 'Concurrent Co',
+    role: 'Principal Data Engineer',
+    url: 'https://jobs.example.com/concurrent-data-162',
+    submittedAt: new Date().toISOString(),
+  });
+
+  const results = await Promise.all([
+    cliConcurrent(env, ['ledger', 'add', '--stdin'], first),
+    cliConcurrent(env, ['ledger', 'add', '--stdin'], second),
+  ]);
+  assert.deepEqual(results.map((result) => result.status).sort(), [0, 1]);
+  assert.match(results.find((result) => result.status === 1).stderr, /reapplication cooldown is active/i);
+  const stored = (await readFile(join(directory, 'applications.ndjson'), 'utf8')).trim().split('\n').map(JSON.parse);
+  assert.equal(stored.length, 2);
 });
 
 test('does not complete a round from blocked or partially filled applications', async (t) => {


### PR DESCRIPTION
## Summary
- enforce company reapplication cooldown and recorded-outcome blocks inside `ledger add` while holding the application lock
- preserve non-overridable hard duplicates and the distinct same-role requisition override
- store only bounded `candidate-explicit` evidence when early reapplication is explicitly approved
- document the write-boundary policy and add concurrency/edge-case regression coverage

## Verification
- `npm run check`
- `npm test` (131 passing)
- `npm run privacy-audit`
- `npm run smoke:package`
- `npm run check:native-artifacts`
- `npm audit --audit-level=high`

This is the cooldown-only split from #21. No community registry, website, payment, or pricing changes are included.