### PR TITLE
fix: isolate community job test traffic

### DIFF
--- a/job-application-agent/scripts/source-community-schema.mjs
+++ b/job-application-agent/scripts/source-community-schema.mjs
@@ -74,6 +74,11 @@ function isPublicHostname(hostname) {
   return value.includes('.');
 }
 
+function isReservedExampleHostname(hostname) {
+  const value = hostname.toLowerCase();
+  return ['example.com', 'example.net', 'example.org'].some((suffix) => value === suffix || value.endsWith(`.${suffix}`));
+}
+
 function hostnameMatches(hostname, suffix) {
   return hostname === suffix || hostname.endsWith(`.${suffix}`);
 }
@@ -139,6 +144,7 @@ export function normalizeCommunityJob(input) {
   if (url.protocol !== 'https:' || url.username || url.password) throw new Error('community job.url must be a public HTTPS URL.');
   url.hostname = url.hostname.replace(/\.+$/, '').toLowerCase();
   if (!isPublicHostname(url.hostname)) throw new Error('community job.url must use a public HTTPS hostname.');
+  if (isReservedExampleHostname(url.hostname)) throw new Error('community job.url must not use a reserved example hostname.');
   const pathname = decodedPathname(url.pathname).normalize('NFKC');
   url.pathname = pathname;
   if (containsEmailLike(pathname) || containsPhoneLikeLocation(url.hostname, pathname) || looksIdentityPath(pathname) || looksPersonal(url)) throw new Error('community job.url must not be a personal URL.');

--- a/job-application-agent/scripts/version.mjs
+++ b/job-application-agent/scripts/version.mjs
@@ -1,1 +1,1 @@
-export const SKILL_VERSION = '3.2.0';
+export const SKILL_VERSION = '3.2.1';

--- a/job-application-agent/tests/job-application.test.mjs
+++ b/job-application-agent/tests/job-application.test.mjs
@@ -48,6 +48,14 @@ const matchingJob = {
   ],
 };
 
+function isolatedCliEnv(directory) {
+  return {
+    ...process.env,
+    JOB_APPLICATION_AGENT_STATE_DIR: directory,
+    JOB_APPLICATION_AGENT_SOURCE_COMMUNITY_URL: 'http://127.0.0.1:9',
+  };
+}
+
 function runCli(script, args, input, env) {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [script, ...args], { env, stdio: ['pipe', 'pipe', 'pipe'] });
@@ -73,7 +81,7 @@ test('returns the canonical resume path for direct browser uploads', async (t) =
   const resume = join(directory, 'resume.pdf');
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
   await writeFile(resume, '%PDF-1.7\ncanonical resume fixture');
-  const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
+  const env = isolatedCliEnv(directory);
 
   const result = JSON.parse(execFileSync(process.execPath, [script, 'resume', 'path'], { env, encoding: 'utf8' }));
 
@@ -246,7 +254,7 @@ test('deduplicates ledger entries by normalized URL', async (t) => {
     telemetry: { durationBucket: '5-15m', fieldsFilled: 14, shortAnswerCount: 2, resumeUploaded: true },
   };
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
-  const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
+  const env = isolatedCliEnv(directory);
   execFileSync(process.execPath, [script, 'ledger', 'add', '--stdin'], { input: JSON.stringify(entry), env, encoding: 'utf8' });
   const duplicate = JSON.parse(execFileSync(process.execPath, [script, 'ledger', 'check', '--stdin'], { input: JSON.stringify({ id: 'different', url: 'https://jobs.example.com/123?ref=friend' }), env, encoding: 'utf8' }));
   assert.equal(duplicate.duplicate, true);
@@ -263,7 +271,7 @@ test('warns on same-company role matches and serializes concurrent duplicate sub
   t.after(() => rm(directory, { recursive: true, force: true }));
   const script = fileURLToPath(new URL('../scripts/job-application.mjs', import.meta.url));
   await writeFile(join(directory, 'telemetry.json'), JSON.stringify({ version: 1, enabled: false, disclosed: true, graceConsumed: true, installationEventPending: false }));
-  const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
+  const env = isolatedCliEnv(directory);
   const base = {
     company: 'Example', role: 'Senior Product Engineer', url: 'https://jobs.example.com/123', source: 'company', score: 88,
     status: 'submitted', submittedAt: '2026-01-15T10:00:00Z', approval: 'STANDING AUTHORIZATION', answers: {}, employerJobId: 'example:123',
@@ -291,7 +299,7 @@ test('records structured outcomes idempotently without duplicate rows', async (t
     id: 'example-role-1', company: 'Example', role: 'Senior Product Engineer', url: 'https://jobs.example.com/123', source: 'company', score: 88,
     status: 'submitted', submittedAt: '2026-01-15T10:00:00Z', approval: 'STANDING AUTHORIZATION', answers: {},
   })}\n`);
-  const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
+  const env = isolatedCliEnv(directory);
   const outcome = { id: 'example-role-1', status: 'rejected', occurredAt: '2026-01-20T09:00:00Z', note: 'No sponsorship' };
   const enriched = { ...outcome, reasons: [{ category: 'eligibility', evidence: 'explicit' }] };
   const first = JSON.parse(execFileSync(process.execPath, [script, 'ledger', 'outcome', '--stdin'], { input: JSON.stringify(outcome), env, encoding: 'utf8' }));
@@ -314,7 +322,7 @@ test('records bounded interview quality and failure-point enrichment idempotentl
     id: 'example-role-1', company: 'Example', role: 'Staff Product Engineer', url: 'https://jobs.example.com/123', source: 'company', score: 91,
     status: 'submitted', submittedAt: '2026-01-15T10:00:00Z', approval: 'STANDING AUTHORIZATION', answers: {},
   })}\n`);
-  const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
+  const env = isolatedCliEnv(directory);
   const base = { id: 'example-role-1', status: 'interview', occurredAt: '2026-01-20T09:00:00Z' };
   const enriched = { ...base, interviewQuality: 'weak', failurePoint: 'role-scope' };
   const first = JSON.parse(execFileSync(process.execPath, [script, 'ledger', 'outcome', '--stdin'], { input: JSON.stringify(base), env, encoding: 'utf8' }));
@@ -400,7 +408,7 @@ test('acknowledges a generated review only through the explicit CLI command', as
     source: 'company', score: 80, status: 'submitted', submittedAt: '2026-01-01T10:00:00Z', approval: 'STANDING AUTHORIZATION', answers: {},
   }));
   await writeFile(join(directory, 'applications.ndjson'), `${entries.map(JSON.stringify).join('\n')}\n`);
-  const env = { ...process.env, JOB_APPLICATION_AGENT_STATE_DIR: directory };
+  const env = isolatedCliEnv(directory);
   const before = JSON.parse(execFileSync(process.execPath, [script, 'ledger', 'review'], { env, encoding: 'utf8' }));
   assert.equal(before.reviewDue, true);
   assert.equal(await readFile(join(directory, 'reviews.ndjson'), 'utf8').catch(() => ''), '');

--- a/job-application-agent/tests/source-community-schema.test.mjs
+++ b/job-application-agent/tests/source-community-schema.test.mjs
@@ -53,6 +53,7 @@ test('accepts public job detail identifiers but rejects private, personal, and c
 
   const rejected = [
     'http://localhost/jobs/123',
+    'https://jobs.example.com/123',
     'https://linkedin.com/in/some-person',
     'https://company.example/candidate/9876543210',
     'https://company.example/referral/12345678-1234-4123-8123-123456789abc',
@@ -61,7 +62,7 @@ test('accepts public job detail identifiers but rejects private, personal, and c
     'https://company.example/jobs/access-token=abcdefghijklmnop',
     'https://user:password@company.example/jobs/123',
   ];
-  for (const url of rejected) assert.throws(() => normalizeCommunityJob({ ...job, url }), /public HTTPS|personal|credential/i, url);
+  for (const url of rejected) assert.throws(() => normalizeCommunityJob({ ...job, url }), /public HTTPS|personal|credential|reserved example/i, url);
 });
 
 test('preserves only stable query job identifiers while removing referral data', async () => {

--- a/job-application-agent/tests/workflow-state.test.mjs
+++ b/job-application-agent/tests/workflow-state.test.mjs
@@ -56,7 +56,7 @@ function submission(index, roundId, overrides = {}) {
     id: `round-role-${index}`,
     company: `Company ${index}`,
     role: 'Senior Product Engineer',
-    url: `https://jobs.example.com/${index}`,
+    url: `https://jobs.fixture.example/${index}`,
     employerJobId: `example:${index}`,
     source: 'ashby',
     discoverySource: 'linkedin',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-application-agent",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-application-agent",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "bin": {
         "job-application-agent": "bin/job-application-agent.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-application-agent",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A privacy-first Agent Skill and CLI for evidence-based job discovery, application completion, and outcome tracking.",
   "license": "MIT",
   "type": "module",

--- a/telemetry-worker/tests/e2e-staging.mjs
+++ b/telemetry-worker/tests/e2e-staging.mjs
@@ -75,7 +75,7 @@ assert.equal(rejected.status, 400);
 const stagingJobRunId = String(process.env.GITHUB_RUN_ID ?? 'local-contract')
   .replace(/\d/g, (digit) => String.fromCharCode('k'.charCodeAt(0) + Number(digit)));
 const stagingJob = {
-  url: `https://jobs.example.com/staging-fixture-community-job-${stagingJobRunId}?ref=private-staging-value#apply`,
+  url: `https://jobs.fixture.example/staging-fixture-community-job-${stagingJobRunId}?ref=private-staging-value#apply`,
   company: 'Staging Fixture Company',
   role: 'Community Job Contract Engineer',
   applicationChannel: 'company',
@@ -102,7 +102,7 @@ const publicJob = communityJobsBody.jobs.find((entry) => entry.jobId === contrib
 if (expectedJobStatus === 'published') {
   assert.ok(publicJob);
   assert.equal(publicJob.url, stagingJob.url.split('?')[0]);
-  assert.equal(publicJob.providerUrl, 'https://jobs.example.com');
+  assert.equal(publicJob.providerUrl, 'https://jobs.fixture.example');
   assert.equal('publicationStatus' in publicJob, false);
 } else {
   assert.equal(publicJob, undefined);


### PR DESCRIPTION
## Summary
- keep CLI integration tests off the production community relay
- reject reserved example.com/.net/.org job hosts at the shared client/server boundary
- move staging fixtures to an isolated hostname and release as 3.2.1

## Verification
- 191/191 tests
- 5/5 privacy audit
- package smoke and native artifact checks
- npm audit --omit=dev: 0 vulnerabilities
- production job/report counts unchanged before and after test runs (253/508)