### PR TITLE
refactor: realign stats dashboard around aggregate evidence

### DIFF
--- a/site/app/components/CommunityDashboard.tsx
+++ b/site/app/components/CommunityDashboard.tsx
@@ -80,7 +80,7 @@ export function CommunityDashboard() {
     </section>
 
     <section id="methodology" className="methodology">
-      <div><p className="eyebrow">Methodology</p><h2>Proof without profiles.</h2></div>
+      <div><p className="eyebrow">Methodology</p><h2>How the evidence is counted.</h2></div>
       <div><p><strong>Active installation</strong> means an anonymous installation assessed a job or submitted an application during the last 30 days. It is not a verified individual-person count.</p><p><strong>Verified application</strong> means the employer or ATS showed a confirmed submission success state.</p><p>Segments with fewer than {data?.privacy.minimumSegmentCount ?? 3} observations are grouped into “other.”</p></div>
     </section>
     <p className="dashboard-updated">{data ? `Updated ${new Intl.DateTimeFormat("en", { dateStyle: "long", timeStyle: "short" }).format(new Date(data.generatedAt))}` : "Anonymous aggregate telemetry"}</p>

--- a/site/app/components/CommunityDashboard.tsx
+++ b/site/app/components/CommunityDashboard.tsx
@@ -2,9 +2,9 @@
 
 import { compactNumber, fullNumber, useCommunityStats } from "./useCommunityStats";
 
-function Leaderboard({ title, subtitle, entries, wide = false }: { title: string; subtitle: string; entries: Array<{ label: string; count: number }>; wide?: boolean }) {
+function Leaderboard({ title, subtitle, entries }: { title: string; subtitle: string; entries: Array<{ label: string; count: number }> }) {
   const maximum = Math.max(1, ...entries.map((entry) => entry.count));
-  return <article className={`dashboard-panel${wide ? " dashboard-panel-wide" : ""}`}>
+  return <article className="dashboard-panel">
     <div className="panel-heading"><div><h2>{title}</h2><p>{subtitle}</p></div><span className="tag">Aggregate</span></div>
     <div className="leaderboard">{entries.length ? entries.slice(0, 7).map((entry) => <div className="leaderboard-row" key={entry.label}>
       <span className="leaderboard-label">{entry.label.replaceAll("-", " ")}</span>
@@ -44,24 +44,39 @@ export function CommunityDashboard() {
       </div>
     </section>
 
-    <section className="dashboard-grid">
-      <article className="dashboard-panel activity-panel">
-        <div className="panel-heading"><div><h2>Reported activity by day</h2><p>Verified application success states across recent reporting days</p></div><span className="tag">Includes backfill</span></div>
-        <div className="activity-chart" role="img" aria-label="Verified applications by recent reporting day">
-          {recentDays.length ? recentDays.map((day) => <div className="activity-column" key={day.day} title={`${day.day}: ${day.submitted} verified applications`}>
-            <strong>{fullNumber.format(day.submitted)}</strong><progress className="activity-bar" max={maximum} value={day.submitted} aria-label={`${day.day}: ${day.submitted} verified applications`} /><small>{new Intl.DateTimeFormat("en", { month: "short", day: "numeric", timeZone: "UTC" }).format(new Date(`${day.day}T00:00:00Z`))}</small>
-          </div>) : <p className="empty-data">Waiting for verified activity.</p>}
-        </div>
-        <p className="backfill-note"><strong>Read the trend carefully.</strong> Totals include clearly labelled historical backfill, so individual spikes are not presented as organic daily growth.</p>
-      </article>
-      <article className="dashboard-panel outcome-panel">
-        <div className="panel-heading"><div><h2>Outcome coverage</h2><p>Early signal, not a placement claim</p></div><span className="tag">{outcomeCoverage}% reported</span></div>
-        <strong className="outcome-number">{fullNumber.format(outcomesReported)}</strong>
-        <p>known outcomes from {data ? fullNumber.format(data.metrics.applicationsSubmitted) : "—"} verified applications.</p>
-        <div className="outcome-list">{data?.breakdowns.outcomes.map((entry) => <span key={entry.label}><i />{fullNumber.format(entry.count)} {entry.label}</span>)}</div>
-      </article>
-      <Leaderboard title="Where applications land" subtitle="Verified submissions by ATS · last 90 days" entries={data?.breakdowns.ats ?? []} />
-      <Leaderboard title="Role levels in view" subtitle="Privacy-safe seniority segments · last 90 days" entries={data?.breakdowns.seniority ?? []} wide />
+    <section className="dashboard-section" aria-labelledby="execution-heading">
+      <div className="dashboard-section-heading">
+        <div><p className="eyebrow">Execution signal</p><h2 id="execution-heading">Activity over time, with outcomes kept in context.</h2></div>
+        <p>Trends show verified submissions by reporting day. Outcome coverage shows how much of that work has a reported result; it is not a placement rate.</p>
+      </div>
+      <div className="dashboard-grid dashboard-grid-execution">
+        <article className="dashboard-panel activity-panel">
+          <div className="panel-heading"><div><h3>Verified submissions by day</h3><p>Recent reporting days; historical backfill is labelled below</p></div><span className="tag">Includes backfill</span></div>
+          <div className={`activity-chart${recentDays.length ? "" : " activity-chart-empty"}`} role="img" aria-label="Verified applications by recent reporting day">
+            {recentDays.length ? recentDays.map((day) => <div className="activity-column" key={day.day} title={`${day.day}: ${day.submitted} verified applications`}>
+              <strong>{fullNumber.format(day.submitted)}</strong><progress className="activity-bar" max={maximum} value={day.submitted} aria-label={`${day.day}: ${day.submitted} verified applications`} /><small>{new Intl.DateTimeFormat("en", { month: "short", day: "numeric", timeZone: "UTC" }).format(new Date(`${day.day}T00:00:00Z`))}</small>
+            </div>) : <p className="empty-data">Waiting for verified activity.</p>}
+          </div>
+          <p className="backfill-note"><strong>Read the trend carefully.</strong> Totals include clearly labelled historical backfill, so individual spikes are not presented as organic daily growth.</p>
+        </article>
+        <article className="dashboard-panel outcome-panel">
+          <div className="panel-heading"><div><h3>Outcome coverage</h3><p>Early signal, not a placement claim</p></div><span className="tag">{outcomeCoverage}% reported</span></div>
+          <strong className="outcome-number">{fullNumber.format(outcomesReported)}</strong>
+          <p>known outcomes from {data ? fullNumber.format(data.metrics.applicationsSubmitted) : "—"} verified applications.</p>
+          <div className="outcome-list">{data?.breakdowns.outcomes.map((entry) => <span key={entry.label}><i />{fullNumber.format(entry.count)} {entry.label}</span>)}</div>
+        </article>
+      </div>
+    </section>
+
+    <section className="dashboard-section" aria-labelledby="coverage-heading">
+      <div className="dashboard-section-heading">
+        <div><p className="eyebrow">Application coverage</p><h2 id="coverage-heading">Where the work is concentrated.</h2></div>
+        <p>ATS and seniority segments describe the mix of verified submissions. Small segments stay grouped to preserve privacy.</p>
+      </div>
+      <div className="dashboard-grid dashboard-grid-coverage">
+        <Leaderboard title="Application destinations" subtitle="Verified submissions by ATS · last 90 days" entries={data?.breakdowns.ats ?? []} />
+        <Leaderboard title="Role levels assessed" subtitle="Privacy-safe seniority segments · last 90 days" entries={data?.breakdowns.seniority ?? []} />
+      </div>
     </section>
 
     <section id="methodology" className="methodology">

--- a/site/app/components/CommunityDashboard.tsx
+++ b/site/app/components/CommunityDashboard.tsx
@@ -25,14 +25,23 @@ export function CommunityDashboard() {
 
   return <main id="main" className="dashboard page-width">
     <section className="dashboard-hero">
-      <div><p className="eyebrow">Community momentum</p><h1>The job search is moving.</h1><p>Anonymous, verified activity from Job Application Agent installations. No names, profiles, résumés, or raw identifiers.</p></div>
-      <div className={`live-status${error ? " live-status-error" : ""}`} role="status"><span />{error ? "Live feed unavailable" : loading ? "Connecting to live aggregate data" : "Live anonymous community data"}</div>
+      <div><p className="eyebrow">Aggregate product evidence</p><h1>See the work the agent is doing.</h1><p>Verified, anonymous activity from Job Application Agent installations. This page shows adoption, execution, and reported outcomes—not job listings or individual profiles.</p></div>
+      <div className="dashboard-hero-meta">
+        <div className={`live-status${error ? " live-status-error" : ""}`} role="status"><span />{error ? "Live feed unavailable" : loading ? "Connecting to live aggregate data" : "Live anonymous community data"}</div>
+        <a className="dashboard-method-link" href="#methodology">How this evidence works ↓</a>
+      </div>
     </section>
 
-    <section className="dashboard-metrics" aria-label="Community totals" aria-busy={loading}>
-      <article><strong>{data ? compactNumber.format(data.metrics.activeInstallations30d) : "—"}</strong><span>Active installations · last 30 days</span></article>
-      <article><strong>{data ? compactNumber.format(data.metrics.applicationsSubmitted) : "—"}</strong><span>Verified applications submitted</span></article>
-      <article><strong>{data ? compactNumber.format(data.metrics.jobsAssessed) : "—"}</strong><span>Jobs assessed</span></article>
+    <section className="dashboard-evidence" aria-labelledby="evidence-heading">
+      <div className="dashboard-section-heading">
+        <div><p className="eyebrow">Evidence at a glance</p><h2 id="evidence-heading">Current adoption and verified execution.</h2></div>
+        <p>Installations show recent activity. Assessed jobs show research volume. Submitted applications require a confirmed employer or ATS success state.</p>
+      </div>
+      <div className="dashboard-metrics" aria-label="Community totals" aria-busy={loading}>
+        <article><strong>{data ? compactNumber.format(data.metrics.activeInstallations30d) : "—"}</strong><span>Active installations · last 30 days</span></article>
+        <article><strong>{data ? compactNumber.format(data.metrics.applicationsSubmitted) : "—"}</strong><span>Verified applications submitted</span></article>
+        <article><strong>{data ? compactNumber.format(data.metrics.jobsAssessed) : "—"}</strong><span>Jobs assessed</span></article>
+      </div>
     </section>
 
     <section className="dashboard-grid">

--- a/site/app/components/CommunityDashboard.tsx
+++ b/site/app/components/CommunityDashboard.tsx
@@ -71,11 +71,11 @@ export function CommunityDashboard() {
     <section className="dashboard-section" aria-labelledby="coverage-heading">
       <div className="dashboard-section-heading">
         <div><p className="eyebrow">Application coverage</p><h2 id="coverage-heading">Where the work is concentrated.</h2></div>
-        <p>ATS and seniority segments describe the mix of verified submissions. Small segments stay grouped to preserve privacy.</p>
+        <p>ATS segments describe verified submission destinations. Seniority segments describe discovered roles. Small segments stay grouped to preserve privacy.</p>
       </div>
       <div className="dashboard-grid dashboard-grid-coverage">
         <Leaderboard title="Application destinations" subtitle="Verified submissions by ATS · last 90 days" entries={data?.breakdowns.ats ?? []} />
-        <Leaderboard title="Role levels assessed" subtitle="Privacy-safe seniority segments · last 90 days" entries={data?.breakdowns.seniority ?? []} />
+        <Leaderboard title="Role levels discovered" subtitle="Privacy-safe seniority segments · last 90 days" entries={data?.breakdowns.seniority ?? []} />
       </div>
     </section>
 

--- a/site/app/components/CommunityDashboard.tsx
+++ b/site/app/components/CommunityDashboard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { compactNumber, fullNumber, useCommunityStats } from "./useCommunityStats";
-import { useCommunityJobs } from "./useCommunityJobs";
 
 function Leaderboard({ title, subtitle, entries, wide = false }: { title: string; subtitle: string; entries: Array<{ label: string; count: number }>; wide?: boolean }) {
   const maximum = Math.max(1, ...entries.map((entry) => entry.count));
@@ -17,7 +16,6 @@ function Leaderboard({ title, subtitle, entries, wide = false }: { title: string
 
 export function CommunityDashboard() {
   const { data, error, loading } = useCommunityStats();
-  const communityJobs = useCommunityJobs();
   const outcomesReported = data?.breakdowns.outcomes.reduce((total, entry) => total + entry.count, 0) ?? 0;
   const outcomeCoverage = data?.metrics.applicationsSubmitted
     ? Math.round((outcomesReported / data.metrics.applicationsSubmitted) * 1000) / 10
@@ -35,22 +33,6 @@ export function CommunityDashboard() {
       <article><strong>{data ? compactNumber.format(data.metrics.activeInstallations30d) : "—"}</strong><span>Active installations · last 30 days</span></article>
       <article><strong>{data ? compactNumber.format(data.metrics.applicationsSubmitted) : "—"}</strong><span>Verified applications submitted</span></article>
       <article><strong>{data ? compactNumber.format(data.metrics.jobsAssessed) : "—"}</strong><span>Jobs assessed</span></article>
-    </section>
-
-    <section className="community-jobs dashboard-panel" aria-labelledby="community-jobs-title" aria-busy={communityJobs.loading || communityJobs.loadingMore}>
-      <div className="panel-heading">
-        <div><p className="eyebrow">Community sourcing</p><h2 id="community-jobs-title">Community job leads</h2><p>Confirmed public application links reported by agent installations and published only after maintainer review.</p></div>
-        <span className="tag">Maintainer-reviewed</span>
-      </div>
-      <p className="community-jobs-caution"><strong>Verify every lead.</strong> Community reports are not employer endorsements; check the company, role, and destination before applying.</p>
-      {communityJobs.loading ? <p className="empty-data" role="status">Loading reviewed job leads…</p>
-        : communityJobs.error && communityJobs.jobs.length === 0 ? <p className="empty-data" role="status">Reviewed job leads are temporarily unavailable.</p>
-          : communityJobs.jobs.length === 0 ? <p className="empty-data">No job leads have completed maintainer review yet.</p>
-            : <ol className="community-job-list">{communityJobs.jobs.map((job) => <li key={job.jobId}>
-              <div className="community-job-copy"><span>{job.company}</span><h3>{job.role}</h3><p>{job.applicationChannel.replaceAll("-", " ")} · {fullNumber.format(job.contributionCount)} agent {job.contributionCount === 1 ? "report" : "reports"}</p></div>
-              <div className="community-job-actions"><a className="button button-small" href={job.url} target="_blank" rel="noopener noreferrer">Open job</a><a className="text-link" href={job.providerUrl} target="_blank" rel="noopener noreferrer">Provider ↗</a></div>
-            </li>)}</ol>}
-      {communityJobs.nextCursor ? <button className="button button-secondary community-jobs-more" type="button" disabled={communityJobs.loadingMore} onClick={() => void communityJobs.loadMore()}>{communityJobs.loadingMore ? "Loading…" : "Load more reviewed jobs"}</button> : null}
     </section>
 
     <section className="dashboard-grid">

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -124,21 +124,22 @@ button, input { font: inherit; }
 .dashboard-section-heading { margin: 0 0 1.4rem; padding-top: 1.4rem; border-top: 1px solid var(--line); display: grid; grid-template-columns: minmax(0, 1fr) minmax(20rem, .7fr); align-items: end; gap: 3rem; }
 .dashboard-section-heading h2 { max-width: 40rem; margin: .55rem 0 0; font-size: clamp(2rem, 3.6vw, 3.15rem); line-height: 1; letter-spacing: -.045em; }
 .dashboard-section-heading > p { max-width: 34rem; margin: 0; color: var(--text); font-size: .95rem; line-height: 1.65; }
+.dashboard-section .dashboard-section-heading { margin-top: 4.5rem; }
 .dashboard-metrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: .8rem; }
 .dashboard-metrics article { min-height: 13rem; padding: 1.6rem; border: 1px solid var(--line); border-radius: 1rem; display: flex; flex-direction: column; justify-content: space-between; background: var(--surface); }
 .dashboard-metrics article:nth-child(2) { background: var(--blue); color: #fff; }
 .dashboard-metrics strong { font-size: clamp(3.4rem, 7vw, 5.75rem); line-height: .85; letter-spacing: -.065em; }
 .dashboard-metrics span { color: var(--text); font-size: .9rem; }
 .dashboard-metrics article:nth-child(2) span { color: #dbe4ff; }
-.dashboard-grid { margin-top: .8rem; display: grid; grid-template-columns: 1fr 1fr; gap: .8rem; }
+.dashboard-grid { display: grid; grid-template-columns: 1fr 1fr; gap: .8rem; }
+.dashboard-grid-execution { grid-template-columns: minmax(0, 1.55fr) minmax(18rem, .7fr); }
 .dashboard-panel { min-width: 0; padding: 1.6rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface); }
-.dashboard-panel-wide { grid-column: 1 / -1; }
-.activity-panel { grid-column: 1 / -1; }
 .panel-heading { display: flex; align-items: start; justify-content: space-between; gap: 1rem; }
-.panel-heading h2 { margin: 0 0 .3rem; font-size: 1.25rem; }
+.panel-heading h2, .panel-heading h3 { margin: 0 0 .3rem; font-size: 1.25rem; }
 .panel-heading p { margin: 0; color: var(--muted); font-size: .85rem; }
 .tag { flex: 0 0 auto; padding: .45rem .65rem; border-radius: 999px; background: var(--blue-soft); color: var(--blue); font: 600 .68rem var(--font-plex-mono), monospace; text-transform: uppercase; }
 .activity-chart { height: 16rem; margin-top: 1.8rem; display: flex; align-items: stretch; gap: .6rem; border-bottom: 1px solid var(--line); }
+.activity-chart-empty { height: 10rem; }
 .activity-column { min-width: 0; flex: 1; display: grid; grid-template-rows: 1.5rem 1fr 2rem; align-items: end; justify-items: center; }
 .activity-column strong { font-size: .7rem; font-variant-numeric: tabular-nums; }
 .activity-bar { width: min(70%, 2.25rem); height: 100%; min-height: .2rem; overflow: hidden; border: 0; border-radius: .35rem .35rem 0 0; background: #edf1f6; writing-mode: vertical-lr; direction: rtl; appearance: none; }
@@ -196,6 +197,7 @@ footer a { margin-left: 1.25rem; color: var(--text); }
   .dashboard-hero { grid-template-columns: 1fr; gap: 1.5rem; }
   .dashboard-hero-meta { justify-items: start; }
   .dashboard-section-heading { grid-template-columns: 1fr; gap: 1rem; }
+  .dashboard-grid-execution { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 48rem) {
@@ -214,8 +216,6 @@ footer a { margin-left: 1.25rem; color: var(--text); }
   .boundary-columns { grid-template-columns: 1fr; }
   .section, .boundary-section { padding-block: 5rem; }
   .founding-card > div:first-child, .offer-panel { padding: 2rem; }
-  .activity-panel { grid-column: auto; }
-  .dashboard-panel-wide { grid-column: auto; }
   .activity-chart { height: auto; padding-block: 1rem; display: grid; gap: .8rem; border-bottom: 0; }
   .activity-column { display: grid; grid-template-columns: 3.5rem 1fr 3rem; grid-template-rows: auto; gap: .7rem; align-items: center; justify-items: stretch; }
   .activity-column small { grid-column: 1; grid-row: 1; padding: 0; }

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -112,12 +112,18 @@ button, input { font: inherit; }
 .faq details p { max-width: 44rem; margin-bottom: 0; color: var(--text); line-height: 1.7; }
 
 .dashboard { padding-block: 3rem 6rem; }
-.dashboard-hero { padding: 3.5rem 0 2.5rem; display: flex; align-items: end; justify-content: space-between; gap: 3rem; }
-.dashboard-hero h1 { max-width: 48rem; margin: .8rem 0 1rem; font-size: clamp(3.5rem, 7vw, 6.25rem); line-height: .88; letter-spacing: -.065em; }
+.dashboard-hero { padding: 3.5rem 0 2.5rem; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: start; gap: 3rem; }
+.dashboard-hero h1 { max-width: 52rem; margin: .8rem 0 1rem; font-size: clamp(3.4rem, 6.5vw, 5.75rem); line-height: .9; letter-spacing: -.06em; }
 .dashboard-hero p:last-child { max-width: 44rem; margin: 0; color: var(--text); font-size: 1.05rem; }
+.dashboard-hero-meta { padding-top: .2rem; display: grid; justify-items: end; gap: .9rem; }
 .live-status { flex: 0 0 auto; padding: .65rem .85rem; border: 1px solid var(--line); border-radius: 999px; background: var(--surface); color: var(--text); font: 500 .72rem var(--font-plex-mono), monospace; }
 .live-status span { width: .55rem; height: .55rem; margin-right: .55rem; border-radius: 50%; display: inline-block; background: var(--green); box-shadow: 0 0 0 .3rem var(--green-soft); }
 .live-status-error span { background: var(--coral); box-shadow: 0 0 0 .3rem var(--coral-soft); }
+.dashboard-method-link { color: var(--blue); font: 600 .72rem var(--font-plex-mono), monospace; text-decoration: none; }
+.dashboard-method-link:hover { text-decoration: underline; text-underline-offset: .2rem; }
+.dashboard-section-heading { margin: 0 0 1.4rem; padding-top: 1.4rem; border-top: 1px solid var(--line); display: grid; grid-template-columns: minmax(0, 1fr) minmax(20rem, .7fr); align-items: end; gap: 3rem; }
+.dashboard-section-heading h2 { max-width: 40rem; margin: .55rem 0 0; font-size: clamp(2rem, 3.6vw, 3.15rem); line-height: 1; letter-spacing: -.045em; }
+.dashboard-section-heading > p { max-width: 34rem; margin: 0; color: var(--text); font-size: .95rem; line-height: 1.65; }
 .dashboard-metrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: .8rem; }
 .dashboard-metrics article { min-height: 13rem; padding: 1.6rem; border: 1px solid var(--line); border-radius: 1rem; display: flex; flex-direction: column; justify-content: space-between; background: var(--surface); }
 .dashboard-metrics article:nth-child(2) { background: var(--blue); color: #fff; }
@@ -187,7 +193,9 @@ footer a { margin-left: 1.25rem; color: var(--text); }
   .boundary-layout { grid-template-columns: 1fr; gap: 3rem; }
   .founding-card { grid-template-columns: 1fr; }
   .founding-card > div:first-child { padding-bottom: 2rem; }
-  .dashboard-hero { align-items: start; flex-direction: column; gap: 1.5rem; }
+  .dashboard-hero { grid-template-columns: 1fr; gap: 1.5rem; }
+  .dashboard-hero-meta { justify-items: start; }
+  .dashboard-section-heading { grid-template-columns: 1fr; gap: 1rem; }
 }
 
 @media (max-width: 48rem) {

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -126,19 +126,6 @@ button, input { font: inherit; }
 .dashboard-metrics article:nth-child(2) span { color: #dbe4ff; }
 .dashboard-grid { margin-top: .8rem; display: grid; grid-template-columns: 1fr 1fr; gap: .8rem; }
 .dashboard-panel { min-width: 0; padding: 1.6rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface); }
-.community-jobs { margin-top: .8rem; }
-.community-jobs .panel-heading h2 { margin-top: .45rem; }
-.community-jobs .panel-heading > div { max-width: 48rem; }
-.community-jobs-caution { margin: 1.25rem 0 0; padding: .85rem 1rem; border-radius: .65rem; background: var(--coral-soft); color: var(--text); font-size: .82rem; }
-.community-jobs-caution strong { color: var(--coral); }
-.community-job-list { margin: 1rem 0 0; padding: 0; list-style: none; }
-.community-job-list li { padding: 1rem 0; border-top: 1px solid var(--line); display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; }
-.community-job-copy { min-width: 0; }
-.community-job-copy > span { color: var(--blue); font: 600 .68rem var(--font-plex-mono), monospace; letter-spacing: .06em; text-transform: uppercase; }
-.community-job-copy h3 { margin: .25rem 0; overflow-wrap: anywhere; font-size: 1.05rem; }
-.community-job-copy p { margin: 0; color: var(--muted); font-size: .78rem; text-transform: capitalize; }
-.community-job-actions { flex: 0 0 auto; display: flex; align-items: center; gap: 1rem; }
-.community-jobs-more { margin-top: 1rem; }
 .dashboard-panel-wide { grid-column: 1 / -1; }
 .activity-panel { grid-column: 1 / -1; }
 .panel-heading { display: flex; align-items: start; justify-content: space-between; gap: 1rem; }

--- a/site/tests/rendered-html.spec.mjs
+++ b/site/tests/rendered-html.spec.mjs
@@ -48,8 +48,7 @@ test("server-renders the branded community dashboard", async () => {
   const html = await response.text();
   assert.match(html, /Community momentum/);
   assert.match(html, /Reported activity by day/);
-  assert.match(html, /Community job leads/);
-  assert.match(html, /maintainer-reviewed/i);
+  assert.doesNotMatch(html, /Community job leads|Open job|maintainer-reviewed/i);
   assert.match(html, /Anonymous aggregate telemetry/);
   assert.doesNotMatch(html, /Install agent|Open source on GitHub/i);
 });

--- a/site/tests/rendered-html.spec.mjs
+++ b/site/tests/rendered-html.spec.mjs
@@ -49,7 +49,9 @@ test("server-renders the branded community dashboard", async () => {
   assert.match(html, /Aggregate product evidence/);
   assert.match(html, /See the work the agent is doing/);
   assert.match(html, /Current adoption and verified execution/);
-  assert.match(html, /Reported activity by day/);
+  assert.match(html, /Activity over time, with outcomes kept in context/);
+  assert.match(html, /Verified submissions by day/);
+  assert.match(html, /Where the work is concentrated/);
   assert.doesNotMatch(html, /Community job leads|Open job|maintainer-reviewed/i);
   assert.match(html, /Anonymous aggregate telemetry/);
   assert.doesNotMatch(html, /Install agent|Open source on GitHub/i);

--- a/site/tests/rendered-html.spec.mjs
+++ b/site/tests/rendered-html.spec.mjs
@@ -52,6 +52,7 @@ test("server-renders the branded community dashboard", async () => {
   assert.match(html, /Activity over time, with outcomes kept in context/);
   assert.match(html, /Verified submissions by day/);
   assert.match(html, /Where the work is concentrated/);
+  assert.match(html, /Role levels discovered/);
   assert.match(html, /How the evidence is counted/);
   assert.doesNotMatch(html, /Community job leads|Open job|maintainer-reviewed/i);
   assert.match(html, /Anonymous aggregate telemetry/);

--- a/site/tests/rendered-html.spec.mjs
+++ b/site/tests/rendered-html.spec.mjs
@@ -46,7 +46,9 @@ test("server-renders the branded community dashboard", async () => {
   const response = await render("/community-view");
   assert.equal(response.status, 200);
   const html = await response.text();
-  assert.match(html, /Community momentum/);
+  assert.match(html, /Aggregate product evidence/);
+  assert.match(html, /See the work the agent is doing/);
+  assert.match(html, /Current adoption and verified execution/);
   assert.match(html, /Reported activity by day/);
   assert.doesNotMatch(html, /Community job leads|Open job|maintainer-reviewed/i);
   assert.match(html, /Anonymous aggregate telemetry/);

--- a/site/tests/rendered-html.spec.mjs
+++ b/site/tests/rendered-html.spec.mjs
@@ -52,6 +52,7 @@ test("server-renders the branded community dashboard", async () => {
   assert.match(html, /Activity over time, with outcomes kept in context/);
   assert.match(html, /Verified submissions by day/);
   assert.match(html, /Where the work is concentrated/);
+  assert.match(html, /How the evidence is counted/);
   assert.doesNotMatch(html, /Community job leads|Open job|maintainer-reviewed/i);
   assert.match(html, /Anonymous aggregate telemetry/);
   assert.doesNotMatch(html, /Install agent|Open source on GitHub/i);


### PR DESCRIPTION
## Summary
- remove community job discovery and job-feed requests from the public stats dashboard
- state the page purpose as aggregate evidence of adoption, execution, and reported outcomes
- organize analytics into adoption, execution, and application-coverage sections
- turn methodology into explicit counting and privacy rules
- retain community sourcing, moderation, and the public jobs API as backend capabilities

## Gstack design review
- FINDING-001: community jobs redefined the dashboard as a job board — fixed
- FINDING-002: the first screen did not state what the evidence proved — fixed
- FINDING-003: analytics read as an undifferentiated card wall — fixed
- FINDING-004: methodology read as a brand claim instead of counting rules — fixed
- Design score: C+ → A-
- AI slop score: B → A

## Verification
- npm test — 32 passed
- npm run lint — passed
- production telemetry rendered locally: 321 active installations, 1.7K verified applications, 5.2K jobs assessed
- browser verification at 1440px and 390px — no horizontal overflow
- community job text and actions — absent

## Known pre-existing issue
- npx tsc --noEmit still reports the existing Dodo checkout theme literal typing error in site/app/api/checkout/route.ts