### PR TITLE
Retry telemetry health checks during edge propagation

### DIFF
--- a/.github/workflows/deploy-telemetry.yml
+++ b/.github/workflows/deploy-telemetry.yml
@@ -36,10 +36,10 @@ jobs:
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
       - name: Verify production health
         run: |
-          curl --fail --silent --show-error "$TELEMETRY_PRODUCTION_URL/healthz"
-          curl --fail --silent --show-error "$TELEMETRY_PRODUCTION_URL/api/public-stats"
-          curl --fail --silent --show-error "$TELEMETRY_PRODUCTION_URL/v1/sources"
-          curl --fail --silent --show-error "$TELEMETRY_PRODUCTION_URL/v1/jobs?limit=1"
-          curl --fail --silent --show-error "$TELEMETRY_PRODUCTION_URL/"
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$TELEMETRY_PRODUCTION_URL/healthz"
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$TELEMETRY_PRODUCTION_URL/api/public-stats"
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$TELEMETRY_PRODUCTION_URL/v1/sources"
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$TELEMETRY_PRODUCTION_URL/v1/jobs?limit=1"
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$TELEMETRY_PRODUCTION_URL/"
         env:
           TELEMETRY_PRODUCTION_URL: https://job-application-agent-telemetry.varora1406.workers.dev


### PR DESCRIPTION
The production Worker deployment succeeded, but the first request to the newly added route briefly reached the prior edge version and returned 404. Add bounded retries to the existing health checks so deployment verification tolerates normal propagation while still failing persistent errors.

Validated with the workflow quality-gate tests.