### PR TITLE
Cloud H0: local apply loop (laptop first, Fly optional)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ coverage/
 *.tmp
 *.swp
 .gstack/
+
+# Cloud operator state (résumé, sqlite, chrome profile)
+cloud/data/
+cloud/.env

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ On Linux, profile storage uses the Secret Service via the `secret-tool` CLI. Ins
 
 Unlike macOS Keychain or Windows Credential Manager, the Linux Secret Service has no always-running system daemon: a keyring daemon (GNOME Keyring, KWallet, or similar) must be running in the user session for `secret-tool` to store or read the profile. On a desktop login this is normally already the case; on headless servers, containers, or SSH-only sessions, start one explicitly (e.g. `gnome-keyring-daemon --unlock --components=secrets`) before first use.
 
+### Laptop apply loop (this branch)
+
+The `cloud/` app on this branch runs the apply loop on your machine: discover → assess → fill → submit, with a page at `http://127.0.0.1:8787`.
+
+```bash
+cd cloud && npm install && npx playwright install chromium
+npm run local
+```
+
+Open the page, import your existing skill profile, start a round of 10. Details: [`cloud/README.md`](cloud/README.md).
+
 ## ✨ What it does
 
 | Stage | Behavior |

--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -1,0 +1,18 @@
+# Operator bind. Use fly proxy / Tailscale. Do not put this on a public hostname.
+HOST=127.0.0.1
+PORT=8787
+
+# Persistent volume (Fly) or local cloud/data
+CLOUD_DATA_DIR=./data
+JOB_APPLICATION_AGENT_STATE_DIR=./data/skill-state
+
+# LLM: Ollama on the tailnet first, then hosted API.
+OLLAMA_HOST=http://127.0.0.1:11434
+OLLAMA_MODEL=llama3.1
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-sonnet-4-20250514
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4.1-mini
+
+# Playwright
+PLAYWRIGHT_HEADLESS=1

--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -1,12 +1,12 @@
-# Operator bind. Use fly proxy / Tailscale. Do not put this on a public hostname.
+# Operator bind. Local default is 127.0.0.1. Do not put this on a public hostname.
 HOST=127.0.0.1
 PORT=8787
 
-# Persistent volume (Fly) or local cloud/data
+# Local laptop data (gitignored). Fly: mount a volume here.
 CLOUD_DATA_DIR=./data
 JOB_APPLICATION_AGENT_STATE_DIR=./data/skill-state
 
-# LLM: Ollama on the tailnet first, then hosted API.
+# LLM: Ollama on this machine first, then hosted API.
 OLLAMA_HOST=http://127.0.0.1:11434
 OLLAMA_MODEL=llama3.1
 ANTHROPIC_API_KEY=

--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/playwright:v1.55.0-noble
+
+WORKDIR /repo
+COPY . .
+WORKDIR /repo/cloud
+RUN npm install --omit=dev
+
+ENV CLOUD_DATA_DIR=/data
+ENV JOB_APPLICATION_AGENT_STATE_DIR=/data/skill-state
+ENV HOST=127.0.0.1
+ENV PORT=8787
+ENV CLOUD_EMBED_WORKER=1
+ENV PLAYWRIGHT_HEADLESS=1
+
+VOLUME ["/data"]
+EXPOSE 8787
+
+CMD ["node", "src/server.mjs"]

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,85 @@
+# Cloud apply (H0 personal dogfood)
+
+Hosted loop around the existing Agent Skill. Onboard once, start a round, leave. The worker discovers public ATS boards, scores with `scoreJob`, fills Greenhouse, and clicks Submit only when the routine-auto gate passes. `submitted` is written only after a visible thank-you page.
+
+This package is `private: true` and is **not** in the root npm `files` list. `npx job-application-agent` does not ship it.
+
+## What this is not
+
+- Not the Paisewise / Founder's Office Machine. Deploy a **new** Fly app.
+- Not a public website. Bind `127.0.0.1` and reach it with `fly proxy`, Tailscale, or WireGuard.
+- Not a second scoring system. Import `scoreJob` / `validateProfile` / `validateLedgerEntry`.
+
+## Local
+
+```bash
+cd cloud
+npm install
+cp .env.example .env
+# Point state at ./data (gitignored). Do not write candidate data into the repo.
+export CLOUD_DATA_DIR="$PWD/data"
+export JOB_APPLICATION_AGENT_STATE_DIR="$PWD/data/skill-state"
+export HOST=127.0.0.1
+export PORT=8787
+export CLOUD_EMBED_WORKER=1
+
+node src/cli.mjs onboard --profile ./profile.json --resume ./resume.pdf
+node src/cli.mjs status
+node src/server.mjs
+```
+
+Open `http://127.0.0.1:8787`. Tap **Find and apply to these**. The HTTP handler only enqueues; Playwright and `cloud llm` run in the worker.
+
+CLI:
+
+```bash
+node src/cli.mjs discover
+node src/cli.mjs round start --count 10
+node src/cli.mjs attention
+node src/cli.mjs llm assess --stdin < job.json
+```
+
+`JOB_APPLICATION_AGENT_STATE_DIR` is the skill's state dir (résumé copy, optional ledger files). Linux `secret-tool` will not work on a headless Fly box; SQLite is the profile source of truth.
+
+## LLM
+
+Tried in order, first success wins:
+
+1. Ollama on your laptop — `OLLAMA_HOST=http://<tailnet-host>:11434`. Bind Ollama to the tailnet, not `0.0.0.0`.
+2. Hosted API — `ANTHROPIC_API_KEY` (default) or `OPENAI_API_KEY`.
+3. Keyword-overlap heuristic if no provider is configured.
+
+If a provider is configured but unreachable, the job stays `pending_llm` and the rest of the round continues.
+
+Do not install Ollama on the 2 GB Fly Machine.
+
+## Fly
+
+Create a **new** app and volume. Do not reuse the Paisewise app, volume, or image.
+
+```bash
+fly apps create job-application-agent
+fly volumes create cloud_data --size 10 --app job-application-agent
+fly deploy --config cloud/fly.toml --app job-application-agent
+fly proxy 8787:8787 -a job-application-agent
+```
+
+Do not allocate a public IPv4 for the UI. Machine size: 2 shared CPUs, 2 GB RAM, `auto_stop` off while a round is running.
+
+After reviewing the first 20 assess outputs, you may set `CLOUD_ROUTINE_CHANNELS=greenhouse` so a `review` decision can Submit on that channel without `autoEligible`.
+
+## Submit gate
+
+The agent clicks Submit only when all of these hold:
+
+- `submissionMode` is `routine-auto`
+- ledger check is clean
+- score decision is `review` and (`autoEligible` or the channel is in `CLOUD_ROUTINE_CHANNELS`)
+- required fields are verified facts
+- résumé is attached
+- no login / MFA / CAPTCHA / legal / demographic / government-id / LinkedIn overlay
+- channel is on `CLOUD_SUBMIT_ALLOWLIST` (default: `greenhouse`)
+
+Otherwise the inbox shows the company URL. H0 does not ship noVNC; refill-on-open is the contract. Never click Submit a second time if confirmation is unclear.
+
+Lever and Ashby are discovered and scored, then handed off until one Greenhouse agent-submit is confirmed.

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,61 +1,44 @@
-# Cloud apply (H0 personal dogfood)
+# Cloud apply (H0)
 
-Hosted loop around the existing Agent Skill. Onboard once, start a round, leave. The worker discovers public ATS boards, scores with `scoreJob`, fills Greenhouse, and clicks Submit only when the routine-auto gate passes. `submitted` is written only after a visible thank-you page.
+Same apply loop as the skill, running as a local app on your laptop. Onboard once, start a round, leave. The worker discovers public ATS boards, scores with `scoreJob`, fills Greenhouse, and clicks Submit only when the routine-auto gate passes. `submitted` is written only after a visible thank-you page.
 
 This package is `private: true` and is **not** in the root npm `files` list. `npx job-application-agent` does not ship it.
 
-## What this is not
+## Run it on your laptop
 
-- Not the Paisewise / Founder's Office Machine. Deploy a **new** Fly app.
-- Not a public website. Bind `127.0.0.1` and reach it with `fly proxy`, Tailscale, or WireGuard.
-- Not a second scoring system. Import `scoreJob` / `validateProfile` / `validateLedgerEntry`.
-
-## Local
+Node 22+. From the repo root:
 
 ```bash
+git checkout cursor/cloud-mvp-plan-b6ff
 cd cloud
 npm install
-cp .env.example .env
-# Point state at ./data (gitignored). Do not write candidate data into the repo.
-export CLOUD_DATA_DIR="$PWD/data"
-export JOB_APPLICATION_AGENT_STATE_DIR="$PWD/data/skill-state"
-export HOST=127.0.0.1
-export PORT=8787
-export CLOUD_EMBED_WORKER=1
-
-node src/cli.mjs onboard --profile ./profile.json --resume ./resume.pdf
-node src/cli.mjs status
-node src/server.mjs
+npx playwright install chromium
+cp .env.example .env          # optional: add ANTHROPIC_API_KEY or leave blank for heuristic / Ollama
+npm run local
 ```
 
-Open `http://127.0.0.1:8787`. Tap **Find and apply to these**. The HTTP handler only enqueues; Playwright and `cloud llm` run in the worker.
+Or from the repo root after `cd cloud && npm install`: `npm run local`.
+
+Open **http://127.0.0.1:8787**. If you already onboarded the Agent Skill on this machine, click **Use my laptop skill profile**. Otherwise fill setup once and upload the PDF. Tap **Find and apply to these**.
+
+State stays in `cloud/data/` (gitignored). Chromium is local Playwright, not Fly.
 
 CLI:
 
 ```bash
-node src/cli.mjs discover
+node src/cli.mjs onboard --from-skill
+node src/cli.mjs status
 node src/cli.mjs round start --count 10
 node src/cli.mjs attention
-node src/cli.mjs llm assess --stdin < job.json
 ```
 
-`JOB_APPLICATION_AGENT_STATE_DIR` is the skill's state dir (résumé copy, optional ledger files). Linux `secret-tool` will not work on a headless Fly box; SQLite is the profile source of truth.
+Watch the browser: `PLAYWRIGHT_HEADLESS=0 npm run local`.
 
-## LLM
+Ollama on this machine is used automatically when `ollama serve` is running (`OLLAMA_HOST=http://127.0.0.1:11434`). Otherwise a hosted API key, otherwise the heuristic.
 
-Tried in order, first success wins:
+## Fly (optional later)
 
-1. Ollama on your laptop — `OLLAMA_HOST=http://<tailnet-host>:11434`. Bind Ollama to the tailnet, not `0.0.0.0`.
-2. Hosted API — `ANTHROPIC_API_KEY` (default) or `OPENAI_API_KEY`.
-3. Keyword-overlap heuristic if no provider is configured.
-
-If a provider is configured but unreachable, the job stays `pending_llm` and the rest of the round continues.
-
-Do not install Ollama on the 2 GB Fly Machine.
-
-## Fly
-
-Create a **new** app and volume. Do not reuse the Paisewise app, volume, or image.
+A **new** Fly app, not the Paisewise Machine. Bind `127.0.0.1` and use `fly proxy` — no public IPv4.
 
 ```bash
 fly apps create job-application-agent
@@ -63,8 +46,6 @@ fly volumes create cloud_data --size 10 --app job-application-agent
 fly deploy --config cloud/fly.toml --app job-application-agent
 fly proxy 8787:8787 -a job-application-agent
 ```
-
-Do not allocate a public IPv4 for the UI. Machine size: 2 shared CPUs, 2 GB RAM, `auto_stop` off while a round is running.
 
 After reviewing the first 20 assess outputs, you may set `CLOUD_ROUTINE_CHANNELS=greenhouse` so a `review` decision can Submit on that channel without `autoEligible`.
 

--- a/cloud/boards.json
+++ b/cloud/boards.json
@@ -1,0 +1,22 @@
+[
+  { "channel": "greenhouse", "slug": "airbnb", "company": "Airbnb" },
+  { "channel": "greenhouse", "slug": "gitlab", "company": "GitLab" },
+  { "channel": "greenhouse", "slug": "figma", "company": "Figma" },
+  { "channel": "greenhouse", "slug": "discord", "company": "Discord" },
+  { "channel": "greenhouse", "slug": "dropbox", "company": "Dropbox" },
+  { "channel": "greenhouse", "slug": "plaid", "company": "Plaid" },
+  { "channel": "greenhouse", "slug": "reddit", "company": "Reddit" },
+  { "channel": "greenhouse", "slug": "twilio", "company": "Twilio" },
+  { "channel": "greenhouse", "slug": "databricks", "company": "Databricks" },
+  { "channel": "greenhouse", "slug": "cloudflare", "company": "Cloudflare" },
+  { "channel": "greenhouse", "slug": "anthropic", "company": "Anthropic" },
+  { "channel": "greenhouse", "slug": "intercom", "company": "Intercom" },
+  { "channel": "greenhouse", "slug": "hashicorp", "company": "HashiCorp" },
+  { "channel": "greenhouse", "slug": "stripe", "company": "Stripe" },
+  { "channel": "lever", "slug": "netflix", "company": "Netflix" },
+  { "channel": "lever", "slug": "palantir", "company": "Palantir" },
+  { "channel": "ashby", "slug": "notion", "company": "Notion" },
+  { "channel": "ashby", "slug": "linear", "company": "Linear" },
+  { "channel": "ashby", "slug": "ramp", "company": "Ramp" },
+  { "channel": "ashby", "slug": "vercel", "company": "Vercel" }
+]

--- a/cloud/fly.toml
+++ b/cloud/fly.toml
@@ -1,0 +1,27 @@
+# New Fly app for the cloud apply loop. Do not attach this to Paisewise
+# (no shared Machine, volume, image, or hostname).
+app = "job-application-agent"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  HOST = "127.0.0.1"
+  PORT = "8787"
+  CLOUD_DATA_DIR = "/data"
+  JOB_APPLICATION_AGENT_STATE_DIR = "/data/skill-state"
+  CLOUD_EMBED_WORKER = "1"
+  PLAYWRIGHT_HEADLESS = "1"
+
+[mounts]
+  source = "cloud_data"
+  destination = "/data"
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "2gb"
+
+# No [[http_service]] and no public IPv4. Operator path:
+#   fly proxy 8787:8787 -a job-application-agent
+# then open http://127.0.0.1:8787

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "job-application-agent-cloud",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "scripts": {
+    "start": "node src/server.mjs",
+    "worker": "node src/worker.mjs",
+    "cli": "node src/cli.mjs",
+    "test": "node --test tests/*.test.mjs"
+  },
+  "dependencies": {
+    "playwright": "1.55.0"
+  }
+}

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "node src/server.mjs",
+    "local": "node src/local.mjs",
     "worker": "node src/worker.mjs",
     "cli": "node src/cli.mjs",
     "test": "node --test tests/*.test.mjs"

--- a/cloud/src/answers.mjs
+++ b/cloud/src/answers.mjs
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto';
+
+import { nowIso, openDb } from './db.mjs';
+
+export function fingerprint(question, channel = 'greenhouse') {
+  const norm = String(question || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+  return createHash('sha1').update(`${channel}|${norm}`).digest('hex');
+}
+
+export function saveAnswer({ channel, question, answer, env = process.env }) {
+  const db = openDb(env);
+  const fp = fingerprint(question, channel);
+  db.prepare(
+    `INSERT INTO answers (fingerprint, channel, question, answer, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(fingerprint) DO UPDATE SET answer = excluded.answer, updated_at = excluded.updated_at`
+  ).run(fp, channel, question, answer, nowIso());
+  return { fingerprint: fp };
+}
+
+export function lookupAnswer(question, channel = 'greenhouse', env = process.env) {
+  const row = openDb(env).prepare('SELECT answer FROM answers WHERE fingerprint = ?')
+    .get(fingerprint(question, channel));
+  return row?.answer || null;
+}
+
+export function allAnswers(env = process.env) {
+  return openDb(env).prepare('SELECT * FROM answers ORDER BY updated_at DESC').all();
+}

--- a/cloud/src/apply/applications.mjs
+++ b/cloud/src/apply/applications.mjs
@@ -1,0 +1,53 @@
+import { nowIso, openDb } from '../db.mjs';
+import { ledgerAdd, ledgerCheck } from '../skill.mjs';
+
+export function upsertApplication({ job, roundId = null, status = 'queued', env = process.env }) {
+  const db = openDb(env);
+  const existing = db.prepare('SELECT * FROM applications WHERE id = ? OR url = ?').get(job.id, job.url);
+  if (existing) {
+    db.prepare('UPDATE applications SET status = ?, round_id = COALESCE(?, round_id), updated_at = ? WHERE id = ?')
+      .run(status, roundId, nowIso(), existing.id);
+    return existing.id;
+  }
+  db.prepare(
+    `INSERT INTO applications (id, job_id, round_id, status, url, company, role, confirmation_url, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+  ).run(job.id, job.id, roundId, status, job.url, job.company, job.role, nowIso());
+  return job.id;
+}
+
+export function setApplicationStatus(id, status, extra = {}, env = process.env) {
+  openDb(env).prepare(
+    'UPDATE applications SET status = ?, confirmation_url = COALESCE(?, confirmation_url), updated_at = ? WHERE id = ?'
+  ).run(status, extra.confirmationUrl ?? null, nowIso(), id);
+}
+
+export async function markSubmitted({
+  applicationId,
+  job,
+  score = 0,
+  approval,
+  confirmationUrl,
+  confirmationExcerpt,
+  env = process.env,
+}) {
+  const check = await ledgerCheck({ id: applicationId, url: job.url, company: job.company, role: job.role }, env);
+  if (check.duplicate) return { ok: false, reason: 'duplicate' };
+  await ledgerAdd({
+    id: applicationId,
+    company: job.company,
+    role: job.role,
+    url: job.url,
+    source: job.application_channel || job.applicationChannel || 'greenhouse',
+    score: Number.isInteger(score) ? score : 0,
+    status: 'submitted',
+    submittedAt: nowIso(),
+    approval,
+    answers: { confirmation: String(confirmationExcerpt || '').slice(0, 200) },
+    employerJobId: job.employer_job_id || undefined,
+    discoverySource: job.discovery_source || 'direct-company',
+    applicationChannel: job.application_channel || undefined,
+  }, env);
+  setApplicationStatus(applicationId, 'submitted', { confirmationUrl }, env);
+  return { ok: true };
+}

--- a/cloud/src/apply/ashby.mjs
+++ b/cloud/src/apply/ashby.mjs
@@ -1,0 +1,19 @@
+import { recordHandoff } from './handoff.mjs';
+import { upsertApplication } from './applications.mjs';
+import { openDb } from '../db.mjs';
+
+export async function fillAshby({ jobId, roundId = null, env = process.env }) {
+  const job = openDb(env).prepare('SELECT * FROM jobs WHERE id = ?').get(jobId);
+  if (!job) return { skipped: true };
+  const applicationId = upsertApplication({ job, roundId, status: 'ready', env });
+  recordHandoff({
+    applicationId,
+    jobId,
+    url: job.url,
+    stage: 'application',
+    blocker: 'other',
+    instructions: 'Ashby fill is out of H0 until one Greenhouse agent-submit is confirmed. Open the apply URL yourself.',
+    env,
+  });
+  return { handedOff: true, reason: 'channel-not-implemented' };
+}

--- a/cloud/src/apply/browser.mjs
+++ b/cloud/src/apply/browser.mjs
@@ -1,0 +1,112 @@
+import { chromeProfileDir, ensureDataDirs } from '../paths.mjs';
+
+export async function withPage(env, fn) {
+  ensureDataDirs(env);
+  const { chromium } = await import('playwright');
+  const headless = env.PLAYWRIGHT_HEADLESS !== '0';
+  const context = await chromium.launchPersistentContext(chromeProfileDir(env), {
+    headless,
+    viewport: { width: 1280, height: 900 },
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+  const page = context.pages()[0] || await context.newPage();
+  try {
+    return await fn(page, context);
+  } finally {
+    await context.close();
+  }
+}
+
+export async function pageText(page) {
+  return page.evaluate(() => document.body?.innerText || '');
+}
+
+export async function fillMappedFields(page, mapped) {
+  let filled = 0;
+  for (const field of mapped) {
+    const value = field.value;
+    if (!value) continue;
+    const locator = await locateField(page, field);
+    if (!locator) continue;
+    try {
+      const type = await locator.evaluate((el) => (el.getAttribute('type') || el.tagName).toLowerCase());
+      if (type === 'checkbox' || type === 'radio') {
+        if (/^(yes|true|1|authorized)$/i.test(value)) await locator.check({ force: true }).catch(() => {});
+      } else if (type === 'select' || type === 'select-one') {
+        await locator.selectOption({ label: value }).catch(() => locator.selectOption({ value }).catch(() => {}));
+      } else {
+        await locator.fill(value, { timeout: 3000 });
+      }
+      filled += 1;
+    } catch {
+      // leftover fields become attention
+    }
+  }
+  return filled;
+}
+
+export async function uploadResume(page, resumePath) {
+  if (!resumePath) return false;
+  const input = page.locator('input[type="file"]').first();
+  if (await input.count() === 0) return false;
+  await input.setInputFiles(resumePath);
+  await page.waitForTimeout(1500);
+  return true;
+}
+
+export async function restoreVerifiedFields(page, mapped) {
+  for (const field of mapped) {
+    if (!field.value || !['firstName', 'lastName', 'email', 'phone', 'name'].includes(field.key)) continue;
+    const locator = await locateField(page, field);
+    if (!locator) continue;
+    try {
+      const current = await locator.inputValue();
+      if (current && current !== field.value) await locator.fill(field.value);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export async function clickSubmit(page) {
+  const button = page.getByRole('button', { name: /submit|send application|apply now/i }).first();
+  if (await button.count()) {
+    await button.click({ timeout: 5000 });
+    return true;
+  }
+  const fallback = page.locator('input[type="submit"], button[type="submit"]').first();
+  if (await fallback.count()) {
+    await fallback.click({ timeout: 5000 });
+    return true;
+  }
+  return false;
+}
+
+async function locateField(page, field) {
+  const label = field.label || field.name || '';
+  if (label) {
+    const byLabel = page.getByLabel(new RegExp(escapeRe(label), 'i')).first();
+    if (await byLabel.count()) return byLabel;
+  }
+  if (field.name) {
+    const byName = page.locator(`[name="${cssEscape(field.name)}"]`).first();
+    if (await byName.count()) return byName;
+  }
+  if (field.id) {
+    const byId = page.locator(`#${cssEscape(field.id)}`).first();
+    if (await byId.count()) return byId;
+  }
+  if (label) {
+    const byPlaceholder = page.getByPlaceholder(new RegExp(escapeRe(label), 'i')).first();
+    if (await byPlaceholder.count()) return byPlaceholder;
+  }
+  return null;
+}
+
+function escapeRe(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function cssEscape(value) {
+  return String(value).replace(/"/g, '\\"');
+}

--- a/cloud/src/apply/gate.mjs
+++ b/cloud/src/apply/gate.mjs
@@ -1,0 +1,37 @@
+const DEFAULT_ALLOWLIST = ['greenhouse'];
+
+export function routineChannels(env = process.env) {
+  const raw = env.CLOUD_ROUTINE_CHANNELS || '';
+  return new Set(raw.split(',').map((item) => item.trim().toLowerCase()).filter(Boolean));
+}
+
+export function submitAllowlist(env = process.env) {
+  const raw = env.CLOUD_SUBMIT_ALLOWLIST || DEFAULT_ALLOWLIST.join(',');
+  return new Set(raw.split(',').map((item) => item.trim().toLowerCase()).filter(Boolean));
+}
+
+export function evaluateSubmitGate({
+  submissionMode,
+  ledgerClean,
+  decision,
+  autoEligible,
+  channel,
+  requiredFilled,
+  resumeAttached,
+  hardStop = null,
+  confirmationAlreadyUnclear = false,
+  env = process.env,
+}) {
+  const failures = [];
+  if (submissionMode !== 'routine-auto') failures.push('review-each');
+  if (!ledgerClean) failures.push('ledger');
+  if (decision !== 'review') failures.push('decision');
+  const routine = routineChannels(env).has(channel);
+  if (!autoEligible && !routine) failures.push('not-auto-eligible');
+  if (!submitAllowlist(env).has(channel)) failures.push('channel');
+  if (!requiredFilled) failures.push('required-fields');
+  if (!resumeAttached) failures.push('resume');
+  if (hardStop) failures.push(hardStop);
+  if (confirmationAlreadyUnclear) failures.push('unclear-confirmation');
+  return { ok: failures.length === 0, failures };
+}

--- a/cloud/src/apply/greenhouse.mjs
+++ b/cloud/src/apply/greenhouse.mjs
@@ -1,0 +1,205 @@
+import { mapFields } from '../llm.mjs';
+import { getProfile } from '../skill.mjs';
+import { openDb } from '../db.mjs';
+import { enqueue } from '../queue.mjs';
+import { clickSubmit, fillMappedFields, pageText, restoreVerifiedFields, uploadResume, withPage } from './browser.mjs';
+import { evaluateSubmitGate } from './gate.mjs';
+import { recordHandoff } from './handoff.mjs';
+import { markSubmitted, setApplicationStatus, upsertApplication } from './applications.mjs';
+import { mapQuestions } from './prefill.mjs';
+import { confirmationLooksSuccessful, detectHardStops } from './signals.mjs';
+import { ledgerCheck } from '../skill.mjs';
+
+export async function fillGreenhouse({ jobId, roundId = null, env = process.env, fetchImpl = fetch }) {
+  const db = openDb(env);
+  const job = db.prepare('SELECT * FROM jobs WHERE id = ?').get(jobId);
+  if (!job) return { skipped: true, reason: 'missing-job' };
+  const stored = getProfile(env);
+  if (!stored.configured || !stored.resumePath) {
+    recordHandoff({
+      applicationId: job.id,
+      jobId,
+      url: job.url,
+      stage: 'resume',
+      blocker: 'upload',
+      instructions: 'Profile or résumé is missing. Finish onboarding.',
+      env,
+    });
+    return { handedOff: true, reason: 'profile' };
+  }
+
+  const applicationId = upsertApplication({ job, roundId, status: 'filling', env });
+  const assessment = db.prepare('SELECT * FROM assessments WHERE job_id = ?').get(jobId);
+  const questions = safeJson(job.questions_json, []);
+  const { mapped, leftover } = mapQuestions(questions, stored.profile, stored.extras, { channel: 'greenhouse', env });
+
+  if (leftover.length) {
+    const llmMapped = await mapFields({
+      labels: leftover.map((item) => item.label),
+      profile: stored.profile,
+      resumeText: stored.extras.motivationBlurb,
+      env,
+      fetchImpl,
+    });
+    for (const item of leftover) {
+      const hit = llmMapped.find((row) => row.label === item.label && row.value && row.confidence >= 0.7);
+      if (hit) mapped.push({ ...item, value: hit.value, key: 'llm', source: 'llm' });
+    }
+  }
+
+  const leftoverRequired = leftover.filter((item) => item.required && !mapped.some((row) => row.label === item.label));
+  if (leftoverRequired.length) {
+    setApplicationStatus(applicationId, 'ready', {}, env);
+    recordHandoff({
+      applicationId,
+      jobId,
+      url: job.url,
+      stage: 'questions',
+      blocker: 'judgment',
+      instructions: `Unmapped required fields: ${leftoverRequired.map((item) => item.label).join(', ')}`,
+      env,
+    });
+    return { handedOff: true, reason: 'unclear-fields' };
+  }
+
+  return withPage(env, async (page) => {
+    await page.goto(job.url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.waitForTimeout(1000);
+    const text = await pageText(page);
+    const linkedIn = /apply with linkedin/i.test(text);
+    const hardStop = detectHardStops(text, { hasLinkedInOverlay: linkedIn });
+    if (hardStop) {
+      setApplicationStatus(applicationId, 'ready', {}, env);
+      recordHandoff({
+        applicationId,
+        jobId,
+        url: job.url,
+        stage: hardStop.stage,
+        blocker: hardStop.blocker,
+        instructions: `${hardStop.reason}. Finish this on the company page, then mark it done.`,
+        env,
+      });
+      return { handedOff: true, reason: hardStop.blocker };
+    }
+
+    await fillMappedFields(page, mapped.length ? mapped : inferBasicFields(stored));
+    const resumeAttached = await uploadResume(page, stored.resumePath);
+    await restoreVerifiedFields(page, mapped.length ? mapped : inferBasicFields(stored));
+
+    const ledger = await ledgerCheck({ id: applicationId, url: job.url, company: job.company, role: job.role }, env);
+    const gate = evaluateSubmitGate({
+      submissionMode: stored.profile.submissionMode,
+      ledgerClean: !ledger.duplicate,
+      decision: assessment?.decision || 'ask',
+      autoEligible: Boolean(assessment?.auto_eligible),
+      channel: 'greenhouse',
+      requiredFilled: leftoverRequired.length === 0,
+      resumeAttached,
+      hardStop: null,
+      env,
+    });
+
+    if (!gate.ok) {
+      setApplicationStatus(applicationId, 'ready', {}, env);
+      recordHandoff({
+        applicationId,
+        jobId,
+        url: job.url,
+        stage: stored.profile.submissionMode === 'review-each' ? 'review' : 'submission',
+        blocker: stored.profile.submissionMode === 'review-each' ? 'judgment' : 'other',
+        instructions: `Filled. Submit gate blocked: ${gate.failures.join(', ')}. Open the page and press Send if you want.`,
+        env,
+      });
+      return { handedOff: true, reason: 'gate', failures: gate.failures };
+    }
+
+    enqueue('submit', { jobId, applicationId, roundId }, env);
+    setApplicationStatus(applicationId, 'ready', {}, env);
+    return { queuedSubmit: true, applicationId };
+  });
+}
+
+export async function submitGreenhouse({ jobId, applicationId, env = process.env }) {
+  const db = openDb(env);
+  const job = db.prepare('SELECT * FROM jobs WHERE id = ?').get(jobId);
+  const stored = getProfile(env);
+  const assessment = db.prepare('SELECT * FROM assessments WHERE job_id = ?').get(jobId);
+  if (!job) return { skipped: true };
+
+  return withPage(env, async (page) => {
+    await page.goto(job.url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.waitForTimeout(800);
+    const before = await pageText(page);
+    const hardStop = detectHardStops(before);
+    if (hardStop) {
+      recordHandoff({
+        applicationId,
+        jobId,
+        url: job.url,
+        stage: hardStop.stage,
+        blocker: hardStop.blocker,
+        instructions: `${hardStop.reason}. Did not click Submit.`,
+        env,
+      });
+      return { handedOff: true };
+    }
+    const clicked = await clickSubmit(page);
+    if (!clicked) {
+      recordHandoff({
+        applicationId,
+        jobId,
+        url: job.url,
+        stage: 'submission',
+        blocker: 'site-error',
+        instructions: 'Could not find a Submit control. Finish on the company page.',
+        env,
+      });
+      return { handedOff: true, reason: 'no-submit' };
+    }
+    await page.waitForTimeout(2500);
+    const after = await pageText(page);
+    const confirm = confirmationLooksSuccessful(after, page.url());
+    if (!confirm.ok) {
+      recordHandoff({
+        applicationId,
+        jobId,
+        url: page.url(),
+        stage: 'confirmation',
+        blocker: 'site-error',
+        instructions: 'Clicked Submit once. Confirmation was unclear — will not click again. Confirm or abandon from the inbox.',
+        env,
+      });
+      return { handedOff: true, reason: 'unclear-confirmation', clicked: true };
+    }
+    return markSubmitted({
+      applicationId,
+      job,
+      score: assessment?.score || 0,
+      approval: stored.profile.submissionMode === 'routine-auto' ? 'STANDING AUTHORIZATION' : 'APPROVE SUBMIT',
+      confirmationUrl: page.url(),
+      confirmationExcerpt: confirm.excerpt,
+      env,
+    });
+  });
+}
+
+function inferBasicFields(stored) {
+  const { profile, extras } = stored;
+  const parts = String(profile.name || '').split(/\s+/);
+  return [
+    { label: 'first name', key: 'firstName', value: parts[0], source: 'profile' },
+    { label: 'last name', key: 'lastName', value: parts.slice(1).join(' ') || parts[0], source: 'profile' },
+    { label: 'email', key: 'email', value: profile.email, source: 'profile' },
+    { label: 'phone', key: 'phone', value: profile.phone, source: 'profile' },
+    { label: 'linkedin', key: 'linkedin', value: profile.linkedin, source: 'profile' },
+    { label: 'how did you hear', key: 'howHeard', value: extras.howHeard, source: 'profile' },
+  ].filter((item) => item.value);
+}
+
+function safeJson(text, fallback) {
+  try {
+    return JSON.parse(text || 'null') ?? fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/cloud/src/apply/handoff.mjs
+++ b/cloud/src/apply/handoff.mjs
@@ -1,0 +1,41 @@
+import { randomUUID } from 'node:crypto';
+
+import { openAttention } from '../attention.mjs';
+import { nowIso, openDb } from '../db.mjs';
+
+export function recordHandoff({
+  applicationId,
+  jobId,
+  url,
+  stage,
+  blocker,
+  instructions,
+  env = process.env,
+}) {
+  const sessionId = `session-${randomUUID()}`;
+  // H0: noVNC is not wired. Inbox shows the apply URL; refill-on-open is the contract.
+  const liveViewUrl = url;
+  openDb(env).prepare(
+    `INSERT INTO browser_sessions (id, application_id, status, live_view_url, last_heartbeat, created_at)
+     VALUES (?, ?, 'leased', ?, ?, ?)`
+  ).run(sessionId, applicationId, liveViewUrl, nowIso(), nowIso());
+  const attentionId = openAttention({
+    applicationId,
+    jobId,
+    url,
+    stage,
+    blocker,
+    instructions,
+    liveViewUrl,
+    env,
+  });
+  return { sessionId, attentionId, liveViewUrl };
+}
+
+export function heartbeatSession(sessionId, env = process.env) {
+  openDb(env).prepare('UPDATE browser_sessions SET last_heartbeat = ? WHERE id = ?').run(nowIso(), sessionId);
+}
+
+export function releaseSession(sessionId, env = process.env) {
+  openDb(env).prepare("UPDATE browser_sessions SET status = 'released' WHERE id = ?").run(sessionId);
+}

--- a/cloud/src/apply/lever.mjs
+++ b/cloud/src/apply/lever.mjs
@@ -1,0 +1,19 @@
+import { recordHandoff } from './handoff.mjs';
+import { upsertApplication } from './applications.mjs';
+import { openDb } from '../db.mjs';
+
+export async function fillLever({ jobId, roundId = null, env = process.env }) {
+  const job = openDb(env).prepare('SELECT * FROM jobs WHERE id = ?').get(jobId);
+  if (!job) return { skipped: true };
+  const applicationId = upsertApplication({ job, roundId, status: 'ready', env });
+  recordHandoff({
+    applicationId,
+    jobId,
+    url: job.url,
+    stage: 'application',
+    blocker: 'other',
+    instructions: 'Lever fill is out of H0 until one Greenhouse agent-submit is confirmed. Open the apply URL yourself.',
+    env,
+  });
+  return { handedOff: true, reason: 'channel-not-implemented' };
+}

--- a/cloud/src/apply/prefill.mjs
+++ b/cloud/src/apply/prefill.mjs
@@ -1,0 +1,86 @@
+import { lookupAnswer } from '../answers.mjs';
+
+const SYNONYMS = [
+  { key: 'name', labels: ['full name', 'legal name', 'candidate name', 'your name'] },
+  { key: 'firstName', labels: ['first name', 'given name', 'fname', 'forename'] },
+  { key: 'lastName', labels: ['last name', 'family name', 'surname', 'lname'] },
+  { key: 'email', labels: ['email', 'e-mail', 'corporate e-mail', 'work email', 'email address'] },
+  { key: 'phone', labels: ['phone', 'mobile', 'telephone', 'phone number', 'mobile phone'] },
+  { key: 'location', labels: ['location', 'city', 'current location', 'where are you based'] },
+  { key: 'linkedin', labels: ['linkedin', 'linkedin url', 'linkedin profile'] },
+  { key: 'github', labels: ['github', 'github url', 'git hub'] },
+  { key: 'portfolio', labels: ['portfolio', 'website', 'personal website', 'personal url'] },
+  { key: 'availability', labels: ['availability', 'notice', 'notice period', 'start date', 'notice (days)'] },
+  { key: 'workAuthorization', labels: ['work authorization', 'authorized to work', 'right to work'] },
+  { key: 'authorizedWithoutSponsorship', labels: ['authorized to work without sponsorship', 'require sponsorship', 'need sponsorship'] },
+  { key: 'willingToRelocate', labels: ['willing to relocate', 'relocate', 'open to relocation'] },
+  { key: 'howHeard', labels: ['how did you hear', 'how you heard', 'how did you find'] },
+  { key: 'motivationBlurb', labels: ['why us', 'why this company', 'cover letter', 'why do you want', 'what interests you'] },
+  { key: 'currentCompensation', labels: ['current compensation', 'current salary'] },
+  { key: 'targetCompensation', labels: ['expected compensation', 'salary expectation', 'desired salary', 'compensation expectation'] },
+];
+
+export function splitName(name) {
+  const parts = String(name || '').trim().split(/\s+/);
+  if (parts.length === 0) return { firstName: '', lastName: '' };
+  if (parts.length === 1) return { firstName: parts[0], lastName: parts[0] };
+  return { firstName: parts[0], lastName: parts.slice(1).join(' ') };
+}
+
+export function normalizeLabel(label) {
+  return String(label || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+export function profileValueMap(profile = {}, extras = {}) {
+  const { firstName, lastName } = splitName(profile.name);
+  return {
+    name: profile.name,
+    firstName,
+    lastName,
+    email: profile.email,
+    phone: profile.phone,
+    location: profile.location,
+    linkedin: profile.linkedin,
+    github: profile.github,
+    portfolio: profile.portfolio,
+    availability: profile.availability,
+    workAuthorization: profile.workAuthorization,
+    authorizedWithoutSponsorship: extras.authorizedWithoutSponsorship,
+    needsSponsorship: extras.needsSponsorship,
+    willingToRelocate: extras.willingToRelocate,
+    howHeard: extras.howHeard,
+    motivationBlurb: extras.motivationBlurb,
+    currentCompensation: profile.currentCompensation,
+    targetCompensation: profile.targetCompensation,
+  };
+}
+
+export function mapLabel(label, profile, extras, { channel = 'greenhouse', env = process.env } = {}) {
+  const stored = lookupAnswer(label, channel, env);
+  if (stored) return { key: 'stored', value: stored, source: 'answer' };
+  const norm = normalizeLabel(label);
+  if (!norm) return { key: null, value: null, source: 'unclear' };
+  const values = profileValueMap(profile, extras);
+  for (const entry of SYNONYMS) {
+    if (entry.labels.some((item) => {
+      const alias = normalizeLabel(item);
+      return norm === alias || norm.includes(alias) || alias.includes(norm);
+    })) {
+      const value = values[entry.key];
+      if (value && value !== 'unclear') return { key: entry.key, value: String(value), source: 'profile' };
+    }
+  }
+  return { key: null, value: null, source: 'unclear' };
+}
+
+export function mapQuestions(questions, profile, extras, options = {}) {
+  const mapped = [];
+  const leftover = [];
+  for (const question of questions || []) {
+    const label = question.label || question.name || question.id || '';
+    const match = mapLabel(label, profile, extras, options);
+    if (match.value) mapped.push({ ...question, label, ...match });
+    else leftover.push({ ...question, label });
+  }
+  return { mapped, leftover };
+}

--- a/cloud/src/apply/signals.mjs
+++ b/cloud/src/apply/signals.mjs
@@ -1,0 +1,39 @@
+const HARD_STOPS = [
+  { blocker: 'authentication', pattern: /\b(sign in|log in|login|sso|single sign[- ]on|continue with google|continue with okta)\b/i, stage: 'application' },
+  { blocker: 'mfa', pattern: /\b(multi[- ]factor|two[- ]factor|2fa|verification code|authenticator)\b/i, stage: 'application' },
+  { blocker: 'captcha', pattern: /\b(captcha|recaptcha|hcaptcha|i am not a robot)\b/i, stage: 'application' },
+  { blocker: 'demographic', pattern: /\b(gender|ethnicity|race|veteran status|disability|sexual orientation|eeo)\b/i, stage: 'demographic' },
+  { blocker: 'government-id', pattern: /\b(social security|ssn|aadhaar|passport number|national id|government id)\b/i, stage: 'legal' },
+  { blocker: 'legal-attestation', pattern: /\b(i agree to the|terms of (use|service)|privacy policy|certify that the information)\b/i, stage: 'legal' },
+  { blocker: 'other', pattern: /\bapply with linkedin\b/i, stage: 'application' },
+];
+
+const CONFIRMATION = /\b(thank you|thanks for (applying|your application)|application (has been )?(received|submitted|sent)|successfully (submitted|applied)|we('ve| have) received your (application|submission))\b/i;
+
+export function detectHardStops(pageText, { hasLinkedInOverlay = false } = {}) {
+  if (hasLinkedInOverlay) {
+    return { blocker: 'authentication', stage: 'application', reason: 'Apply with LinkedIn overlay' };
+  }
+  const text = String(pageText || '');
+  for (const stop of HARD_STOPS) {
+    if (stop.pattern.test(text)) return { blocker: stop.blocker, stage: stop.stage, reason: `Page matched ${stop.blocker}` };
+  }
+  return null;
+}
+
+export function confirmationLooksSuccessful(pageText, url = '') {
+  const text = String(pageText || '');
+  const href = String(url || '').toLowerCase();
+  if (CONFIRMATION.test(text)) return { ok: true, excerpt: text.match(CONFIRMATION)?.[0] || 'thank-you' };
+  if (/\/(thanks|thank-you|confirmation|submitted)\b/.test(href) && /application|applied|received|thank/i.test(text)) {
+    return { ok: true, excerpt: 'confirmation-url' };
+  }
+  return { ok: false };
+}
+
+export function looksAmbiguous(pageText, kind) {
+  const text = String(pageText || '').toLowerCase();
+  if (kind === 'authorization') return /\b(authorized to work|sponsorship|visa)\b/.test(text);
+  if (kind === 'compensation') return /\b(salary|compensation|expected pay)\b/.test(text);
+  return false;
+}

--- a/cloud/src/assess.mjs
+++ b/cloud/src/assess.mjs
@@ -1,0 +1,158 @@
+import { upsertApplication } from './apply/applications.mjs';
+import { homePiles, openAttention } from './attention.mjs';
+import { nowIso, openDb } from './db.mjs';
+import { assessJob, resumeHash, resumeTextFromProfile } from './llm.mjs';
+import { enqueue } from './queue.mjs';
+import { remainingSlots } from './round.mjs';
+import { getProfile, ledgerCheck, scoreJob } from './skill.mjs';
+
+function parseLocations(value) {
+  try {
+    const parsed = JSON.parse(value || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function assessQueuedJob(jobId, { roundId = null, env = process.env, fetchImpl = fetch } = {}) {
+  const db = openDb(env);
+  const job = db.prepare('SELECT * FROM jobs WHERE id = ?').get(jobId);
+  if (!job) return { skipped: true, reason: 'missing-job' };
+
+  const stored = getProfile(env);
+  if (!stored.configured) {
+    openAttention({
+      jobId,
+      url: job.url,
+      stage: 'assessment',
+      blocker: 'judgment',
+      instructions: 'Profile is incomplete. Finish onboarding before jobs can be scored.',
+      env,
+    });
+    return { skipped: true, reason: 'profile-incomplete' };
+  }
+
+  const resumeText = resumeTextFromProfile(stored.profile, stored.extras);
+  const hash = resumeHash(`${resumeText}|${(stored.profile.skills || []).join(',')}|${stored.resumePath || ''}`);
+  const cached = db.prepare('SELECT * FROM assessments WHERE job_id = ?').get(jobId);
+  if (cached && cached.decision !== 'pending_llm') {
+    const payload = safeJson(cached.payload_json);
+    if (payload.resumeHash === hash) {
+      return { cached: true, decision: cached.decision, autoEligible: Boolean(cached.auto_eligible) };
+    }
+  }
+
+  const llm = await assessJob({
+    job,
+    resumeText,
+    profile: stored.profile,
+    env,
+    fetchImpl,
+  });
+
+  if (llm.pendingLlm) {
+    db.prepare(
+      `INSERT INTO assessments (job_id, decision, score, auto_eligible, must_have_coverage, payload_json, result_json, provider, created_at)
+       VALUES (?, 'pending_llm', NULL, 0, NULL, ?, ?, ?, ?)
+       ON CONFLICT(job_id) DO UPDATE SET
+         decision = 'pending_llm',
+         payload_json = excluded.payload_json,
+         result_json = excluded.result_json,
+         provider = excluded.provider,
+         created_at = excluded.created_at`
+    ).run(jobId, JSON.stringify({ resumeHash: hash, llm }), JSON.stringify({ decision: 'pending_llm' }), 'none', nowIso());
+    return { pendingLlm: true, jobId };
+  }
+
+  const locations = parseLocations(job.locations);
+  const scored = scoreJob({
+    title: job.title,
+    company: job.company,
+    description: job.description,
+    source: job.application_channel,
+    discoverySource: job.discovery_source,
+    applicationChannel: job.application_channel,
+    url: job.url,
+    eligibility: llm.eligibility,
+    postingStatus: llm.postingStatus,
+    seniority: llm.seniority,
+    roleFamily: llm.roleFamily,
+    workMode: llm.workMode || job.work_mode || 'unspecified',
+    locations,
+    salaryMaximum: job.salary_maximum,
+    salaryCurrency: job.salary_currency,
+    mustHaves: llm.mustHaves,
+  }, stored.profile);
+
+  const ledger = await ledgerCheck({
+    id: job.id,
+    url: job.url,
+    company: job.company,
+    role: job.role,
+  }, env);
+
+  let decision = scored.decision;
+  if (ledger.duplicate) decision = 'skip';
+
+  db.prepare(
+    `INSERT INTO assessments (job_id, decision, score, auto_eligible, must_have_coverage, payload_json, result_json, provider, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(job_id) DO UPDATE SET
+       decision = excluded.decision,
+       score = excluded.score,
+       auto_eligible = excluded.auto_eligible,
+       must_have_coverage = excluded.must_have_coverage,
+       payload_json = excluded.payload_json,
+       result_json = excluded.result_json,
+       provider = excluded.provider,
+       created_at = excluded.created_at`
+  ).run(
+    jobId,
+    decision,
+    scored.score,
+    scored.autoEligible ? 1 : 0,
+    scored.mustHaveCoverage,
+    JSON.stringify({ resumeHash: hash, llm, ledger }),
+    JSON.stringify(scored),
+    llm.provider,
+    nowIso(),
+  );
+
+  if (decision === 'ask') {
+    openAttention({
+      jobId,
+      url: job.url,
+      stage: 'assessment',
+      blocker: 'judgment',
+      instructions: `Needs a human look: ${(scored.gaps || []).join(' ') || 'score asked before apply.'}`,
+      liveViewUrl: job.url,
+      env,
+    });
+  }
+
+  if (decision === 'review' && remainingSlots(roundId, env) > 0) {
+    upsertApplication({ job, roundId, status: 'queued', env });
+    enqueue('fill', { jobId, roundId, assessmentDecision: decision }, env);
+  }
+
+  return { decision, score: scored.score, autoEligible: scored.autoEligible, provider: llm.provider };
+}
+
+export function requeuePendingLlm(env = process.env) {
+  const rows = openDb(env).prepare("SELECT job_id FROM assessments WHERE decision = 'pending_llm'").all();
+  for (const row of rows) enqueue('assess', { jobId: row.job_id }, env);
+  return rows.length;
+}
+
+export function statusSnapshot(env = process.env) {
+  return homePiles(env);
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text || '{}');
+  } catch {
+    return {};
+  }
+}

--- a/cloud/src/attention.mjs
+++ b/cloud/src/attention.mjs
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto';
+
+import { nowIso, openDb } from './db.mjs';
+import { enqueue } from './queue.mjs';
+
+const BLOCKERS = new Set([
+  'authentication', 'mfa', 'captcha', 'legal-attestation', 'demographic', 'government-id',
+  'ambiguous-authorization', 'ambiguous-compensation', 'unverifiable-claim', 'judgment',
+  'video', 'upload', 'site-error', 'other',
+]);
+const STAGES = new Set([
+  'discovery', 'assessment', 'application', 'contact', 'resume', 'questions', 'legal',
+  'demographic', 'review', 'submission', 'confirmation', 'outcome', 'answers', 'upload',
+]);
+
+export function openAttention({
+  applicationId = null,
+  jobId = null,
+  url,
+  stage,
+  blocker,
+  instructions,
+  liveViewUrl = null,
+  env = process.env,
+} = {}) {
+  if (!STAGES.has(stage)) throw new Error(`attention.stage is invalid: ${stage}`);
+  if (!BLOCKERS.has(blocker)) throw new Error(`attention.blocker is invalid: ${blocker}`);
+  const db = openDb(env);
+  const existing = db.prepare(
+    `SELECT id FROM attention WHERE status = 'open' AND blocker = ? AND IFNULL(job_id,'') = IFNULL(?, '')`
+  ).get(blocker, jobId);
+  if (existing) return existing.id;
+  const id = `attention-${randomUUID()}`;
+  db.prepare(
+    `INSERT INTO attention (id, application_id, job_id, url, stage, blocker, instructions, live_view_url, status, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', ?)`
+  ).run(id, applicationId, jobId, url, stage, blocker, instructions, liveViewUrl, nowIso());
+  return id;
+}
+
+export function listOpenAttention(env = process.env) {
+  return openDb(env).prepare(
+    `SELECT a.*, j.title AS job_title, j.company AS job_company
+     FROM attention a
+     LEFT JOIN jobs j ON j.id = a.job_id
+     WHERE a.status = 'open'
+     ORDER BY a.created_at DESC`
+  ).all();
+}
+
+export function resolveAttention(id, { note = '', resumeFill = false, env = process.env } = {}) {
+  const db = openDb(env);
+  const row = db.prepare('SELECT * FROM attention WHERE id = ?').get(id);
+  if (!row) throw new Error(`attention ${id} not found`);
+  db.prepare('UPDATE attention SET status = ?, resolved_at = ? WHERE id = ?')
+    .run(note ? `resolved:${note.slice(0, 80)}` : 'resolved', nowIso(), id);
+  if (resumeFill && row.job_id) {
+    enqueue('fill', { jobId: row.job_id, afterAttention: id }, env);
+  }
+  return { ok: true, id };
+}
+
+export function homePiles(env = process.env) {
+  const db = openDb(env);
+  const sent = db.prepare(
+    `SELECT a.id, a.status, a.confirmation_url, a.updated_at, a.company, a.role, a.url
+     FROM applications a
+     WHERE a.status IN ('submitted', 'confirmed')
+     ORDER BY a.updated_at DESC`
+  ).all();
+  const needsYou = listOpenAttention(env);
+  const working = db.prepare(
+    `SELECT a.id, a.status, a.updated_at, a.company, a.role, a.url
+     FROM applications a
+     WHERE a.status IN ('queued', 'filling', 'ready')
+     ORDER BY a.updated_at DESC`
+  ).all();
+  const queue = db.prepare(
+    `SELECT type, status, COUNT(*) AS n FROM work_queue WHERE status IN ('queued', 'running') GROUP BY type, status`
+  ).all();
+  return { sent, needsYou, working, queue };
+}

--- a/cloud/src/cli.mjs
+++ b/cloud/src/cli.mjs
@@ -7,12 +7,13 @@ import { listOpenAttention, resolveAttention } from './attention.mjs';
 import { assessJob, draftAnswer, mapFields, resumeTextFromProfile } from './llm.mjs';
 import { enqueue } from './queue.mjs';
 import { startRound } from './round.mjs';
-import { extrasFromBody, getProfile, saveProfile, storeResume } from './skill.mjs';
+import { extrasFromBody, getProfile, importFromLocalSkill, saveProfile, storeResume } from './skill.mjs';
 import { cloudStatus } from './status.mjs';
 
 function usage() {
   return `Usage:
   node src/cli.mjs status
+  node src/cli.mjs onboard --from-skill
   node src/cli.mjs onboard --profile <file.json> --resume <file.pdf>
   node src/cli.mjs discover
   node src/cli.mjs round start [--count N]
@@ -37,9 +38,10 @@ export async function runCli(argv, env = process.env) {
   const [cmd, sub] = argv;
   if (cmd === 'status' || !cmd) return cloudStatus(env);
   if (cmd === 'onboard') {
+    if (argv.includes('--from-skill')) return importFromLocalSkill(env);
     const profilePath = arg('--profile', argv);
     const resumePath = arg('--resume', argv);
-    if (!profilePath) throw new Error('onboard requires --profile');
+    if (!profilePath) throw new Error('onboard requires --from-skill or --profile');
     const raw = JSON.parse(await readFile(resolve(profilePath), 'utf8'));
     const extras = extrasFromBody(raw);
     const saved = saveProfile(raw, extras, null, env);

--- a/cloud/src/cli.mjs
+++ b/cloud/src/cli.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { listOpenAttention, resolveAttention } from './attention.mjs';
+import { assessJob, draftAnswer, mapFields, resumeTextFromProfile } from './llm.mjs';
+import { enqueue } from './queue.mjs';
+import { startRound } from './round.mjs';
+import { extrasFromBody, getProfile, saveProfile, storeResume } from './skill.mjs';
+import { cloudStatus } from './status.mjs';
+
+function usage() {
+  return `Usage:
+  node src/cli.mjs status
+  node src/cli.mjs onboard --profile <file.json> --resume <file.pdf>
+  node src/cli.mjs discover
+  node src/cli.mjs round start [--count N]
+  node src/cli.mjs attention
+  node src/cli.mjs attention resolve <id>
+  node src/cli.mjs llm assess|map-fields|draft --stdin`;
+}
+
+function arg(flag, argv) {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : null;
+}
+
+async function readStdinJson() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  return raw ? JSON.parse(raw) : {};
+}
+
+export async function runCli(argv, env = process.env) {
+  const [cmd, sub] = argv;
+  if (cmd === 'status' || !cmd) return cloudStatus(env);
+  if (cmd === 'onboard') {
+    const profilePath = arg('--profile', argv);
+    const resumePath = arg('--resume', argv);
+    if (!profilePath) throw new Error('onboard requires --profile');
+    const raw = JSON.parse(await readFile(resolve(profilePath), 'utf8'));
+    const extras = extrasFromBody(raw);
+    const saved = saveProfile(raw, extras, null, env);
+    if (resumePath) await storeResume(resolve(resumePath), env);
+    return { ok: true, configured: saved.configured, missing: saved.missing, resume: Boolean(resumePath) };
+  }
+  if (cmd === 'discover') return enqueue('discover', { source: 'cli' }, env);
+  if (cmd === 'round' && sub === 'start') return startRound(Number(arg('--count', argv) || 10), env);
+  if (cmd === 'attention' && !sub) return listOpenAttention(env);
+  if (cmd === 'attention' && sub === 'resolve') {
+    return resolveAttention(argv[2], { resumeFill: argv.includes('--resume-fill'), env });
+  }
+  if (cmd === 'llm') {
+    const input = await readStdinJson();
+    const stored = getProfile(env);
+    const resumeText = input.resumeText || resumeTextFromProfile(stored.profile || {}, stored.extras || {});
+    if (sub === 'assess') return assessJob({ job: input.job || input, resumeText, profile: stored.profile || input.profile || {}, env });
+    if (sub === 'map-fields') return mapFields({ labels: input.labels || [], profile: stored.profile || input.profile || {}, resumeText, env });
+    if (sub === 'draft') return { text: await draftAnswer({ prompt: input.prompt, aboutMe: stored.extras?.motivationBlurb || input.aboutMe, job: input.job, env }) };
+    throw new Error('llm assess|map-fields|draft');
+  }
+  throw new Error(usage());
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli(process.argv.slice(2), process.env)
+    .then((result) => {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    })
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/cloud/src/db.mjs
+++ b/cloud/src/db.mjs
@@ -1,0 +1,126 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { dataDir } from './paths.mjs';
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS profile (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  json TEXT NOT NULL,
+  motivation_blurb TEXT,
+  how_heard TEXT,
+  authorized_without_sponsorship TEXT,
+  needs_sponsorship TEXT,
+  willing_to_relocate TEXT,
+  resume_path TEXT,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS jobs (
+  id TEXT PRIMARY KEY,
+  company TEXT NOT NULL,
+  role TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  url TEXT NOT NULL UNIQUE,
+  employer_job_id TEXT,
+  application_channel TEXT NOT NULL,
+  discovery_source TEXT NOT NULL,
+  locations TEXT,
+  salary_maximum INTEGER,
+  salary_currency TEXT,
+  work_mode TEXT,
+  questions_json TEXT,
+  raw_json TEXT,
+  created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS assessments (
+  job_id TEXT PRIMARY KEY,
+  decision TEXT NOT NULL,
+  score INTEGER,
+  auto_eligible INTEGER NOT NULL DEFAULT 0,
+  must_have_coverage INTEGER,
+  payload_json TEXT NOT NULL,
+  result_json TEXT NOT NULL,
+  provider TEXT,
+  created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS applications (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL,
+  round_id TEXT,
+  status TEXT NOT NULL,
+  url TEXT NOT NULL,
+  company TEXT NOT NULL,
+  role TEXT NOT NULL,
+  confirmation_url TEXT,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS answers (
+  fingerprint TEXT PRIMARY KEY,
+  channel TEXT,
+  question TEXT NOT NULL,
+  answer TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS attention (
+  id TEXT PRIMARY KEY,
+  application_id TEXT,
+  job_id TEXT,
+  url TEXT NOT NULL,
+  stage TEXT NOT NULL,
+  blocker TEXT NOT NULL,
+  instructions TEXT NOT NULL,
+  live_view_url TEXT,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  resolved_at TEXT
+);
+CREATE TABLE IF NOT EXISTS browser_sessions (
+  id TEXT PRIMARY KEY,
+  application_id TEXT,
+  status TEXT NOT NULL,
+  live_view_url TEXT,
+  last_heartbeat TEXT,
+  created_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS work_queue (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  status TEXT NOT NULL,
+  error TEXT,
+  created_at TEXT NOT NULL,
+  started_at TEXT,
+  finished_at TEXT
+);
+CREATE TABLE IF NOT EXISTS rounds (
+  id TEXT PRIMARY KEY,
+  requested_count INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+`;
+
+let cached;
+
+export function openDb(env = process.env) {
+  if (cached && !env.CLOUD_DB_PATH && !env.CLOUD_DATA_DIR) return cached;
+  const file = env.CLOUD_DB_PATH || join(dataDir(env), 'cloud.sqlite');
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 });
+  const db = new DatabaseSync(file);
+  db.exec(SCHEMA);
+  if (!env.CLOUD_DB_PATH && !env.CLOUD_DATA_DIR) cached = db;
+  return db;
+}
+
+export function closeDb() {
+  if (cached) {
+    cached.close();
+    cached = undefined;
+  }
+}
+
+export function nowIso() {
+  return new Date().toISOString();
+}

--- a/cloud/src/discover/ashby.mjs
+++ b/cloud/src/discover/ashby.mjs
@@ -1,0 +1,26 @@
+import { canonicalJob, guessWorkMode } from './normalize.mjs';
+
+export async function fetchAshbyBoard(slug, company, fetchImpl = fetch) {
+  const response = await fetchImpl(`https://api.ashbyhq.com/posting-api/job-board/${encodeURIComponent(slug)}`);
+  if (!response.ok) throw new Error(`Ashby ${slug} returned HTTP ${response.status}.`);
+  const body = await response.json();
+  return (body.jobs || []).filter((job) => job.isListed !== false).map((job) => canonicalJob({
+    company: company || slug,
+    role: job.title,
+    title: job.title,
+    description: stripHtml(job.descriptionPlain || job.descriptionHtml || job.title),
+    url: job.jobUrl || job.applyUrl,
+    employerJobId: job.id ? `ashby:${job.id}` : null,
+    applicationChannel: 'ashby',
+    discoverySource: 'direct-company',
+    locations: [job.location, ...(job.secondaryLocations || []).map((item) => item.location)].filter(Boolean),
+    salaryMaximum: job.compensation?.max ?? null,
+    salaryCurrency: job.compensation?.currency ?? null,
+    workMode: guessWorkMode(`${job.title}\n${job.location || ''}`),
+    raw: { id: job.id },
+  }));
+}
+
+function stripHtml(value) {
+  return String(value).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/cloud/src/discover/greenhouse.mjs
+++ b/cloud/src/discover/greenhouse.mjs
@@ -1,0 +1,25 @@
+import { canonicalJob, guessWorkMode } from './normalize.mjs';
+
+export async function fetchGreenhouseBoard(slug, company, fetchImpl = fetch) {
+  const response = await fetchImpl(`https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(slug)}/jobs?content=true`);
+  if (!response.ok) throw new Error(`Greenhouse ${slug} returned HTTP ${response.status}.`);
+  const body = await response.json();
+  return (body.jobs || []).map((job) => canonicalJob({
+    company: company || slug,
+    role: job.title,
+    title: job.title,
+    description: stripHtml(job.content || job.title),
+    url: job.absolute_url,
+    employerJobId: job.id != null ? `greenhouse:${job.id}` : null,
+    applicationChannel: 'greenhouse',
+    discoverySource: 'direct-company',
+    locations: job.location?.name ? [job.location.name] : [],
+    workMode: guessWorkMode(`${job.title}\n${job.content || ''}\n${job.location?.name || ''}`),
+    questions: job.questions || null,
+    raw: { id: job.id, updated_at: job.updated_at },
+  }));
+}
+
+function stripHtml(value) {
+  return String(value).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/cloud/src/discover/index.mjs
+++ b/cloud/src/discover/index.mjs
@@ -1,0 +1,62 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { nowIso, openDb } from '../db.mjs';
+import { enqueue } from '../queue.mjs';
+import { CLOUD_ROOT } from '../paths.mjs';
+import { fetchAshbyBoard } from './ashby.mjs';
+import { fetchGreenhouseBoard } from './greenhouse.mjs';
+import { fetchLeverBoard } from './lever.mjs';
+
+export async function loadBoards(env = process.env) {
+  const file = env.CLOUD_BOARDS_PATH || join(CLOUD_ROOT, 'boards.json');
+  const boards = JSON.parse(await readFile(file, 'utf8'));
+  if (!Array.isArray(boards)) throw new Error('boards.json must be an array.');
+  return boards;
+}
+
+export async function discoverBoards({ fetchImpl = fetch, env = process.env, roundId = null } = {}) {
+  const db = openDb(env);
+  const insert = db.prepare(`INSERT INTO jobs (id, company, role, title, description, url, employer_job_id, application_channel, discovery_source, locations, salary_maximum, salary_currency, work_mode, questions_json, raw_json, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(url) DO UPDATE SET
+      description = excluded.description,
+      questions_json = excluded.questions_json`);
+  const boards = await loadBoards(env);
+  let found = 0;
+  let inserted = 0;
+  const errors = [];
+  for (const board of boards) {
+    let jobs;
+    try {
+      jobs = await fetchBoard(board, fetchImpl);
+    } catch (error) {
+      errors.push({ slug: board.slug, error: error.message });
+      continue;
+    }
+    found += jobs.length;
+    for (const job of jobs) {
+      const existed = db.prepare('SELECT id FROM jobs WHERE url = ?').get(job.url);
+      insert.run(
+        job.id, job.company, job.role, job.title, job.description, job.url, job.employerJobId,
+        job.applicationChannel, job.discoverySource, JSON.stringify(job.locations),
+        job.salaryMaximum, job.salaryCurrency, job.workMode,
+        job.questions ? JSON.stringify(job.questions) : null,
+        job.raw ? JSON.stringify(job.raw) : null,
+        nowIso(),
+      );
+      if (!existed) {
+        inserted += 1;
+        enqueue('assess', { jobId: job.id, roundId }, env);
+      }
+    }
+  }
+  return { boards: boards.length, found, inserted, errors };
+}
+
+async function fetchBoard(board, fetchImpl) {
+  if (board.channel === 'greenhouse') return fetchGreenhouseBoard(board.slug, board.company, fetchImpl);
+  if (board.channel === 'lever') return fetchLeverBoard(board.slug, board.company, fetchImpl);
+  if (board.channel === 'ashby') return fetchAshbyBoard(board.slug, board.company, fetchImpl);
+  throw new Error(`Unsupported board channel: ${board.channel}`);
+}

--- a/cloud/src/discover/lever.mjs
+++ b/cloud/src/discover/lever.mjs
@@ -1,0 +1,24 @@
+import { canonicalJob, guessWorkMode } from './normalize.mjs';
+
+export async function fetchLeverBoard(slug, company, fetchImpl = fetch) {
+  const response = await fetchImpl(`https://api.lever.co/v0/postings/${encodeURIComponent(slug)}?mode=json`);
+  if (!response.ok) throw new Error(`Lever ${slug} returned HTTP ${response.status}.`);
+  const body = await response.json();
+  return (Array.isArray(body) ? body : []).map((job) => canonicalJob({
+    company: company || slug,
+    role: job.text,
+    title: job.text,
+    description: stripHtml(job.descriptionPlain || job.description || job.text),
+    url: job.hostedUrl || job.applyUrl,
+    employerJobId: job.id ? `lever:${job.id}` : null,
+    applicationChannel: 'lever',
+    discoverySource: 'direct-company',
+    locations: job.categories?.location ? [job.categories.location] : [],
+    workMode: guessWorkMode(`${job.text}\n${job.descriptionPlain || ''}\n${job.categories?.location || ''}`),
+    raw: { id: job.id },
+  }));
+}
+
+function stripHtml(value) {
+  return String(value).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/cloud/src/discover/normalize.mjs
+++ b/cloud/src/discover/normalize.mjs
@@ -1,0 +1,43 @@
+import { createHash } from 'node:crypto';
+
+export function jobId({ company, role, employerJobId, url }) {
+  const basis = employerJobId || url;
+  const slug = `${String(company || 'company').toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${String(role || 'role').toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+  return `${slug.slice(0, 80)}-${createHash('sha1').update(String(basis)).digest('hex').slice(0, 10)}`;
+}
+
+export function guessWorkMode(text, remoteFlag) {
+  const hay = String(text || '').toLowerCase();
+  if (remoteFlag === true || /\bremote\b/.test(hay)) return 'remote';
+  if (/\bhybrid\b/.test(hay)) return 'hybrid';
+  if (/\bonsite\b|\bon-site\b|\bin office\b|\boffice\b/.test(hay)) return 'onsite';
+  return 'unspecified';
+}
+
+export function canonicalJob(input) {
+  const url = String(input.url || '').split('#')[0];
+  if (!url.startsWith('https://')) throw new Error('Job url must be https.');
+  const company = String(input.company || '').trim();
+  const role = String(input.role || input.title || '').trim();
+  const title = String(input.title || role).trim();
+  const description = String(input.description || title);
+  const applicationChannel = input.applicationChannel;
+  const employerJobId = input.employerJobId ? String(input.employerJobId) : null;
+  return {
+    id: jobId({ company, role, employerJobId, url }),
+    company,
+    role,
+    title,
+    description,
+    url,
+    employerJobId,
+    applicationChannel,
+    discoverySource: input.discoverySource || 'direct-company',
+    locations: input.locations || [],
+    salaryMaximum: input.salaryMaximum ?? null,
+    salaryCurrency: input.salaryCurrency ?? null,
+    workMode: input.workMode || guessWorkMode(`${title}\n${description}\n${(input.locations || []).join(' ')}`, input.remote),
+    questions: input.questions || null,
+    raw: input.raw || null,
+  };
+}

--- a/cloud/src/env.mjs
+++ b/cloud/src/env.mjs
@@ -1,0 +1,47 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { CLOUD_ROOT } from './paths.mjs';
+
+export function parseDotEnv(text) {
+  const out = {};
+  for (const raw of String(text || '').split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq < 1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export function loadDotEnv(filePath, env = process.env) {
+  if (!existsSync(filePath)) return env;
+  const parsed = parseDotEnv(readFileSync(filePath, 'utf8'));
+  for (const [key, value] of Object.entries(parsed)) {
+    if (env[key] == null || env[key] === '') env[key] = value;
+  }
+  return env;
+}
+
+export function applyLocalDefaults(env = process.env, { cloudRoot = CLOUD_ROOT } = {}) {
+  const data = env.CLOUD_DATA_DIR || join(cloudRoot, 'data');
+  if (!env.HOST) env.HOST = '127.0.0.1';
+  if (!env.PORT) env.PORT = '8787';
+  if (!env.CLOUD_DATA_DIR) env.CLOUD_DATA_DIR = data;
+  if (!env.JOB_APPLICATION_AGENT_STATE_DIR) env.JOB_APPLICATION_AGENT_STATE_DIR = join(data, 'skill-state');
+  if (!env.CLOUD_EMBED_WORKER) env.CLOUD_EMBED_WORKER = '1';
+  if (env.OLLAMA_HOST == null) env.OLLAMA_HOST = 'http://127.0.0.1:11434';
+  if (!env.PLAYWRIGHT_HEADLESS) env.PLAYWRIGHT_HEADLESS = '1';
+  return env;
+}
+
+export function loadLocalEnv(env = process.env, { cloudRoot = CLOUD_ROOT } = {}) {
+  loadDotEnv(join(cloudRoot, '.env'), env);
+  return applyLocalDefaults(env, { cloudRoot });
+}

--- a/cloud/src/llm.mjs
+++ b/cloud/src/llm.mjs
@@ -1,0 +1,319 @@
+/**
+ * Reader/writer only. Never decides Send.
+ *
+ * Provider order:
+ *   1. Ollama on the user's laptop (OLLAMA_HOST over Tailscale)
+ *   2. Hosted default (Anthropic, or OpenAI if ANTHROPIC_API_KEY is unset)
+ *   3. Keyword-overlap heuristic when no provider is configured
+ *
+ * If a provider is configured but unreachable, return pending_llm so the
+ * rest of the round continues.
+ */
+
+const SYSTEM = `You are a careful reader for a job-application agent.
+Return JSON only. No markdown. No extra keys.
+When you claim the résumé meets a requirement, quote the résumé text that supports it.
+If you cannot quote supporting text, use status "unclear" — never invent coverage.`;
+
+const ROLE_FAMILIES = [
+  'frontend', 'backend', 'full-stack', 'product-engineering', 'ai-ml', 'platform',
+  'infrastructure', 'mobile', 'engineering-management', 'architecture', 'security', 'data', 'other',
+];
+const SENIORITIES = ['junior', 'mid', 'senior', 'staff', 'principal', 'lead', 'manager', 'director', 'founding', 'unspecified'];
+const WORK_MODES = ['remote', 'hybrid', 'onsite', 'unspecified'];
+
+export function resumeHash(text) {
+  let h = 2166136261;
+  const s = String(text || '');
+  for (let i = 0; i < s.length; i += 1) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(16);
+}
+
+export function resumeTextFromProfile(profile = {}, extras = {}) {
+  const skills = Array.isArray(profile.skills) ? profile.skills.join(', ') : '';
+  return [
+    extras.motivationBlurb,
+    profile.name,
+    profile.workAuthorization,
+    skills,
+    profile.linkedin,
+    profile.github,
+    profile.portfolio,
+    profile.availability,
+    profile.location,
+  ].filter(Boolean).join('\n');
+}
+
+export function guessRoleFamily(title, description) {
+  const hay = `${title}\n${description}`.toLowerCase();
+  if (/\b(machine learning|ml engineer|llm|ai engineer|deep learning)\b/.test(hay)) return 'ai-ml';
+  if (/\b(full[-\s]?stack)\b/.test(hay)) return 'full-stack';
+  if (/\b(front[-\s]?end|react|vue|css)\b/.test(hay)) return 'frontend';
+  if (/\b(back[-\s]?end|api engineer|distributed)\b/.test(hay)) return 'backend';
+  if (/\b(platform)\b/.test(hay)) return 'platform';
+  if (/\b(sre|infrastructure|devops|reliability)\b/.test(hay)) return 'infrastructure';
+  if (/\b(ios|android|mobile)\b/.test(hay)) return 'mobile';
+  if (/\b(security|appsec)\b/.test(hay)) return 'security';
+  if (/\b(data engineer|analytics)\b/.test(hay)) return 'data';
+  if (/\b(engineering manager|director of engineering)\b/.test(hay)) return 'engineering-management';
+  if (/\b(product engineer|product-minded)\b/.test(hay)) return 'product-engineering';
+  return 'other';
+}
+
+export function guessSeniority(title) {
+  const hay = String(title || '').toLowerCase();
+  if (/\b(staff|principal|distinguished|fellow)\b/.test(hay)) return 'staff';
+  if (/\b(senior|sr\.?|lead)\b/.test(hay)) return 'senior';
+  if (/\b(intern|junior|jr\.?|graduate|entry)\b/.test(hay)) return 'junior';
+  if (/\b(manager|director|head of)\b/.test(hay)) return 'manager';
+  return 'mid';
+}
+
+export function heuristicAssess({ job, resumeText, profile = {} }) {
+  const hay = `${job.title || ''} ${job.description || ''}`.toLowerCase();
+  const resume = String(resumeText || '').toLowerCase();
+  const skills = Array.isArray(profile.skills) ? profile.skills : [];
+  const mustHaves = (skills.length ? skills : ['relevant experience']).map((skill) => {
+    const token = String(skill).toLowerCase();
+    const inJob = token.length >= 3 && hay.includes(token);
+    const inResume = token.length >= 3 && resume.includes(token);
+    if (inJob && inResume) {
+      const idx = resume.indexOf(token);
+      return {
+        requirement: skill,
+        status: 'met',
+        evidence: String(resumeText).slice(Math.max(0, idx - 20), idx + token.length + 40).trim(),
+      };
+    }
+    if (inJob && !inResume) return { requirement: skill, status: 'missing' };
+    if (!inJob && inResume) return { requirement: skill, status: 'partial', evidence: skill };
+    return { requirement: skill, status: 'unclear' };
+  });
+  return {
+    provider: 'heuristic',
+    pendingLlm: false,
+    eligibility: 'eligible',
+    postingStatus: 'active',
+    seniority: guessSeniority(job.title),
+    roleFamily: guessRoleFamily(job.title, job.description),
+    workMode: job.workMode || 'unspecified',
+    mustHaves,
+  };
+}
+
+function parseJsonObject(text) {
+  const raw = String(text || '').trim();
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start < 0 || end <= start) throw new Error('llm: no JSON object in response');
+  return JSON.parse(raw.slice(start, end + 1));
+}
+
+function quoteOrUnclear(assessment, resumeText) {
+  if (!assessment || typeof assessment !== 'object') return assessment;
+  const resume = String(resumeText || '');
+  const mustHaves = Array.isArray(assessment.mustHaves) ? assessment.mustHaves.map((item) => {
+    if (!item || (item.status !== 'met' && item.status !== 'partial')) return item;
+    const evidence = String(item.evidence || '').replace(/^quote:\s*/i, '').trim();
+    if (evidence.length >= 8 && resume.toLowerCase().includes(evidence.slice(0, 40).toLowerCase())) return item;
+    return { ...item, status: 'unclear', evidence: undefined };
+  }) : [];
+  return { ...assessment, mustHaves };
+}
+
+function clampEnum(value, allowed, fallback) {
+  const v = String(value || '').toLowerCase();
+  return allowed.includes(v) ? v : fallback;
+}
+
+async function ollamaAvailable(env, fetchImpl) {
+  const host = env.OLLAMA_HOST;
+  if (!host) return false;
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), 1500);
+  try {
+    const res = await fetchImpl(new URL('/api/tags', host), { signal: ac.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function ollamaComplete(prompt, env, fetchImpl) {
+  const host = env.OLLAMA_HOST;
+  const model = env.OLLAMA_MODEL || 'llama3.1';
+  const res = await fetchImpl(new URL('/api/chat', host), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model,
+      stream: false,
+      messages: [
+        { role: 'system', content: SYSTEM },
+        { role: 'user', content: prompt },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`ollama ${res.status}`);
+  const data = await res.json();
+  return data?.message?.content || '';
+}
+
+async function hostedComplete(prompt, env, fetchImpl) {
+  if (env.ANTHROPIC_API_KEY) {
+    const res = await fetchImpl('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514',
+        max_tokens: 800,
+        system: SYSTEM,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!res.ok) throw new Error(`anthropic ${res.status}`);
+    const data = await res.json();
+    return data?.content?.[0]?.text || '';
+  }
+  if (env.OPENAI_API_KEY) {
+    const res = await fetchImpl('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${env.OPENAI_API_KEY}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: env.OPENAI_MODEL || 'gpt-4.1-mini',
+        temperature: 0,
+        messages: [
+          { role: 'system', content: SYSTEM },
+          { role: 'user', content: prompt },
+        ],
+      }),
+    });
+    if (!res.ok) throw new Error(`openai ${res.status}`);
+    const data = await res.json();
+    return data?.choices?.[0]?.message?.content || '';
+  }
+  throw new Error('no hosted key');
+}
+
+function providerConfigured(env) {
+  return Boolean(env.OLLAMA_HOST || env.ANTHROPIC_API_KEY || env.OPENAI_API_KEY);
+}
+
+async function completeJson(prompt, env, fetchImpl) {
+  if (await ollamaAvailable(env, fetchImpl)) {
+    return { provider: 'ollama', data: parseJsonObject(await ollamaComplete(prompt, env, fetchImpl)) };
+  }
+  if (env.ANTHROPIC_API_KEY || env.OPENAI_API_KEY) {
+    const name = env.ANTHROPIC_API_KEY ? 'anthropic' : 'openai';
+    return { provider: name, data: parseJsonObject(await hostedComplete(prompt, env, fetchImpl)) };
+  }
+  return null;
+}
+
+function normalizeAssessment(data, job) {
+  return {
+    eligibility: clampEnum(data.eligibility, ['eligible', 'unclear', 'ineligible'], 'unclear'),
+    postingStatus: clampEnum(data.postingStatus, ['active', 'closed', 'unclear'], 'active'),
+    seniority: clampEnum(data.seniority, SENIORITIES, guessSeniority(job.title)),
+    roleFamily: clampEnum(data.roleFamily, ROLE_FAMILIES, guessRoleFamily(job.title, job.description)),
+    workMode: clampEnum(data.workMode, WORK_MODES, job.workMode || 'unspecified'),
+    mustHaves: Array.isArray(data.mustHaves) ? data.mustHaves : [],
+  };
+}
+
+export async function assessJob({ job, resumeText, profile = {}, env = process.env, fetchImpl = fetch }) {
+  const prompt = `Assess this role against the résumé.
+Return {"eligibility":"eligible|unclear|ineligible","postingStatus":"active|closed|unclear","seniority":"junior|mid|senior|staff|unspecified","roleFamily":"product-engineering|full-stack|ai-ml|backend|frontend|other","workMode":"remote|hybrid|onsite|unspecified","mustHaves":[{"requirement":"…","status":"met|partial|missing|unclear","evidence":"quote from résumé"}]}
+Title: ${job.title}
+Company: ${job.company}
+Listing:
+${String(job.description || '').slice(0, 6000)}
+Résumé:
+${String(resumeText || '').slice(0, 8000)}
+Skills: ${JSON.stringify(profile.skills || [])}`;
+
+  try {
+    const result = await completeJson(prompt, env, fetchImpl);
+    if (result) {
+      const cleaned = quoteOrUnclear(normalizeAssessment(result.data, job), resumeText);
+      return { ...cleaned, provider: result.provider, pendingLlm: false };
+    }
+  } catch {
+    if (providerConfigured(env)) {
+      return {
+        provider: 'none',
+        pendingLlm: true,
+        eligibility: 'unclear',
+        postingStatus: 'active',
+        seniority: 'unspecified',
+        roleFamily: 'other',
+        workMode: job.workMode || 'unspecified',
+        mustHaves: [],
+      };
+    }
+  }
+  if (providerConfigured(env)) {
+    return {
+      provider: 'none',
+      pendingLlm: true,
+      eligibility: 'unclear',
+      postingStatus: 'active',
+      seniority: 'unspecified',
+      roleFamily: 'other',
+      workMode: job.workMode || 'unspecified',
+      mustHaves: [],
+    };
+  }
+  return heuristicAssess({ job, resumeText, profile });
+}
+
+export async function mapFields({ labels, profile, resumeText, env = process.env, fetchImpl = fetch }) {
+  const prompt = `Map leftover application field labels to profile values.
+Return {"mappings":[{"label":"…","value":"…","confidence":0-1}]}
+Labels: ${JSON.stringify(labels)}
+Profile keys: ${JSON.stringify(Object.keys(profile || {}))}
+Résumé excerpt: ${String(resumeText || '').slice(0, 2000)}`;
+  try {
+    const result = await completeJson(prompt, env, fetchImpl);
+    if (result?.data?.mappings) return result.data.mappings;
+  } catch {
+    // leftover labels stay unclear
+  }
+  return [];
+}
+
+export async function draftAnswer({ prompt: userPrompt, aboutMe, job, env = process.env, fetchImpl = fetch }) {
+  const prompt = `Draft a short application answer in first person from the saved blurb only. Do not invent employers or years.
+Return {"text":"…"}
+Prompt: ${userPrompt}
+About me: ${aboutMe || ''}
+Role: ${job?.title || ''} at ${job?.company || ''}`;
+  try {
+    const result = await completeJson(prompt, env, fetchImpl);
+    if (result?.data?.text) return String(result.data.text);
+  } catch {
+    // no draft
+  }
+  return aboutMe ? String(aboutMe).slice(0, 600) : '';
+}
+
+export async function providerStatus(env = process.env, fetchImpl = fetch) {
+  const ollama = await ollamaAvailable(env, fetchImpl);
+  return {
+    ollama,
+    hosted: Boolean(env.ANTHROPIC_API_KEY || env.OPENAI_API_KEY),
+    heuristic: !env.OLLAMA_HOST && !env.ANTHROPIC_API_KEY && !env.OPENAI_API_KEY,
+  };
+}

--- a/cloud/src/local.mjs
+++ b/cloud/src/local.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
+
+import { loadLocalEnv } from './env.mjs';
+import { ensureDataDirs } from './paths.mjs';
+import { startServer } from './server.mjs';
+import { getProfile } from './skill.mjs';
+
+export async function startLocal(env = process.env, options = {}) {
+  const loaded = loadLocalEnv(env, options);
+  ensureDataDirs(loaded);
+  const server = startServer(loaded, { embedWorker: loaded.CLOUD_EMBED_WORKER !== '0' });
+  const { host, port } = await server.ready;
+  const status = getProfile(loaded);
+  const url = `http://${host}:${port}`;
+  return { url, host, port, configured: status.configured, resume: Boolean(status.resumePath), close: server.close };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startLocal(process.env)
+    .then((started) => {
+      const setup = started.configured && started.resume
+        ? 'Profile and résumé are ready. Start a round from the page.'
+        : 'Open the page and import your laptop skill profile, or fill setup once.';
+      process.stdout.write(`Job Application Agent (local)\n${started.url}\n${setup}\n`);
+    })
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/cloud/src/paths.mjs
+++ b/cloud/src/paths.mjs
@@ -1,0 +1,25 @@
+import { mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const CLOUD_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+export const REPO_ROOT = resolve(CLOUD_ROOT, '..');
+export const SKILL_CLI = join(REPO_ROOT, 'job-application-agent/scripts/job-application.mjs');
+
+export function dataDir(env = process.env) {
+  return resolve(env.CLOUD_DATA_DIR || join(CLOUD_ROOT, 'data'));
+}
+
+export function skillStateDir(env = process.env) {
+  return resolve(env.JOB_APPLICATION_AGENT_STATE_DIR || join(dataDir(env), 'skill-state'));
+}
+
+export function chromeProfileDir(env = process.env) {
+  return join(dataDir(env), 'chrome-profile');
+}
+
+export function ensureDataDirs(env = process.env) {
+  for (const dir of [dataDir(env), skillStateDir(env), chromeProfileDir(env), join(dataDir(env), 'confirmations')]) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+}

--- a/cloud/src/queue.mjs
+++ b/cloud/src/queue.mjs
@@ -1,0 +1,34 @@
+import { randomUUID } from 'node:crypto';
+
+import { nowIso, openDb } from './db.mjs';
+
+export function enqueue(type, payload = {}, env = process.env) {
+  const db = openDb(env);
+  const id = `job-${randomUUID()}`;
+  db.prepare(`INSERT INTO work_queue (id, type, payload_json, status, created_at) VALUES (?, ?, ?, 'queued', ?)`)
+    .run(id, type, JSON.stringify(payload), nowIso());
+  return { id, type, payload };
+}
+
+export function claimNext(types, env = process.env) {
+  const db = openDb(env);
+  const placeholders = types.map(() => '?').join(', ');
+  const row = db.prepare(`SELECT id, type, payload_json FROM work_queue WHERE status = 'queued' AND type IN (${placeholders}) ORDER BY created_at LIMIT 1`).get(...types);
+  if (!row) return null;
+  db.prepare(`UPDATE work_queue SET status = 'running', started_at = ? WHERE id = ? AND status = 'queued'`).run(nowIso(), row.id);
+  const claimed = db.prepare(`SELECT id, type, payload_json, status FROM work_queue WHERE id = ?`).get(row.id);
+  if (claimed.status !== 'running') return null;
+  return { id: claimed.id, type: claimed.type, payload: JSON.parse(claimed.payload_json) };
+}
+
+export function finish(id, error = null, env = process.env) {
+  const db = openDb(env);
+  db.prepare(`UPDATE work_queue SET status = ?, error = ?, finished_at = ? WHERE id = ?`)
+    .run(error ? 'failed' : 'done', error, nowIso(), id);
+}
+
+export function queuedCounts(env = process.env) {
+  const db = openDb(env);
+  const rows = db.prepare(`SELECT type, status, COUNT(*) AS n FROM work_queue GROUP BY type, status`).all();
+  return rows;
+}

--- a/cloud/src/round.mjs
+++ b/cloud/src/round.mjs
@@ -1,0 +1,33 @@
+import { randomUUID } from 'node:crypto';
+
+import { nowIso, openDb } from './db.mjs';
+import { enqueue } from './queue.mjs';
+
+export function startRound(count = 10, env = process.env) {
+  const requested = Math.max(1, Math.min(50, Number(count) || 10));
+  const id = `round-${randomUUID()}`;
+  openDb(env).prepare(
+    'INSERT INTO rounds (id, requested_count, status, created_at) VALUES (?, ?, ?, ?)'
+  ).run(id, requested, 'running', nowIso());
+  enqueue('discover', { roundId: id, count: requested }, env);
+  return { id, requestedCount: requested, status: 'running' };
+}
+
+export function offeredFills(roundId, env = process.env) {
+  if (!roundId) return 0;
+  const row = openDb(env).prepare(
+    `SELECT COUNT(*) AS n FROM applications WHERE round_id = ? AND status NOT IN ('abandoned')`
+  ).get(roundId);
+  return Number(row?.n || 0);
+}
+
+export function remainingSlots(roundId, env = process.env) {
+  if (!roundId) return 10;
+  const round = openDb(env).prepare('SELECT requested_count FROM rounds WHERE id = ?').get(roundId);
+  if (!round) return 0;
+  return Math.max(0, round.requested_count - offeredFills(roundId, env));
+}
+
+export function listRounds(env = process.env) {
+  return openDb(env).prepare('SELECT * FROM rounds ORDER BY created_at DESC').all();
+}

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -1,0 +1,130 @@
+import { createServer } from 'node:http';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { resolveAttention } from './attention.mjs';
+import { saveAnswer } from './answers.mjs';
+import { markSubmitted } from './apply/applications.mjs';
+import { enqueue } from './queue.mjs';
+import { startRound } from './round.mjs';
+import { extrasFromBody, getProfile, saveProfile, storeResume } from './skill.mjs';
+import { cloudStatus } from './status.mjs';
+import { openDb } from './db.mjs';
+import { ensureDataDirs, skillStateDir } from './paths.mjs';
+
+const UI_PATH = fileURLToPath(new URL('./ui.html', import.meta.url));
+
+export function startServer(env = process.env, { embedWorker = env.CLOUD_EMBED_WORKER !== '0' } = {}) {
+  ensureDataDirs(env);
+  const host = env.HOST || '127.0.0.1';
+  const port = Number(env.PORT || 8787);
+  const server = createServer((req, res) => {
+    handle(req, res, env).catch((error) => {
+      json(res, 500, { error: error.message });
+    });
+  });
+  const ready = new Promise((resolve) => {
+    server.listen(port, host, () => resolve({ host, port: server.address().port }));
+  });
+  let stopWorker = () => {};
+  if (embedWorker) {
+    import('./worker.mjs').then((mod) => mod.startWorker(env)).then((stop) => { stopWorker = stop; });
+  }
+  return {
+    ready,
+    close: () => new Promise((resolve) => {
+      stopWorker();
+      server.close(() => resolve());
+    }),
+  };
+}
+
+async function handle(req, res, env) {
+  const url = new URL(req.url, `http://${req.headers.host || '127.0.0.1'}`);
+  if (req.method === 'GET' && url.pathname === '/') {
+    const html = await readFile(UI_PATH, 'utf8');
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(html);
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/api/status') {
+    json(res, 200, await cloudStatus(env));
+    return;
+  }
+  if (req.method === 'POST' && url.pathname === '/api/onboard') {
+    const body = await readJson(req);
+    const saved = saveProfile(body.profile, extrasFromBody(body.extras || body), null, env);
+    json(res, 200, { ok: true, configured: saved.configured, missing: saved.missing });
+    return;
+  }
+  if (req.method === 'POST' && url.pathname === '/api/resume') {
+    const dest = join(skillStateDir(env), `upload-${Date.now()}.pdf`);
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    await writeFile(dest, Buffer.concat(chunks));
+    const path = await storeResume(dest, env);
+    json(res, 200, { ok: true, resumePath: Boolean(path) });
+    return;
+  }
+  if (req.method === 'POST' && url.pathname === '/api/rounds') {
+    const body = await readJson(req);
+    json(res, 202, startRound(body.count, env));
+    return;
+  }
+  if (req.method === 'POST' && url.pathname === '/api/discover') {
+    const job = enqueue('discover', { source: 'api' }, env);
+    json(res, 202, job);
+    return;
+  }
+  if (req.method === 'POST' && url.pathname.startsWith('/api/attention/') && url.pathname.endsWith('/resolve')) {
+    const id = url.pathname.split('/')[3];
+    const body = await readJson(req);
+    json(res, 200, resolveAttention(id, { note: body.note, resumeFill: Boolean(body.resumeFill), env }));
+    return;
+  }
+  if (req.method === 'POST' && url.pathname === '/api/answers') {
+    const body = await readJson(req);
+    json(res, 200, saveAnswer({ ...body, env }));
+    return;
+  }
+  if (req.method === 'POST' && url.pathname.startsWith('/api/applications/') && url.pathname.endsWith('/confirm')) {
+    const id = url.pathname.split('/')[3];
+    const body = await readJson(req);
+    const row = openDb(env).prepare('SELECT a.*, j.application_channel, j.employer_job_id, j.discovery_source FROM applications a JOIN jobs j ON j.id = a.job_id WHERE a.id = ?').get(id);
+    if (!row) {
+      json(res, 404, { error: 'application not found' });
+      return;
+    }
+    const result = await markSubmitted({
+      applicationId: id,
+      job: row,
+      score: 0,
+      approval: 'APPROVE SUBMIT',
+      confirmationUrl: body.confirmationUrl || row.url,
+      confirmationExcerpt: body.confirmationExcerpt || 'operator-confirmed',
+      env,
+    });
+    json(res, result.ok ? 200 : 409, result);
+    return;
+  }
+  json(res, 404, { error: 'not found' });
+}
+
+async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  return raw ? JSON.parse(raw) : {};
+}
+
+function json(res, status, body) {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startServer(process.env).ready.then(({ host, port }) => {
+    console.log(`cloud operator on http://${host}:${port} (use fly proxy; do not publish)`);
+  });
+}

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -8,7 +8,7 @@ import { saveAnswer } from './answers.mjs';
 import { markSubmitted } from './apply/applications.mjs';
 import { enqueue } from './queue.mjs';
 import { startRound } from './round.mjs';
-import { extrasFromBody, getProfile, saveProfile, storeResume } from './skill.mjs';
+import { extrasFromBody, getProfile, importFromLocalSkill, saveProfile, storeResume } from './skill.mjs';
 import { cloudStatus } from './status.mjs';
 import { openDb } from './db.mjs';
 import { ensureDataDirs, skillStateDir } from './paths.mjs';
@@ -56,6 +56,10 @@ async function handle(req, res, env) {
     const body = await readJson(req);
     const saved = saveProfile(body.profile, extrasFromBody(body.extras || body), null, env);
     json(res, 200, { ok: true, configured: saved.configured, missing: saved.missing });
+    return;
+  }
+  if (req.method === 'POST' && url.pathname === '/api/onboard/from-skill') {
+    json(res, 200, await importFromLocalSkill(env));
     return;
   }
   if (req.method === 'POST' && url.pathname === '/api/resume') {

--- a/cloud/src/skill.mjs
+++ b/cloud/src/skill.mjs
@@ -1,0 +1,129 @@
+import { spawn } from 'node:child_process';
+import { copyFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { scoreJob, validateLedgerEntry, validateProfile, profileStatus } from '../../job-application-agent/scripts/job-application.mjs';
+import { nowIso, openDb } from './db.mjs';
+import { SKILL_CLI, ensureDataDirs, skillStateDir } from './paths.mjs';
+
+export { scoreJob, validateLedgerEntry, validateProfile, profileStatus };
+
+export function extrasFromBody(body = {}) {
+  return {
+    motivationBlurb: body.motivationBlurb ?? body.motivation_blurb ?? '',
+    howHeard: body.howHeard ?? body.how_heard ?? 'company careers page',
+    authorizedWithoutSponsorship: body.authorizedWithoutSponsorship ?? body.authorized_without_sponsorship ?? 'unclear',
+    needsSponsorship: body.needsSponsorship ?? body.needs_sponsorship ?? 'unclear',
+    willingToRelocate: body.willingToRelocate ?? body.willing_to_relocate ?? 'unclear',
+  };
+}
+
+export function saveProfile(profileInput, extras = {}, resumePath = null, env = process.env) {
+  const profile = validateProfile(profileInput);
+  const db = openDb(env);
+  db.prepare(`INSERT INTO profile (id, json, motivation_blurb, how_heard, authorized_without_sponsorship, needs_sponsorship, willing_to_relocate, resume_path, updated_at)
+    VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      json = excluded.json,
+      motivation_blurb = excluded.motivation_blurb,
+      how_heard = excluded.how_heard,
+      authorized_without_sponsorship = excluded.authorized_without_sponsorship,
+      needs_sponsorship = excluded.needs_sponsorship,
+      willing_to_relocate = excluded.willing_to_relocate,
+      resume_path = COALESCE(excluded.resume_path, profile.resume_path),
+      updated_at = excluded.updated_at`)
+    .run(
+      JSON.stringify(profile),
+      extras.motivationBlurb ?? '',
+      extras.howHeard ?? '',
+      extras.authorizedWithoutSponsorship ?? 'unclear',
+      extras.needsSponsorship ?? 'unclear',
+      extras.willingToRelocate ?? 'unclear',
+      resumePath,
+      nowIso(),
+    );
+  return getProfile(env);
+}
+
+export function getProfile(env = process.env) {
+  const row = openDb(env).prepare('SELECT * FROM profile WHERE id = 1').get();
+  if (!row) return { configured: false, missing: ['profile'], profile: null, extras: {} };
+  const profile = JSON.parse(row.json);
+  const status = profileStatus(profile);
+  return {
+    ...status,
+    profile,
+    extras: {
+      motivationBlurb: row.motivation_blurb,
+      howHeard: row.how_heard,
+      authorizedWithoutSponsorship: row.authorized_without_sponsorship,
+      needsSponsorship: row.needs_sponsorship,
+      willingToRelocate: row.willing_to_relocate,
+    },
+    resumePath: row.resume_path,
+  };
+}
+
+export async function storeResume(sourcePath, env = process.env) {
+  ensureDataDirs(env);
+  const dest = join(skillStateDir(env), 'resume.pdf');
+  await mkdir(skillStateDir(env), { recursive: true, mode: 0o700 });
+  await copyFile(sourcePath, dest);
+  const db = openDb(env);
+  db.prepare('UPDATE profile SET resume_path = ?, updated_at = ? WHERE id = 1').run(dest, nowIso());
+  try {
+    await runSkill(['resume', 'import', dest], null, env);
+  } catch {
+    // Headless boxes may lack a keyring; the copied PDF is enough for Playwright.
+  }
+  return dest;
+}
+
+export async function runSkill(args, stdinObject = null, env = process.env) {
+  ensureDataDirs(env);
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [SKILL_CLI, ...args], {
+      env: { ...env, JOB_APPLICATION_AGENT_STATE_DIR: skillStateDir(env) },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || stdout.trim() || `skill exited ${code}`));
+        return;
+      }
+      try { resolve(JSON.parse(stdout)); }
+      catch { resolve(stdout.trim() ? { raw: stdout.trim() } : {}); }
+    });
+    if (stdinObject != null) child.stdin.end(`${JSON.stringify(stdinObject)}\n`);
+    else child.stdin.end();
+  });
+}
+
+export async function ledgerCheck(candidate, env = process.env) {
+  try {
+    return await runSkill(['ledger', 'check', '--stdin'], candidate, env);
+  } catch {
+    const db = openDb(env);
+    const dup = db.prepare(`SELECT id, status FROM applications WHERE url = ? OR id = ? LIMIT 1`)
+      .get(candidate.url, candidate.id);
+    return {
+      duplicate: Boolean(dup),
+      source: 'cloud-db',
+      existing: dup ?? null,
+    };
+  }
+}
+
+export async function ledgerAdd(entry, env = process.env) {
+  const validated = validateLedgerEntry(entry);
+  try {
+    return await runSkill(['ledger', 'add', '--stdin'], validated, env);
+  } catch (error) {
+    return { stored: 'cloud-only', warning: error.message, id: validated.id };
+  }
+}

--- a/cloud/src/skill.mjs
+++ b/cloud/src/skill.mjs
@@ -1,8 +1,10 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { copyFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { scoreJob, validateLedgerEntry, validateProfile, profileStatus } from '../../job-application-agent/scripts/job-application.mjs';
+import { createSecretStore, resolveStateDir } from '../../job-application-agent/scripts/secret-store.mjs';
 import { nowIso, openDb } from './db.mjs';
 import { SKILL_CLI, ensureDataDirs, skillStateDir } from './paths.mjs';
 
@@ -77,6 +79,50 @@ export async function storeResume(sourcePath, env = process.env) {
     // Headless boxes may lack a keyring; the copied PDF is enough for Playwright.
   }
   return dest;
+}
+
+export function hostSkillEnv(env = process.env) {
+  const host = { ...env };
+  delete host.JOB_APPLICATION_AGENT_STATE_DIR;
+  delete host.CLOUD_DATA_DIR;
+  delete host.CLOUD_DB_PATH;
+  return host;
+}
+
+export async function importLocalCandidate({
+  profile,
+  resumePath = null,
+  extras = {},
+  env = process.env,
+} = {}) {
+  if (!profile) throw new Error('No profile to import.');
+  const saved = saveProfile(profile, extrasFromBody({ ...profile, ...extras }), null, env);
+  let copiedResume = null;
+  if (resumePath && existsSync(resumePath)) copiedResume = await storeResume(resumePath, env);
+  return { ...saved, resumePath: copiedResume || saved.resumePath, imported: true };
+}
+
+export async function importFromLocalSkill(env = process.env, {
+  readProfile = null,
+  resumePath = null,
+} = {}) {
+  const host = hostSkillEnv(env);
+  let profile;
+  try {
+    const raw = readProfile
+      ? readProfile()
+      : createSecretStore({ env: host }).readProfile();
+    profile = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch (error) {
+    throw new Error(`Could not read the laptop skill profile. ${error.message}`);
+  }
+  const resume = resumePath || join(resolveStateDir({ env: host }), 'resume.pdf');
+  return importLocalCandidate({
+    profile,
+    extras: extrasFromBody(profile),
+    resumePath: existsSync(resume) ? resume : null,
+    env,
+  });
 }
 
 export async function runSkill(args, stdinObject = null, env = process.env) {

--- a/cloud/src/status.mjs
+++ b/cloud/src/status.mjs
@@ -1,0 +1,22 @@
+import { homePiles } from './attention.mjs';
+import { providerStatus } from './llm.mjs';
+import { queuedCounts } from './queue.mjs';
+import { listRounds } from './round.mjs';
+import { getProfile } from './skill.mjs';
+
+export async function cloudStatus(env = process.env, fetchImpl = fetch) {
+  const profile = getProfile(env);
+  return {
+    profile: {
+      configured: profile.configured,
+      missing: profile.missing,
+      resumePath: Boolean(profile.resumePath),
+      submissionMode: profile.profile?.submissionMode || null,
+      extras: profile.extras || {},
+    },
+    llm: await providerStatus(env, fetchImpl),
+    piles: homePiles(env),
+    queue: queuedCounts(env),
+    rounds: listRounds(env),
+  };
+}

--- a/cloud/src/ui.html
+++ b/cloud/src/ui.html
@@ -1,0 +1,257 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Job Application Agent</title>
+  <style>
+    :root {
+      --ink: #173f35;
+      --text: #486159;
+      --muted: #526b63;
+      --background: #f2e9d8;
+      --surface: #fffaf0;
+      --line: #d8ccb7;
+      --accent: #63b995;
+      --coral: #9f4d42;
+      --coral-soft: #f4e2dc;
+      --green-soft: #e5f2eb;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--background); color: var(--ink); font: 16px/1.55 ui-sans-serif, system-ui, sans-serif; }
+    header, main { width: min(56rem, calc(100% - 2rem)); margin: 0 auto; }
+    header { padding: 1.5rem 0 1rem; }
+    h1 { margin: 0; font-family: ui-serif, Georgia, serif; font-size: 1.8rem; font-weight: 500; }
+    h1 span { color: #2f755f; font-style: italic; }
+    .eyebrow { color: #2f6f5b; font: 600 .72rem/1.4 ui-monospace, monospace; letter-spacing: .1em; text-transform: uppercase; }
+    .piles { display: grid; grid-template-columns: repeat(3, 1fr); gap: .8rem; margin: 1rem 0 1.5rem; }
+    .pile { background: var(--surface); border: 1px solid var(--line); border-radius: 1rem; padding: 1rem; min-height: 8rem; }
+    .pile.needs { background: var(--coral-soft); }
+    .pile h2 { margin: 0 0 .6rem; font-size: .95rem; }
+    .pile ul { margin: 0; padding: 0; list-style: none; }
+    .pile li { padding: .4rem 0; border-top: 1px solid var(--line); font-size: .85rem; }
+    .card { background: var(--surface); border: 1px solid var(--line); border-radius: 1rem; padding: 1.1rem 1.2rem; margin-bottom: 1rem; }
+    label { display: grid; gap: .25rem; margin: .55rem 0; font-size: .85rem; color: var(--text); }
+    input, select, textarea { width: 100%; padding: .6rem .7rem; border: 1px solid var(--line); border-radius: .5rem; background: #fff; color: var(--ink); font: inherit; }
+    textarea { min-height: 6rem; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: .7rem; }
+    button { min-height: 2.75rem; padding: .6rem 1.1rem; border: 0; border-radius: 999px; background: var(--accent); color: var(--ink); font-weight: 700; cursor: pointer; }
+    button.secondary { background: var(--surface); border: 1px solid var(--line); }
+    .actions { display: flex; flex-wrap: wrap; gap: .6rem; margin-top: .8rem; }
+    .muted { color: var(--muted); font-size: .85rem; }
+    .error { color: var(--coral); }
+    a { color: inherit; }
+    @media (max-width: 720px) {
+      .piles, .row { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <p class="eyebrow">Private operator</p>
+    <h1>Keep the search <span>moving.</span></h1>
+    <p class="muted">Sent only counts after the company shows a thank-you page. This page is for fly proxy / Tailscale — not a public hostname.</p>
+  </header>
+  <main>
+    <section class="piles" id="piles">
+      <article class="pile"><h2>Sent</h2><p class="muted">Loading…</p></article>
+      <article class="pile needs"><h2>Needs you</h2><p class="muted">Loading…</p></article>
+      <article class="pile"><h2>Working</h2><p class="muted">Loading…</p></article>
+    </section>
+
+    <section class="card">
+      <h2>Start a round</h2>
+      <p class="muted" id="status-line">Checking setup…</p>
+      <div class="actions">
+        <label style="max-width:8rem">Count
+          <input id="round-count" type="number" min="1" max="50" value="10" />
+        </label>
+        <button id="start-round" type="button">Find and apply to these</button>
+      </div>
+    </section>
+
+    <section class="card" id="inbox"></section>
+
+    <section class="card">
+      <h2>Setup (once)</h2>
+      <form id="onboard">
+        <div class="row">
+          <label>Name <input name="name" required /></label>
+          <label>Email <input name="email" type="email" required /></label>
+        </div>
+        <div class="row">
+          <label>Phone <input name="phone" required /></label>
+          <label>Location <input name="location" required /></label>
+        </div>
+        <label>Work authorization <input name="workAuthorization" required placeholder="e.g. Indian citizen, no US sponsorship needed" /></label>
+        <div class="row">
+          <label>LinkedIn <input name="linkedin" /></label>
+          <label>GitHub <input name="github" /></label>
+        </div>
+        <div class="row">
+          <label>Portfolio <input name="portfolio" /></label>
+          <label>Availability <input name="availability" placeholder="30 days" /></label>
+        </div>
+        <div class="row">
+          <label>Role families <input name="roleFamilies" value="product-engineering, full-stack, ai-ml" /></label>
+          <label>Seniority <input name="seniority" value="senior, staff" /></label>
+        </div>
+        <div class="row">
+          <label>Target locations <input name="targetLocations" value="Remote, India" /></label>
+          <label>Work modes <input name="workModes" value="remote" /></label>
+        </div>
+        <label>Skills <input name="skills" value="TypeScript, Python, React" /></label>
+        <label>About me / why I am looking
+          <textarea name="motivationBlurb" placeholder="100–150 words you wrote. Used for why-us drafts."></textarea>
+        </label>
+        <div class="row">
+          <label>Send for me?
+            <select name="submissionMode">
+              <option value="routine-auto">Send for me when the form is routine</option>
+              <option value="review-each">I will press Send on every job</option>
+            </select>
+          </label>
+          <label>Authorized without sponsorship
+            <select name="authorizedWithoutSponsorship">
+              <option value="unclear">unclear</option>
+              <option value="yes">yes</option>
+              <option value="no">no</option>
+            </select>
+          </label>
+        </div>
+        <div class="row">
+          <label>Needs sponsorship
+            <select name="needsSponsorship">
+              <option value="unclear">unclear</option>
+              <option value="yes">yes</option>
+              <option value="no">no</option>
+            </select>
+          </label>
+          <label>Willing to relocate
+            <select name="willingToRelocate">
+              <option value="unclear">unclear</option>
+              <option value="yes">yes</option>
+              <option value="no">no</option>
+            </select>
+          </label>
+        </div>
+        <label>Résumé PDF <input name="resume" type="file" accept="application/pdf" /></label>
+        <div class="actions">
+          <button type="submit">Save profile</button>
+        </div>
+        <p class="muted" id="onboard-msg"></p>
+      </form>
+    </section>
+  </main>
+  <script>
+    async function api(path, options) {
+      const res = await fetch(path, options);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || res.statusText);
+      return data;
+    }
+    function list(items, empty) {
+      if (!items?.length) return `<p class="muted">${empty}</p>`;
+      return `<ul>${items.map((item) => `<li><strong>${item.company || item.job_company || ''}</strong> ${item.role || item.job_title || item.blocker || ''}<br><a href="${item.url || item.job_url || '#'}" target="_blank" rel="noreferrer">${item.url || item.instructions || ''}</a></li>`).join('')}</ul>`;
+    }
+    async function refresh() {
+      const status = await api('/api/status');
+      const piles = status.piles;
+      document.getElementById('piles').innerHTML = `
+        <article class="pile"><h2>Sent (${piles.sent.length})</h2>${list(piles.sent, 'Nothing confirmed yet.')}</article>
+        <article class="pile needs"><h2>Needs you (${piles.needsYou.length})</h2>${list(piles.needsYou, 'Quiet.')}</article>
+        <article class="pile"><h2>Working (${piles.working.length})</h2>${list(piles.working, 'Idle.')}</article>`;
+      const ready = status.profile.configured && status.profile.resumePath;
+      document.getElementById('status-line').textContent = ready
+        ? `Ready. Mode: ${status.profile.submissionMode}. LLM: ${status.llm.ollama ? 'Ollama' : status.llm.hosted ? 'hosted' : 'heuristic'}.`
+        : `Setup needed. Missing: ${(status.profile.missing || []).join(', ') || 'résumé'}.`;
+      document.getElementById('inbox').innerHTML = piles.needsYou.length
+        ? `<h2>Inbox</h2>${piles.needsYou.map((item) => `
+            <p><strong>${item.job_company || ''}</strong> — ${item.blocker}<br>${item.instructions || ''}
+            <br><a href="${item.live_view_url || item.url}" target="_blank" rel="noreferrer">Open the company page</a></p>
+            <div class="actions">
+              <button class="secondary" data-resolve="${item.id}" data-resume="1">I finished — keep going</button>
+              <button class="secondary" data-resolve="${item.id}">Dismiss</button>
+            </div>`).join('')}`
+        : `<h2>Inbox</h2><p class="muted">Nothing needs you.</p>`;
+    }
+    document.getElementById('start-round').onclick = async () => {
+      try {
+        await api('/api/rounds', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ count: Number(document.getElementById('round-count').value || 10) }),
+        });
+        await refresh();
+      } catch (error) {
+        document.getElementById('status-line').textContent = error.message;
+        document.getElementById('status-line').className = 'error';
+      }
+    };
+    document.getElementById('inbox').onclick = async (event) => {
+      const id = event.target.dataset.resolve;
+      if (!id) return;
+      await api(`/api/attention/${id}/resolve`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ resumeFill: event.target.dataset.resume === '1' }),
+      });
+      await refresh();
+    };
+    document.getElementById('onboard').onsubmit = async (event) => {
+      event.preventDefault();
+      const form = event.target;
+      const csv = (value) => String(value || '').split(',').map((s) => s.trim()).filter(Boolean);
+      const profile = {
+        name: form.name.value,
+        email: form.email.value,
+        phone: form.phone.value,
+        location: form.location.value,
+        workAuthorization: form.workAuthorization.value,
+        linkedin: form.linkedin.value || undefined,
+        github: form.github.value || undefined,
+        portfolio: form.portfolio.value || undefined,
+        availability: form.availability.value || undefined,
+        roleFamilies: csv(form.roleFamilies.value),
+        seniority: csv(form.seniority.value),
+        targetLocations: csv(form.targetLocations.value),
+        workModes: csv(form.workModes.value),
+        skills: csv(form.skills.value),
+        submissionMode: form.submissionMode.value,
+        yearsExperience: 10,
+        autoSubmitMinScore: 80,
+        manualReviewMinScore: 70,
+        minMustHaveCoverage: 70,
+      };
+      const extras = {
+        motivationBlurb: form.motivationBlurb.value,
+        howHeard: 'company careers page',
+        authorizedWithoutSponsorship: form.authorizedWithoutSponsorship.value,
+        needsSponsorship: form.needsSponsorship.value,
+        willingToRelocate: form.willingToRelocate.value,
+      };
+      const msg = document.getElementById('onboard-msg');
+      try {
+        await api('/api/onboard', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ profile, extras }),
+        });
+        const file = form.resume.files[0];
+        if (file) {
+          await fetch('/api/resume', { method: 'POST', headers: { 'content-type': 'application/pdf' }, body: file });
+        }
+        msg.textContent = 'Saved.';
+        await refresh();
+      } catch (error) {
+        msg.textContent = error.message;
+        msg.className = 'error';
+      }
+    };
+    refresh().catch((error) => {
+      document.getElementById('status-line').textContent = error.message;
+    });
+    setInterval(() => refresh().catch(() => {}), 8000);
+  </script>
+</body>
+</html>

--- a/cloud/src/ui.html
+++ b/cloud/src/ui.html
@@ -50,7 +50,7 @@
   <header>
     <p class="eyebrow">Private operator</p>
     <h1>Keep the search <span>moving.</span></h1>
-    <p class="muted">Sent only counts after the company shows a thank-you page. This page is for fly proxy / Tailscale — not a public hostname.</p>
+    <p class="muted">Runs on this computer at 127.0.0.1. Sent only counts after the company shows a thank-you page.</p>
   </header>
   <main>
     <section class="piles" id="piles">
@@ -74,6 +74,11 @@
 
     <section class="card">
       <h2>Setup (once)</h2>
+      <p class="muted">If you already onboarded the Agent Skill on this laptop, import that profile and résumé. Otherwise fill the form below.</p>
+      <div class="actions">
+        <button id="import-skill" class="secondary" type="button">Use my laptop skill profile</button>
+      </div>
+      <p class="muted" id="import-msg"></p>
       <form id="onboard">
         <div class="row">
           <label>Name <input name="name" required /></label>
@@ -197,6 +202,18 @@
         body: JSON.stringify({ resumeFill: event.target.dataset.resume === '1' }),
       });
       await refresh();
+    };
+    document.getElementById('import-skill').onclick = async () => {
+      const msg = document.getElementById('import-msg');
+      try {
+        await api('/api/onboard/from-skill', { method: 'POST' });
+        msg.textContent = 'Imported from this laptop’s skill profile.';
+        msg.className = 'muted';
+        await refresh();
+      } catch (error) {
+        msg.textContent = error.message;
+        msg.className = 'error';
+      }
     };
     document.getElementById('onboard').onsubmit = async (event) => {
       event.preventDefault();

--- a/cloud/src/worker.mjs
+++ b/cloud/src/worker.mjs
@@ -1,0 +1,72 @@
+import { pathToFileURL } from 'node:url';
+
+import { assessQueuedJob, requeuePendingLlm } from './assess.mjs';
+import { fillAshby } from './apply/ashby.mjs';
+import { fillGreenhouse, submitGreenhouse } from './apply/greenhouse.mjs';
+import { fillLever } from './apply/lever.mjs';
+import { openDb } from './db.mjs';
+import { discoverBoards } from './discover/index.mjs';
+import { claimNext, finish } from './queue.mjs';
+
+const TYPES = ['discover', 'assess', 'fill', 'submit', 'handoff'];
+
+export async function drainOnce(env = process.env, { fetchImpl = fetch } = {}) {
+  const job = claimNext(TYPES, env);
+  if (!job) return null;
+  try {
+    const result = await handle(job, env, fetchImpl);
+    finish(job.id, null, env);
+    return { id: job.id, type: job.type, result };
+  } catch (error) {
+    finish(job.id, error.message, env);
+    return { id: job.id, type: job.type, error: error.message };
+  }
+}
+
+async function handle(job, env, fetchImpl) {
+  if (job.type === 'discover') {
+    return discoverBoards({ fetchImpl, env, roundId: job.payload.roundId });
+  }
+  if (job.type === 'assess') {
+    return assessQueuedJob(job.payload.jobId, { roundId: job.payload.roundId, env, fetchImpl });
+  }
+  if (job.type === 'fill') {
+    const row = openDb(env).prepare('SELECT application_channel FROM jobs WHERE id = ?').get(job.payload.jobId);
+    const channel = row?.application_channel;
+    if (channel === 'greenhouse') return fillGreenhouse({ ...job.payload, env, fetchImpl });
+    if (channel === 'lever') return fillLever({ ...job.payload, env });
+    if (channel === 'ashby') return fillAshby({ ...job.payload, env });
+    throw new Error(`Unsupported fill channel: ${channel}`);
+  }
+  if (job.type === 'submit') {
+    return submitGreenhouse({ ...job.payload, env });
+  }
+  if (job.type === 'handoff') {
+    return { ok: true, note: 'Handoff is operator-driven. Use the inbox.' };
+  }
+  throw new Error(`Unknown job type: ${job.type}`);
+}
+
+export async function startWorker(env = process.env) {
+  const interval = Number(env.CLOUD_WORKER_INTERVAL_MS || 1500);
+  let pendingSweep = 0;
+  const tick = async () => {
+    try {
+      pendingSweep += 1;
+      if (pendingSweep % 20 === 0) requeuePendingLlm(env);
+      await drainOnce(env);
+    } catch (error) {
+      console.error(`[worker] ${error.message}`);
+    }
+  };
+  await tick();
+  const timer = setInterval(tick, interval);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startWorker(process.env).then(() => {
+    console.log('cloud worker listening for queue jobs');
+  });
+}

--- a/cloud/tests/assess.test.mjs
+++ b/cloud/tests/assess.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { assessQueuedJob } from '../src/assess.mjs';
+import { nowIso, openDb } from '../src/db.mjs';
+import { queuedCounts } from '../src/queue.mjs';
+import { startRound } from '../src/round.mjs';
+import { saveProfile } from '../src/skill.mjs';
+import { isolatedEnv, sampleExtras, sampleProfile } from './helpers.mjs';
+
+function insertJob(env, overrides = {}) {
+  const db = openDb(env);
+  const job = {
+    id: 'acme-senior-product-aaaaaaaaaa',
+    company: 'Example AI',
+    role: 'Senior Product Engineer',
+    title: 'Senior Product Engineer',
+    description: 'Build AI products with TypeScript, React and Python. Remote Canada.',
+    url: 'https://job-boards.greenhouse.io/example/jobs/1',
+    employer_job_id: 'greenhouse:1',
+    application_channel: 'greenhouse',
+    discovery_source: 'direct-company',
+    locations: JSON.stringify(['Remote', 'Canada']),
+    salary_maximum: null,
+    salary_currency: null,
+    work_mode: 'remote',
+    questions_json: null,
+    raw_json: null,
+    created_at: nowIso(),
+    ...overrides,
+  };
+  db.prepare(`INSERT INTO jobs (id, company, role, title, description, url, employer_job_id, application_channel, discovery_source, locations, salary_maximum, salary_currency, work_mode, questions_json, raw_json, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    job.id, job.company, job.role, job.title, job.description, job.url, job.employer_job_id,
+    job.application_channel, job.discovery_source, job.locations, job.salary_maximum,
+    job.salary_currency, job.work_mode, job.questions_json, job.raw_json, job.created_at,
+  );
+  return job;
+}
+
+test('assess scores with the skill and enqueues fill on review', async (t) => {
+  const env = await isolatedEnv(t);
+  saveProfile(sampleProfile, sampleExtras, '/tmp/resume.pdf', env);
+  const job = insertJob(env);
+  const round = startRound(10, env);
+  const result = await assessQueuedJob(job.id, { roundId: round.id, env });
+  assert.equal(result.pendingLlm, undefined);
+  assert.ok(['review', 'ask', 'skip', 'exclude'].includes(result.decision));
+  const row = openDb(env).prepare('SELECT * FROM assessments WHERE job_id = ?').get(job.id);
+  assert.equal(row.provider, 'heuristic');
+  if (result.decision === 'review') {
+    assert.ok(queuedCounts(env).some((item) => item.type === 'fill'));
+  }
+});
+
+test('empty must-haves never reach fill: missing skills become ask', async (t) => {
+  const env = await isolatedEnv(t);
+  saveProfile({ ...sampleProfile, skills: [] }, sampleExtras, '/tmp/resume.pdf', env);
+  const job = insertJob(env, {
+    id: 'acme-other-bbbbbbbbbb',
+    url: 'https://job-boards.greenhouse.io/example/jobs/2',
+    description: 'A vague posting about collaboration and culture.',
+    title: 'Senior Mystery Role',
+    role: 'Senior Mystery Role',
+    work_mode: 'unspecified',
+  });
+  const result = await assessQueuedJob(job.id, { env });
+  assert.ok(['ask', 'skip'].includes(result.decision));
+  assert.ok(!queuedCounts(env).some((item) => item.type === 'fill' && item.status === 'queued'));
+});

--- a/cloud/tests/discover.test.mjs
+++ b/cloud/tests/discover.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { writeFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { discoverBoards } from '../src/discover/index.mjs';
+import { openDb } from '../src/db.mjs';
+import { queuedCounts } from '../src/queue.mjs';
+import { isolatedEnv } from './helpers.mjs';
+
+test('discover upserts jobs from mocked board APIs and enqueues assess once', async (t) => {
+  const env = await isolatedEnv(t);
+  await writeFile(env.CLOUD_BOARDS_PATH, JSON.stringify([
+    { channel: 'greenhouse', slug: 'acme', company: 'Acme' },
+    { channel: 'lever', slug: 'broken', company: 'Broken' },
+  ]));
+  const fetchImpl = async (url) => {
+    if (String(url).includes('greenhouse')) {
+      return {
+        ok: true,
+        json: async () => ({
+          jobs: [{
+            id: 99,
+            title: 'Senior Product Engineer',
+            content: '<p>TypeScript remote</p>',
+            absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/99',
+            location: { name: 'Remote' },
+            questions: [{ id: 'first_name', label: 'First Name' }],
+          }],
+        }),
+      };
+    }
+    return { ok: false, status: 500 };
+  };
+  const first = await discoverBoards({ fetchImpl, env, roundId: 'round-1' });
+  assert.equal(first.inserted, 1);
+  assert.equal(first.found, 1);
+  assert.equal(first.errors.length, 1);
+  const second = await discoverBoards({ fetchImpl, env, roundId: 'round-1' });
+  assert.equal(second.inserted, 0);
+  const jobs = openDb(env).prepare('SELECT * FROM jobs').all();
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].application_channel, 'greenhouse');
+  assert.match(jobs[0].questions_json, /First Name/);
+  const assessJobs = queuedCounts(env).filter((row) => row.type === 'assess');
+  assert.equal(assessJobs.reduce((sum, row) => sum + row.n, 0), 1);
+});

--- a/cloud/tests/gate.test.mjs
+++ b/cloud/tests/gate.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { evaluateSubmitGate } from '../src/apply/gate.mjs';
+import { mapLabel, splitName } from '../src/apply/prefill.mjs';
+import { confirmationLooksSuccessful, detectHardStops } from '../src/apply/signals.mjs';
+import { isolatedEnv, sampleExtras, sampleProfile } from './helpers.mjs';
+
+test('submit gate requires routine-auto, review, résumé, and a clean page', () => {
+  const base = {
+    submissionMode: 'routine-auto',
+    ledgerClean: true,
+    decision: 'review',
+    autoEligible: true,
+    channel: 'greenhouse',
+    requiredFilled: true,
+    resumeAttached: true,
+    env: {},
+  };
+  assert.equal(evaluateSubmitGate(base).ok, true);
+  assert.deepEqual(evaluateSubmitGate({ ...base, submissionMode: 'review-each' }).failures, ['review-each']);
+  assert.ok(evaluateSubmitGate({ ...base, autoEligible: false }).failures.includes('not-auto-eligible'));
+  assert.equal(evaluateSubmitGate({
+    ...base,
+    autoEligible: false,
+    env: { CLOUD_ROUTINE_CHANNELS: 'greenhouse' },
+  }).ok, true);
+  assert.ok(evaluateSubmitGate({ ...base, hardStop: 'captcha' }).failures.includes('captcha'));
+  assert.ok(evaluateSubmitGate({ ...base, channel: 'lever' }).failures.includes('channel'));
+});
+
+test('confirmation detector is conservative', () => {
+  assert.equal(confirmationLooksSuccessful('Thanks for applying to Acme.').ok, true);
+  assert.equal(confirmationLooksSuccessful('Please review your application before sending.').ok, false);
+  assert.equal(confirmationLooksSuccessful('Application received', 'https://boards.greenhouse.io/acme/confirmation').ok, true);
+});
+
+test('hard stops include login, captcha, and Apply with LinkedIn', () => {
+  assert.equal(detectHardStops('Please sign in to continue').blocker, 'authentication');
+  assert.equal(detectHardStops('I am not a robot').blocker, 'captcha');
+  assert.equal(detectHardStops('Welcome', { hasLinkedInOverlay: true }).blocker, 'authentication');
+  assert.equal(detectHardStops('Name and email only'), null);
+});
+
+test('prefill maps common ATS labels to profile facts', async (t) => {
+  const env = await isolatedEnv(t);
+  const email = mapLabel('Corporate e-mail', sampleProfile, sampleExtras, { env });
+  assert.equal(email.value, sampleProfile.email);
+  assert.equal(splitName(sampleProfile.name).firstName, 'Test');
+  const leftover = mapLabel('Favorite ice cream', sampleProfile, sampleExtras, { env });
+  assert.equal(leftover.source, 'unclear');
+});

--- a/cloud/tests/helpers.mjs
+++ b/cloud/tests/helpers.mjs
@@ -1,0 +1,49 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const sampleProfile = {
+  name: 'Test Candidate',
+  email: 'candidate@example.com',
+  phone: '+1 555 0100',
+  location: 'Toronto, Canada',
+  workAuthorization: 'Canada',
+  linkedin: 'https://linkedin.com/in/example',
+  github: 'https://github.com/example',
+  roleFamilies: ['product-engineering', 'full-stack', 'ai-ml'],
+  seniority: ['senior', 'staff'],
+  skills: ['TypeScript', 'Python', 'React'],
+  targetLocations: ['Canada', 'Remote'],
+  workModes: ['remote'],
+  industries: ['AI'],
+  submissionMode: 'routine-auto',
+  yearsExperience: 10,
+  autoSubmitMinScore: 80,
+  manualReviewMinScore: 70,
+  minMustHaveCoverage: 70,
+};
+
+export const sampleExtras = {
+  motivationBlurb: 'I build TypeScript and React products for ten years, including Python services.',
+  howHeard: 'company careers page',
+  authorizedWithoutSponsorship: 'yes',
+  needsSponsorship: 'no',
+  willingToRelocate: 'no',
+};
+
+export async function isolatedEnv(t) {
+  const dir = await mkdtemp(join(tmpdir(), 'cloud-h0-'));
+  return {
+    ...process.env,
+    CLOUD_DATA_DIR: dir,
+    CLOUD_DB_PATH: join(dir, 'cloud.sqlite'),
+    JOB_APPLICATION_AGENT_STATE_DIR: join(dir, 'skill-state'),
+    CLOUD_BOARDS_PATH: join(dir, 'boards.json'),
+    HOST: '127.0.0.1',
+    PORT: '0',
+    CLOUD_EMBED_WORKER: '0',
+    OLLAMA_HOST: '',
+    ANTHROPIC_API_KEY: '',
+    OPENAI_API_KEY: '',
+  };
+}

--- a/cloud/tests/llm.test.mjs
+++ b/cloud/tests/llm.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { assessJob, heuristicAssess } from '../src/llm.mjs';
+import { sampleProfile } from './helpers.mjs';
+
+const job = {
+  title: 'Senior Product Engineer',
+  company: 'Example AI',
+  description: 'Build AI products with TypeScript, React and Python. Remote.',
+  workMode: 'remote',
+};
+
+const resumeText = 'I build TypeScript and React products for ten years, including Python services.';
+
+test('heuristic marks overlapping skills as met when the résumé quotes them', () => {
+  const result = heuristicAssess({ job, resumeText, profile: sampleProfile });
+  assert.equal(result.provider, 'heuristic');
+  assert.equal(result.pendingLlm, false);
+  assert.equal(result.seniority, 'senior');
+  const ts = result.mustHaves.find((item) => item.requirement === 'TypeScript');
+  assert.equal(ts.status, 'met');
+  assert.match(ts.evidence, /TypeScript/i);
+});
+
+test('assessJob uses heuristic when no provider is configured', async () => {
+  const result = await assessJob({
+    job,
+    resumeText,
+    profile: sampleProfile,
+    env: { ...process.env, OLLAMA_HOST: '', ANTHROPIC_API_KEY: '', OPENAI_API_KEY: '' },
+    fetchImpl: async () => { throw new Error('network should not be used'); },
+  });
+  assert.equal(result.provider, 'heuristic');
+  assert.equal(result.pendingLlm, false);
+});
+
+test('assessJob stays pending_llm when a hosted key is set but fetch fails', async () => {
+  const result = await assessJob({
+    job,
+    resumeText,
+    profile: sampleProfile,
+    env: { ...process.env, OLLAMA_HOST: '', ANTHROPIC_API_KEY: 'sk-test', OPENAI_API_KEY: '' },
+    fetchImpl: async () => { throw new Error('offline'); },
+  });
+  assert.equal(result.pendingLlm, true);
+  assert.equal(result.provider, 'none');
+});
+
+test('assessJob accepts hosted JSON and downgrades unquoted met claims', async () => {
+  const result = await assessJob({
+    job,
+    resumeText,
+    profile: sampleProfile,
+    env: { ...process.env, OLLAMA_HOST: '', ANTHROPIC_API_KEY: 'sk-test', OPENAI_API_KEY: '' },
+    fetchImpl: async (url) => {
+      if (String(url).includes('/api/tags')) return { ok: false };
+      return {
+        ok: true,
+        json: async () => ({
+          content: [{
+            text: JSON.stringify({
+              eligibility: 'eligible',
+              postingStatus: 'active',
+              seniority: 'senior',
+              roleFamily: 'product-engineering',
+              workMode: 'remote',
+              mustHaves: [
+                { requirement: 'TypeScript', status: 'met', evidence: 'I build TypeScript and React products' },
+                { requirement: 'GraphQL', status: 'met', evidence: 'invented-not-in-resume' },
+              ],
+            }),
+          }],
+        }),
+      };
+    },
+  });
+  assert.equal(result.provider, 'anthropic');
+  assert.equal(result.mustHaves[0].status, 'met');
+  assert.equal(result.mustHaves[1].status, 'unclear');
+});

--- a/cloud/tests/local.test.mjs
+++ b/cloud/tests/local.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { applyLocalDefaults, parseDotEnv } from '../src/env.mjs';
+import { startLocal } from '../src/local.mjs';
+import { importFromLocalSkill, importLocalCandidate } from '../src/skill.mjs';
+import { isolatedEnv, sampleExtras, sampleProfile } from './helpers.mjs';
+
+test('parseDotEnv ignores comments and does not require quotes', () => {
+  const parsed = parseDotEnv('# x\nHOST=127.0.0.1\nPORT="8787"\nEMPTY=\n');
+  assert.equal(parsed.HOST, '127.0.0.1');
+  assert.equal(parsed.PORT, '8787');
+  assert.equal(parsed.EMPTY, '');
+});
+
+test('local defaults bind localhost and keep data under cloud/data', () => {
+  const env = applyLocalDefaults({}, { cloudRoot: '/tmp/job-agent-cloud' });
+  assert.equal(env.HOST, '127.0.0.1');
+  assert.equal(env.PORT, '8787');
+  assert.equal(env.CLOUD_DATA_DIR, '/tmp/job-agent-cloud/data');
+  assert.equal(env.CLOUD_EMBED_WORKER, '1');
+});
+
+test('importLocalCandidate copies profile and résumé into cloud state', async (t) => {
+  const env = await isolatedEnv(t);
+  const resume = join(env.CLOUD_DATA_DIR, 'source.pdf');
+  await writeFile(resume, '%PDF-1.4 ' + 'x'.repeat(1200));
+  const result = await importLocalCandidate({
+    profile: sampleProfile,
+    extras: sampleExtras,
+    resumePath: resume,
+    env,
+  });
+  assert.equal(result.configured, true);
+  assert.ok(result.resumePath.endsWith('resume.pdf'));
+});
+
+test('onboard --from-skill explains a missing laptop profile', async (t) => {
+  const env = await isolatedEnv(t);
+  const { runCli } = await import('../src/cli.mjs');
+  await assert.rejects(() => runCli(['onboard', '--from-skill'], env), /laptop skill profile/);
+});
+
+test('importFromLocalSkill copies an injected laptop profile and résumé', async (t) => {
+  const env = await isolatedEnv(t);
+  const hostDir = join(env.CLOUD_DATA_DIR, 'host-skill');
+  await mkdir(hostDir, { recursive: true });
+  const resume = join(hostDir, 'resume.pdf');
+  await writeFile(resume, '%PDF-1.4 ' + 'y'.repeat(1200));
+  const imported = await importFromLocalSkill(env, {
+    readProfile: () => JSON.stringify(sampleProfile),
+    resumePath: resume,
+  });
+  assert.equal(imported.configured, true);
+  assert.ok(imported.resumePath);
+});
+
+test('local launcher starts the operator page without Playwright', async (t) => {
+  const env = await isolatedEnv(t);
+  const started = await startLocal(env, { cloudRoot: env.CLOUD_DATA_DIR });
+  t.after(() => started.close());
+  const html = await (await fetch(started.url)).text();
+  assert.match(html, /Use my laptop skill profile/);
+  assert.match(html, /Find and apply/);
+  const fromSkill = await fetch(`${started.url}/api/onboard/from-skill`, { method: 'POST' });
+  assert.equal(fromSkill.status, 500);
+});

--- a/cloud/tests/normalize.test.mjs
+++ b/cloud/tests/normalize.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { canonicalJob, guessWorkMode, jobId } from '../src/discover/normalize.mjs';
+
+test('canonicalJob hashes a stable id and keeps https apply urls', () => {
+  const job = canonicalJob({
+    company: 'Acme',
+    role: 'Senior Product Engineer',
+    title: 'Senior Product Engineer',
+    description: 'Build products.',
+    url: 'https://job-boards.greenhouse.io/acme/jobs/123#apply',
+    employerJobId: 'greenhouse:123',
+    applicationChannel: 'greenhouse',
+    locations: ['Remote'],
+  });
+  assert.equal(job.url, 'https://job-boards.greenhouse.io/acme/jobs/123');
+  assert.equal(job.id, jobId(job));
+  assert.equal(job.workMode, 'remote');
+});
+
+test('canonicalJob rejects non-https urls', () => {
+  assert.throws(() => canonicalJob({
+    company: 'Acme',
+    title: 'Role',
+    url: 'http://example.com/job',
+    applicationChannel: 'greenhouse',
+  }), /https/);
+});
+
+test('guessWorkMode reads listing text', () => {
+  assert.equal(guessWorkMode('Hybrid in Berlin', false), 'hybrid');
+  assert.equal(guessWorkMode('Office in NYC', false), 'onsite');
+  assert.equal(guessWorkMode('Something else', true), 'remote');
+});

--- a/cloud/tests/queue.test.mjs
+++ b/cloud/tests/queue.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { claimNext, enqueue, finish, queuedCounts } from '../src/queue.mjs';
+import { isolatedEnv } from './helpers.mjs';
+
+test('queue claims one job and marks it done or failed', async (t) => {
+  const env = await isolatedEnv(t);
+  const first = enqueue('discover', { n: 1 }, env);
+  enqueue('assess', { jobId: 'x' }, env);
+  const claimed = claimNext(['discover', 'assess'], env);
+  assert.equal(claimed.id, first.id);
+  assert.equal(claimed.type, 'discover');
+  finish(claimed.id, null, env);
+  const next = claimNext(['discover', 'assess'], env);
+  assert.equal(next.type, 'assess');
+  finish(next.id, 'boom', env);
+  const counts = queuedCounts(env);
+  assert.ok(counts.some((row) => row.status === 'done' && row.n === 1));
+  assert.ok(counts.some((row) => row.status === 'failed' && row.n === 1));
+});

--- a/cloud/tests/server.test.mjs
+++ b/cloud/tests/server.test.mjs
@@ -57,6 +57,7 @@ test('operator API onboards, starts a round, and never calls Playwright inline',
     const html = await (await fetch(`${base}/`)).text();
     assert.match(html, /Needs you/);
     assert.match(html, /Find and apply/);
+    assert.match(html, /Use my laptop skill profile/);
   });
 });
 

--- a/cloud/tests/server.test.mjs
+++ b/cloud/tests/server.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { openDb } from '../src/db.mjs';
+import { startServer } from '../src/server.mjs';
+import { isolatedEnv, sampleExtras, sampleProfile } from './helpers.mjs';
+
+async function withServer(env, fn) {
+  const server = startServer(env, { embedWorker: false });
+  const { port } = await server.ready;
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await server.close();
+  }
+}
+
+test('operator API onboards, starts a round, and never calls Playwright inline', async (t) => {
+  const env = await isolatedEnv(t);
+  await withServer(env, async (base) => {
+    const status = await (await fetch(`${base}/api/status`)).json();
+    assert.equal(status.profile.configured, false);
+
+    const onboard = await fetch(`${base}/api/onboard`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ profile: sampleProfile, extras: sampleExtras }),
+    });
+    assert.equal(onboard.status, 200);
+    const saved = await onboard.json();
+    assert.equal(saved.configured, true);
+
+    const pdf = join(env.CLOUD_DATA_DIR, 'resume.pdf');
+    await writeFile(pdf, '%PDF-1.4 test');
+    const resume = await fetch(`${base}/api/resume`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/pdf' },
+      body: await (await import('node:fs/promises')).readFile(pdf),
+    });
+    assert.equal(resume.status, 200);
+
+    const round = await fetch(`${base}/api/rounds`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ count: 10 }),
+    });
+    assert.equal(round.status, 202);
+    const body = await round.json();
+    assert.match(body.id, /^round-/);
+
+    const home = await (await fetch(`${base}/api/status`)).json();
+    assert.equal(home.profile.resumePath, true);
+    assert.ok(home.queue.some((row) => row.type === 'discover' && row.status === 'queued'));
+
+    const html = await (await fetch(`${base}/`)).text();
+    assert.match(html, /Needs you/);
+    assert.match(html, /Find and apply/);
+  });
+});
+
+test('cli status works against an empty isolated data dir', async (t) => {
+  const env = await isolatedEnv(t);
+  const { runCli } = await import('../src/cli.mjs');
+  const status = await runCli(['status'], env);
+  assert.equal(status.profile.configured, false);
+  openDb(env); // created
+});

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -12,7 +12,8 @@ Reuse the OSS CLI as the source of truth for candidate state. Add a new `cloud/`
 |---|---|---|
 | Profile, résumé, ledger, rounds, attention enums | Existing `job-application.mjs` via import + subprocess | Extract shared package both skill and worker import |
 | Discovered jobs, watched slugs, assessments, browser sessions | New SQLite in `cloud/data/` (gitignored) | D1 / Postgres + R2 |
-| Must-have assessment | LLM (or you) writes the `score --stdin` payload; never invent evidence | Same, with stored prompts and review |
+| Must-have assessment | Heuristic: JD tokens vs `profile.skills` / résumé text, then `scoreJob`. Hand override. Optional HTTP LLM later, never a local model | Same |
+| Prefill | ATS `questions` + label synonym map + stored answers. No model | Same |
 | Apply | Playwright + Chromium on a **new Fly Machine** (not Paisewise); agent Submit when the gate passes | Browser adapter `{launch, fill, submit, handoff, heartbeat, close}` |
 | Takeover | noVNC / CDP live view URL stored on `browser_sessions` | Cloudflare Browser Run or Steel/Browserbase |
 | Operator UI | One local page, bound to `fly proxy` / WireGuard | Quiet Trust UI on the existing site |
@@ -39,7 +40,7 @@ cloud/
     db.mjs              # SQLite
     skill.mjs           # import + subprocess bridge
     discover/{greenhouse,lever,ashby,normalize}.mjs
-    assess.mjs          # JD + résumé → score input
+    assess.mjs          # heuristic mustHaves + scoreJob; optional HTTP LLM later
     apply/{browser,greenhouse,lever,ashby,handoff}.mjs
     server.mjs          # localhost API + operator page
   data/                 # gitignored
@@ -54,7 +55,7 @@ Must exist before Phase 1 coding:
 - Node 20+, Chromium for Playwright (in that image)
 - Your `profile set` JSON and canonical PDF
 - A `boards.json` seed of companies you would actually join (start with 20 slugs, not 200)
-- An LLM key **only** for assessment, or willingness to assess the first batch by hand
+- No LLM key. Prefill and `scoreJob` are deterministic. An API key is optional later for essays only — never a local model on the Fly box.
 
 Must **not** be in place: auth, Dodo activation, public DNS, Cloudflare Browser Run, LinkedIn session, anything running on the Paisewise app.
 
@@ -104,21 +105,21 @@ HTTP only. No browser.
 
 ### Phase 3 — Assess and queue
 
-This is the step the coding agent does today by reading the posting.
+No model. The coding agent does this today by reading the posting; on Fly we use a heuristic plus `scoreJob`.
 
 - [ ] For each new job, build a `score --stdin` payload:
   - `postingStatus: active` only after the apply URL still resolves
-  - `eligibility` from authorization / location text; `unclear` if not explicit
-  - `mustHaves[]` from the JD, each `met|partial|missing|unclear` with résumé-backed evidence or no evidence
-- [ ] Default assessor: model + canonical résumé text + JD. Prompt forbids inventing evidence.
-- [ ] Fallback: `cloud assess --job <id>` you fill by hand
+  - `eligibility` from structured onboarding flags + location text; `unclear` if not explicit
+  - `mustHaves[]` from JD token overlap with `profile.skills` and résumé text (`met` / `missing` only — no invented evidence)
 - [ ] Call `scoreJob(job, profile)`; store the full result on `assessments`
+- [ ] `cloud assess --job <id>` lets you override a heuristic by hand
 - [ ] `exclude` / `skip` stay out of the fill queue
-- [ ] `ask` becomes an attention item (`ambiguous-authorization`, `ambiguous-compensation`, or `unverifiable-claim`) — no browser yet
-- [ ] `review` (and `autoEligible`) enter the fill queue. `autoEligible` means fill, not submit
+- [ ] `ask` becomes an attention item — no browser yet
+- [ ] `review` enters the fill queue; `autoEligible` + `routine-auto` may Submit after fill
 - [ ] `ledger check` before queueing; hard duplicates never enter
+- [ ] Do not add an on-box LLM. An HTTP assessor is a later optional adapter behind the same `mustHaves` shape.
 
-**Done when:** a discover → assess pass leaves a fill queue of `review` jobs and a separate list of questions for you. Empty `mustHaves` never reaches fill.
+**Done when:** a discover → assess pass leaves a fill queue of `review` jobs using only Node + the existing CLI. Empty `mustHaves` never reaches fill.
 
 ### Phase 4 — Fill (Greenhouse first)
 
@@ -126,10 +127,10 @@ One channel until it is boring.
 
 - [ ] Playwright launches Chromium with a dedicated `cloud/data/chrome-profile`
 - [ ] Open the job `url`, not a Google/LinkedIn redirect
-- [ ] Fill name, email, phone, location, links, work authorization, compensation from profile only
+- [ ] Prefill from Greenhouse `questions` ids → profile keys; fall back to a label synonym map; unknown required field → attention
 - [ ] Upload résumé with `setInputFiles` / file chooser using `resume path` ([BROWSER_UPLOADS.md](../job-application-agent/references/BROWSER_UPLOADS.md))
 - [ ] After ATS parse, restore any verified field the parser changed
-- [ ] Draft “why this company” from [APPLICATION_GUIDANCE.md](../job-application-agent/references/APPLICATION_GUIDANCE.md); do not submit it blindly if the profile is `review-each`
+- [ ] Narratives: paste `motivationBlurb` or stop. No on-box draft model.
 - [ ] Stop on login, MFA, CAPTCHA, legal, demographic, government-id, unclear compensation/authorization, unverifiable claim, “Apply with LinkedIn”
 - [ ] Implement the submit gate from [cloud-mvp.md](./cloud-mvp.md#when-the-agent-submits)
 - [ ] On a passing gate: screenshot, click Submit, wait for confirmation, `ledger add` with `STANDING AUTHORIZATION`
@@ -201,7 +202,7 @@ Do not start this until Phase 8 is done.
 
 | Risk | Why it shows up | Mitigation |
 |---|---|---|
-| Assessor invents experience | `scoreJob` will happily score invented `met` evidence | Prompt + store evidence text; you review the first 20; `unclear` → `ask` |
+| Assessor invents experience | `scoreJob` will happily score invented `met` evidence | H0 heuristic only marks `met` on explicit skill overlap; hand override; no on-box model |
 | Greenhouse iframe / “Apply with LinkedIn” | Fill script clicks the wrong surface | Prefer the hosted board apply form; stop on LinkedIn overlay |
 | ATS résumé parse clobbers fields | Local runbook already warns | Re-read fields after upload; restore from profile |
 | Bot detection | Worse on hosted browsers than on a residential VM | Dogfood on your VM first; vendor choice is an output of Phase 8 |
@@ -231,8 +232,8 @@ When implementation starts, land in this order so each PR stays reviewable:
 2. `onboard` / `status` (Phase 1)
 3. `discover` + `boards.json` example (Phase 2)
 4. `assess` + fill queue (Phase 3)
-5. Greenhouse fill, no submit (Phase 4)
-6. Handoff + `ledger add` on confirmation (Phase 5)
+5. Greenhouse fill + agent Submit (Phase 4)
+6. Handoff for hard stops + `ledger add` on confirmation (Phase 5)
 7. Localhost operator page (Phase 6)
 
 Lever/Ashby and the public-cloud move are their own PRs after a real Greenhouse submission.

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -208,6 +208,8 @@ Do not start this until Phase 8 is done.
 | Risk | Why it shows up | Mitigation |
 |---|---|---|
 | Assessor invents experience | `scoreJob` will happily score invented `met` evidence | `cloud llm assess` must quote résumé text; no quote → `unclear`; first 20 reviewed; heuristic fallback only |
+| Ollama offline while a round is running | Laptop closed; Fly cannot reach `:11434` | Short probe; `pending_llm`; hosted API fallback; never block the HTTP handler |
+| Ollama on a public bind | Résumé posted to the open internet | Tailscale only; do not advertise `0.0.0.0:11434` |
 | Greenhouse iframe / “Apply with LinkedIn” | Fill script clicks the wrong surface | Prefer the hosted board apply form; stop on LinkedIn overlay |
 | ATS résumé parse clobbers fields | Local runbook already warns | Re-read fields after upload; restore from profile |
 | Bot detection | Worse on hosted browsers than on a residential VM | Dogfood on your VM first; vendor choice is an output of Phase 8 |

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -1,0 +1,224 @@
+# Implementation Plan: Cloud apply MVP
+
+**Specification:** [docs/cloud-mvp.md](./cloud-mvp.md)
+
+**Overview.** Build a single-tenant hosted loop you can run for yourself: onboard once, discover Greenhouse / Lever / Ashby jobs over HTTP, score with the existing runbook, fill in a Playwright browser, and hand you the live tab to submit. Auth, multi-tenant isolation, and founding-access gating stay out. Do not fork scoring or ledger rules.
+
+## Technical approach
+
+Reuse the OSS CLI as the source of truth for candidate state. Add a new `cloud/` package that is **not** published in the npm skill.
+
+| Concern | Personal MVP | Later (public cloud) |
+|---|---|---|
+| Profile, résumé, ledger, rounds, attention enums | Existing `job-application.mjs` via import + subprocess | Extract shared package both skill and worker import |
+| Discovered jobs, watched slugs, assessments, browser sessions | New SQLite in `cloud/data/` (gitignored) | D1 / Postgres + R2 |
+| Must-have assessment | LLM (or you) writes the `score --stdin` payload; never invent evidence | Same, with stored prompts and review |
+| Apply | Playwright + local Chromium, never click Submit | Browser adapter `{launch, fill, handoff, heartbeat, close}` |
+| Takeover | noVNC / CDP live view URL stored on `browser_sessions` | Cloudflare Browser Run or Steel/Browserbase |
+| Operator UI | One local page, bound to localhost / Tailscale | Quiet Trust UI on the existing site |
+
+**Do not extend `attention.ndjson` with a live-view URL.** The CLI schema is closed. Store `session_id` + `live_view_url` on `browser_sessions` and join by `applicationId`.
+
+**`scoreJob` requires `mustHaves`.** A board API row is not enough. A fetch that skips assessment will always get `ask`. The assessor is a real phase, not a footnote.
+
+Import from the skill, do not copy:
+
+- `validateProfile`, `profileStatus`, `migrateProfile`
+- `scoreJob`
+- `validateLedgerEntry`
+- `sourcesList`
+
+Call the CLI for persistence until extraction: `profile set|check`, `resume import|path`, `ledger check|add`, `attention add|list|resolve`, `round start|status`.
+
+```text
+cloud/
+  package.json          # private, not in root "files"
+  boards.json           # watched {channel, slug, company}
+  src/
+    cli.mjs             # onboard, discover, round, attention
+    db.mjs              # SQLite
+    skill.mjs           # import + subprocess bridge
+    discover/{greenhouse,lever,ashby,normalize}.mjs
+    assess.mjs          # JD + résumé → score input
+    apply/{browser,greenhouse,lever,ashby,handoff}.mjs
+    server.mjs          # localhost API + operator page
+  data/                 # gitignored
+```
+
+## Dependencies
+
+Must exist before Phase 1 coding:
+
+- A machine you control (laptop is fine; a small VM is better)
+- Node 20+, Chromium for Playwright
+- Your `profile set` JSON and canonical PDF
+- A `boards.json` seed of companies you would actually join (start with 20 slugs, not 200)
+- An LLM key **only** for assessment, or willingness to assess the first batch by hand
+
+Must **not** be in place: auth, Dodo activation, public DNS, Cloudflare Browser Run, LinkedIn session.
+
+## Phases
+
+### Phase 0 — Skeleton
+
+Keep cloud code out of the published skill.
+
+- [ ] Add `cloud/` with its own `package.json` (`private: true`)
+- [ ] Leave root `package.json` `files` unchanged so `npx job-application-agent` does not ship this
+- [ ] Gitignore `cloud/data/`, `cloud/.env`, uploaded PDFs
+- [ ] `cloud/src/skill.mjs` can `profile check` against a configured state dir
+- [ ] README: how to point `JOB_APPLICATION_STATE_DIR` at `cloud/data/skill-state`
+
+**Done when:** `node cloud/src/cli.mjs status` prints skill profile status without writing candidate data into the repo.
+
+### Phase 1 — Onboarding
+
+Collect the known set once. Mid-run questions come later.
+
+- [ ] `cloud onboard --profile profile.json --resume resume.pdf`
+- [ ] Validate with `validateProfile`; refuse inferring missing required fields
+- [ ] Collect the extra ATS-common fields on the same command even if the CLI marks them optional: LinkedIn, GitHub, portfolio, availability, current/target compensation, compensation floor, skills, industries, exclusions
+- [ ] Store the résumé through `resume import`; resolve later with `resume path`
+- [ ] `cloud status` shows missing profile fields and whether a canonical résumé exists
+
+**Done when:** one command takes you from empty state to a complete `profile check` plus `resume path`.
+
+### Phase 2 — Discovery
+
+HTTP only. No browser.
+
+- [ ] `boards.json` entries: `{ "channel": "greenhouse"|"lever"|"ashby", "slug": "acme", "company": "Acme" }`
+- [ ] Fetchers:
+  - Greenhouse `GET /v1/boards/{slug}/jobs?content=true`
+  - Lever `GET /v0/postings/{slug}?mode=json`
+  - Ashby `GET /posting-api/job-board/{slug}`
+- [ ] Normalize to `{company, role, title, description, url, employerJobId, applicationChannel, discoverySource, locations, salaryMaximum, salaryCurrency, workMode}`
+- [ ] Upsert `jobs` on canonical URL / employer job id; skip closed
+- [ ] For Greenhouse, persist the `questions` array for pre-flight later
+- [ ] `cloud discover` is idempotent and safe to cron
+
+**Done when:** 20 slugs produce a de-duplicated `jobs` table with direct apply URLs and descriptions. No scoring yet.
+
+### Phase 3 — Assess and queue
+
+This is the step the coding agent does today by reading the posting.
+
+- [ ] For each new job, build a `score --stdin` payload:
+  - `postingStatus: active` only after the apply URL still resolves
+  - `eligibility` from authorization / location text; `unclear` if not explicit
+  - `mustHaves[]` from the JD, each `met|partial|missing|unclear` with résumé-backed evidence or no evidence
+- [ ] Default assessor: model + canonical résumé text + JD. Prompt forbids inventing evidence.
+- [ ] Fallback: `cloud assess --job <id>` you fill by hand
+- [ ] Call `scoreJob(job, profile)`; store the full result on `assessments`
+- [ ] `exclude` / `skip` stay out of the fill queue
+- [ ] `ask` becomes an attention item (`ambiguous-authorization`, `ambiguous-compensation`, or `unverifiable-claim`) — no browser yet
+- [ ] `review` (and `autoEligible`) enter the fill queue. `autoEligible` means fill, not submit
+- [ ] `ledger check` before queueing; hard duplicates never enter
+
+**Done when:** a discover → assess pass leaves a fill queue of `review` jobs and a separate list of questions for you. Empty `mustHaves` never reaches fill.
+
+### Phase 4 — Fill (Greenhouse first)
+
+One channel until it is boring.
+
+- [ ] Playwright launches Chromium with a dedicated `cloud/data/chrome-profile`
+- [ ] Open the job `url`, not a Google/LinkedIn redirect
+- [ ] Fill name, email, phone, location, links, work authorization, compensation from profile only
+- [ ] Upload résumé with `setInputFiles` / file chooser using `resume path` ([BROWSER_UPLOADS.md](../job-application-agent/references/BROWSER_UPLOADS.md))
+- [ ] After ATS parse, restore any verified field the parser changed
+- [ ] Draft “why this company” from [APPLICATION_GUIDANCE.md](../job-application-agent/references/APPLICATION_GUIDANCE.md); do not submit it blindly if the profile is `review-each`
+- [ ] Stop on login, MFA, CAPTCHA, legal, demographic, government-id, unclear compensation/authorization, unverifiable claim
+- [ ] **Never click Submit**
+- [ ] On stop or “ready to submit”, write skill `attention add` plus a `browser_sessions` row
+- [ ] Skip Lever / Ashby / `other` until Greenhouse fill + handoff works end to end
+
+**Done when:** one real Greenhouse application sits filled, résumé attached, waiting, with no submission recorded.
+
+### Phase 5 — Handoff and confirm
+
+You finish in the same tab.
+
+- [ ] Expose the Playwright page over noVNC or a CDP live-view link
+- [ ] Operator page (or CLI) prints `live_view_url` + instructions (“Review. If truthful, Submit. Wait for thank-you.”)
+- [ ] Heartbeat the browser so the tab survives while you walk over
+- [ ] If the session dies: reopen URL, refill, new attention item. No cookie export
+- [ ] Detect confirmation conservatively (thank-you / application received). If unsure, stay `needs_attention`
+- [ ] Only then `ledger add` with `approval: "APPROVE SUBMIT"` and a private confirmation artifact (URL + screenshot in `cloud/data/`)
+- [ ] `attention resolve` after a confirmed submit or explicit abandon
+
+**Done when:** you can submit from the live tab and the ledger gains a `submitted` row only after the success page.
+
+### Phase 6 — Operator surface and mid-run answers
+
+- [ ] Localhost page: profile completeness, fill queue, open attention with “Open live session”, submitted ledger
+- [ ] Mid-run missing field: prompt on that page, store in `answers` keyed by `normalized question + channel`, resume fill
+- [ ] Ping (ntfy / email) when attention is non-empty
+- [ ] `cloud round start --count 10` uses skill `round start` and stops offering new fills at the target
+
+**Done when:** you can run a round without SSH-ing into logs to find the next pause.
+
+### Phase 7 — Lever + Ashby adapters
+
+- [ ] Copy the Greenhouse fill contract: same stop rules, same no-submit, same confirmation rule
+- [ ] Treat each channel’s extra widgets (Ashby steps, Lever custom questions, “Apply with LinkedIn”) as a stop if they are not mapped
+- [ ] Record `friction` for reproducible general failures only (existing enum + no candidate data)
+
+**Done when:** at least one confirmed Lever or Ashby submission exists, with a note of what had to be manual.
+
+### Phase 8 — Dogfood a round of 10
+
+- [ ] Seed ≥ 20 slugs, start a round of 10
+- [ ] Per application, log: found via API? filled? bot/login block? you submitted? confirmation detected?
+- [ ] Kill a session on purpose and confirm refill-without-cookies
+- [ ] Decide the September browser: Cloudflare Browser Run vs Steel vs Browserbase vs stay on the VM
+
+**Done when:** the [decision checklist](./cloud-mvp.md#decision-checklist) in the spec is ticked.
+
+### Phase 9 — Public product (after dogfood)
+
+Do not start this until Phase 8 is done.
+
+- [ ] Extract score / ledger / attention / source-normalization into a shared package
+- [ ] Browser adapter interface; swap VM Playwright without changing assess/queue
+- [ ] Move control plane onto the existing site (D1 or Postgres, R2 for résumés)
+- [ ] Auth + founding activation in front of that API
+- [ ] Scheduled discovery + attention notifications
+- [ ] Explicit cloud privacy controls before any third-party profile is accepted (already promised on the privacy page)
+- [ ] Still no auto-submit until a channel is boringly reliable
+
+## Risks
+
+| Risk | Why it shows up | Mitigation |
+|---|---|---|
+| Assessor invents experience | `scoreJob` will happily score invented `met` evidence | Prompt + store evidence text; you review the first 20; `unclear` → `ask` |
+| Greenhouse iframe / “Apply with LinkedIn” | Fill script clicks the wrong surface | Prefer the hosted board apply form; stop on LinkedIn overlay |
+| ATS résumé parse clobbers fields | Local runbook already warns | Re-read fields after upload; restore from profile |
+| Bot detection | Worse on hosted browsers than on a residential VM | Dogfood on your VM first; vendor choice is an output of Phase 8 |
+| Confirmation false positive | Ledger would lie | Conservative detector; default to attention |
+| Live view expires | Cloudflare idle 10 min; you are not at the desk | Heartbeat; VM/noVNC for MVP; longer-session vendor later |
+| Schema drift from the skill | Copied score/ledger rules will rot | Import functions; subprocess writes; extract only in Phase 9 |
+| PII on a public URL | Résumé + authorization in SQLite | Localhost / Tailscale only; no public DNS in Phases 0–8 |
+| Scope creep into LinkedIn / Workday | Session + ToS + detection | Boards that need a login are skipped, not “tried a little” |
+
+## Out of scope until Phase 9+
+
+- User accounts, OAuth, Dodo activation
+- Auto-submit
+- LinkedIn Easy Apply, X, YC Work at a Startup
+- Demographic answers, government IDs, stored passwords, CAPTCHA solvers
+- Per-company résumé rewrites
+- A second scoring system
+
+## First commit sequence
+
+When implementation starts, land in this order so each PR stays reviewable:
+
+1. `cloud/` skeleton + skill bridge + gitignore (Phase 0)
+2. `onboard` / `status` (Phase 1)
+3. `discover` + `boards.json` example (Phase 2)
+4. `assess` + fill queue (Phase 3)
+5. Greenhouse fill, no submit (Phase 4)
+6. Handoff + `ledger add` on confirmation (Phase 5)
+7. Localhost operator page (Phase 6)
+
+Lever/Ashby and the public-cloud move are their own PRs after a real Greenhouse submission.

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -183,8 +183,13 @@ Do not start this until Phase 8 is done.
 
 - [ ] Extract score / ledger / attention / source-normalization into a shared package
 - [ ] Browser adapter interface; swap VM Playwright without changing assess/queue
-- [ ] Move control plane onto the existing site (D1 or Postgres, R2 for résumés)
+- [ ] Session lease: `needs_attention` does not require a live tab; “Open live session” acquires, refills, hands off, releases
+- [ ] One browser context per user; never share a Chrome profile across tenants
+- [ ] Move control plane onto the existing site (Postgres + object storage once more than one operator; D1 remains for founding checkout)
 - [ ] Auth + founding activation in front of that API
+- [ ] Browser pool sized to concurrent fills + concurrent handoffs, not pending-row count (see [100 × 100](./cloud-mvp.md#scale-100-users--100-pending-submits))
+- [ ] Per-channel rate limits and staggered fills so one egress IP does not look like a botnet
+- [ ] Inbox UX: filter + “next ready,” not 100 open tabs
 - [ ] Scheduled discovery + attention notifications
 - [ ] Explicit cloud privacy controls before any third-party profile is accepted (already promised on the privacy page)
 - [ ] Still no auto-submit until a channel is boringly reliable
@@ -198,9 +203,12 @@ Do not start this until Phase 8 is done.
 | ATS résumé parse clobbers fields | Local runbook already warns | Re-read fields after upload; restore from profile |
 | Bot detection | Worse on hosted browsers than on a residential VM | Dogfood on your VM first; vendor choice is an output of Phase 8 |
 | Confirmation false positive | Ledger would lie | Conservative detector; default to attention |
-| Live view expires | Cloudflare idle 10 min; you are not at the desk | Heartbeat; VM/noVNC for MVP; longer-session vendor later |
+| Live view expires | Cloudflare idle 10 min; you are not at the desk | Heartbeat while *leased*; refill-on-open is the default at scale |
+| Holding a tab per pending submit | 100 users × 100 ready ≈ 10,000 Chromiums | Queue is data; pool ≈ concurrent fills + people in live view |
+| Shared Chrome profile across users | Cookies and résumés leak | One context per user; destroy or freeze after release |
 | Schema drift from the skill | Copied score/ledger rules will rot | Import functions; subprocess writes; extract only in Phase 9 |
-| PII on a public URL | Résumé + authorization in SQLite | Localhost / Tailscale only; no public DNS in Phases 0–8 |
+| PII on a public URL | Résumé + authorization in SQLite | `fly proxy` / WireGuard only; no public DNS in Phases 0–8 |
+| Sharing the Paisewise Machine | Chromium OOMs payroll; deploys kill tabs; untrusted ATS pages sit next to money data | Second Fly app + volume; never attach to `paisewise.com` |
 | Scope creep into LinkedIn / Workday | Session + ToS + detection | Boards that need a login are skipped, not “tried a little” |
 
 ## Out of scope until Phase 9+

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -231,7 +231,7 @@ When implementation starts, land in this order so each PR stays reviewable:
 1. `cloud/` skeleton + skill bridge + gitignore (Phase 0)
 2. `onboard` / `status` (Phase 1)
 3. `discover` + `boards.json` example (Phase 2)
-4. `assess` + fill queue (Phase 3)
+4. `cloud llm assess` + fill queue (Phase 3)
 5. Greenhouse fill + agent Submit (Phase 4)
 6. Handoff for hard stops + `ledger add` on confirmation (Phase 5)
 7. Localhost operator page (Phase 6)

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -2,7 +2,7 @@
 
 **Specification:** [docs/cloud-mvp.md](./cloud-mvp.md)
 
-**Overview.** Build horizon **H0** from [docs/cloud-mvp.md](./cloud-mvp.md): a hosted loop that keeps a truthful search moving and only pulls the candidate in for real decisions. Onboard once, discover Greenhouse / Lever / Ashby over HTTP, score with the existing runbook, fill in Playwright, open a **just-in-time** live view to submit, record `submitted` only after visible confirmation. Auth and multi-tenant isolation stay out of H0. Do not fork scoring or ledger rules. Do not treat “keep the same tab warm” as the goal — that is an H0 convenience. H1/H2 need acquire → refill → release.
+**Overview.** Build horizon **H0** from [docs/cloud-mvp.md](./cloud-mvp.md): a hosted loop that keeps a truthful search moving and only pulls the candidate in for real decisions. Onboard once, discover Greenhouse / Lever / Ashby over HTTP, score with the existing runbook, fill in Playwright, **click Submit when the gate passes**, record `submitted` only after visible confirmation. Live view is for hard stops and `review-each`. Auth and multi-tenant isolation stay out of H0. Do not fork scoring or ledger rules.
 
 ## Technical approach
 
@@ -13,7 +13,7 @@ Reuse the OSS CLI as the source of truth for candidate state. Add a new `cloud/`
 | Profile, résumé, ledger, rounds, attention enums | Existing `job-application.mjs` via import + subprocess | Extract shared package both skill and worker import |
 | Discovered jobs, watched slugs, assessments, browser sessions | New SQLite in `cloud/data/` (gitignored) | D1 / Postgres + R2 |
 | Must-have assessment | LLM (or you) writes the `score --stdin` payload; never invent evidence | Same, with stored prompts and review |
-| Apply | Playwright + Chromium on a **new Fly Machine** (not Paisewise), never click Submit | Browser adapter `{launch, fill, handoff, heartbeat, close}` |
+| Apply | Playwright + Chromium on a **new Fly Machine** (not Paisewise); agent Submit when the gate passes | Browser adapter `{launch, fill, submit, handoff, heartbeat, close}` |
 | Takeover | noVNC / CDP live view URL stored on `browser_sessions` | Cloudflare Browser Run or Steel/Browserbase |
 | Operator UI | One local page, bound to `fly proxy` / WireGuard | Quiet Trust UI on the existing site |
 
@@ -130,26 +130,29 @@ One channel until it is boring.
 - [ ] Upload résumé with `setInputFiles` / file chooser using `resume path` ([BROWSER_UPLOADS.md](../job-application-agent/references/BROWSER_UPLOADS.md))
 - [ ] After ATS parse, restore any verified field the parser changed
 - [ ] Draft “why this company” from [APPLICATION_GUIDANCE.md](../job-application-agent/references/APPLICATION_GUIDANCE.md); do not submit it blindly if the profile is `review-each`
-- [ ] Stop on login, MFA, CAPTCHA, legal, demographic, government-id, unclear compensation/authorization, unverifiable claim
-- [ ] **Never click Submit**
-- [ ] On stop or “ready to submit”, write skill `attention add` plus a `browser_sessions` row
-- [ ] Skip Lever / Ashby / `other` until Greenhouse fill + handoff works end to end
+- [ ] Stop on login, MFA, CAPTCHA, legal, demographic, government-id, unclear compensation/authorization, unverifiable claim, “Apply with LinkedIn”
+- [ ] Implement the submit gate from [cloud-mvp.md](./cloud-mvp.md#when-the-agent-submits)
+- [ ] On a passing gate: screenshot, click Submit, wait for confirmation, `ledger add` with `STANDING AUTHORIZATION`
+- [ ] On a failing gate or `review-each`: `attention add` plus a `browser_sessions` row — do not click
+- [ ] If confirmation is unclear after a click: attention only, never click again
+- [ ] Skip Lever / Ashby / `other` until one Greenhouse agent-submit is confirmed
 
-**Done when:** one real Greenhouse application sits filled, résumé attached, waiting, with no submission recorded.
+**Done when:** one real Greenhouse application is agent-submitted and the ledger row exists only after the thank-you page.
 
-### Phase 5 — Handoff and confirm
+### Phase 5 — Handoff (hard stops and review-each)
 
-You finish in the same tab.
+You finish only what the agent must not.
 
 - [ ] Expose the Playwright page over noVNC or a CDP live-view link
-- [ ] Operator page (or CLI) prints `live_view_url` + instructions (“Review. If truthful, Submit. Wait for thank-you.”)
-- [ ] Heartbeat the browser so the tab survives while you walk over
-- [ ] If the session dies: reopen URL, refill, new attention item. No cookie export
-- [ ] Detect confirmation conservatively (thank-you / application received). If unsure, stay `needs_attention`
-- [ ] Only then `ledger add` with `approval: "APPROVE SUBMIT"` and a private confirmation artifact (URL + screenshot in `cloud/data/`)
+- [ ] Operator page prints `live_view_url` + blocker-specific instructions
+- [ ] Heartbeat while leased; if the session dies, reopen, refill, new attention item. No cookie export
+- [ ] After the operator unblocks, the agent may resume and Submit if the gate now passes
+- [ ] In `review-each`, the operator clicks Submit; the agent still waits for confirmation
+- [ ] Detect confirmation conservatively. If unsure, stay `needs_attention`
+- [ ] `ledger add` uses `STANDING AUTHORIZATION` for agent Submit, `APPROVE SUBMIT` for review-each, plus a private confirmation artifact
 - [ ] `attention resolve` after a confirmed submit or explicit abandon
 
-**Done when:** you can submit from the live tab and the ledger gains a `submitted` row only after the success page.
+**Done when:** a CAPTCHA or legal stop can be finished in live view, after which the agent Submits (routine-auto) or you do (`review-each`), and the ledger moves only after confirmation.
 
 ### Phase 6 — Operator surface and mid-run answers
 
@@ -162,7 +165,7 @@ You finish in the same tab.
 
 ### Phase 7 — Lever + Ashby adapters
 
-- [ ] Copy the Greenhouse fill contract: same stop rules, same no-submit, same confirmation rule
+- [ ] Copy the Greenhouse fill contract: same stop rules, same submit gate, same confirmation rule
 - [ ] Treat each channel’s extra widgets (Ashby steps, Lever custom questions, “Apply with LinkedIn”) as a stop if they are not mapped
 - [ ] Record `friction` for reproducible general failures only (existing enum + no candidate data)
 
@@ -171,7 +174,7 @@ You finish in the same tab.
 ### Phase 8 — Dogfood a round of 10
 
 - [ ] Seed ≥ 20 slugs, start a round of 10
-- [ ] Per application, log: found via API? filled? bot/login block? you submitted? confirmation detected?
+- [ ] Per application, log: found via API? filled? bot/login block? agent submitted or handed off? confirmation detected?
 - [ ] Kill a session on purpose and confirm refill-without-cookies
 - [ ] Decide the September browser: Cloudflare Browser Run vs Steel vs Browserbase vs stay on the VM
 
@@ -192,7 +195,7 @@ Do not start this until Phase 8 is done.
 - [ ] Inbox UX: filter + “next ready,” not 100 open tabs
 - [ ] Scheduled discovery + attention notifications
 - [ ] Explicit cloud privacy controls before any third-party profile is accepted (already promised on the privacy page)
-- [ ] Still no auto-submit until a channel is boringly reliable
+- [ ] Agent Submit only through the documented gate; new channels start watched until one clean confirm
 
 ## Risks
 

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -2,7 +2,7 @@
 
 **Specification:** [docs/cloud-mvp.md](./cloud-mvp.md)
 
-**Overview.** Build horizon **H0** from [docs/cloud-mvp.md](./cloud-mvp.md): a hosted loop that keeps a truthful search moving and only pulls the candidate in for real decisions. Onboard once, discover Greenhouse / Lever / Ashby over HTTP, score with the existing runbook, fill in Playwright, **click Submit when the gate passes**, record `submitted` only after visible confirmation. Live view is for hard stops and `review-each`. Auth and multi-tenant isolation stay out of H0. Do not fork scoring or ledger rules.
+**Overview.** Build horizon **H0** from [docs/cloud-mvp.md](./cloud-mvp.md): a hosted **async** loop. Onboard once, enqueue a round, workers discover / assess / fill / submit in the background. `cloud llm` prefers local Ollama when the tailnet is up, else a hosted API. Agent Submit when the gate passes. Live view is for hard stops and `review-each`. The HTTP API never holds a browser. Auth stays out of H0.
 
 ## Technical approach
 
@@ -12,9 +12,9 @@ Reuse the OSS CLI as the source of truth for candidate state. Add a new `cloud/`
 |---|---|---|
 | Profile, résumé, ledger, rounds, attention enums | Existing `job-application.mjs` via import + subprocess | Extract shared package both skill and worker import |
 | Discovered jobs, watched slugs, assessments, browser sessions | New SQLite in `cloud/data/` (gitignored) | D1 / Postgres + R2 |
-| Must-have assessment | `cloud llm assess` → hosted API → `mustHaves` + `scoreJob`. Heuristic fallback. Never a local model | Same |
+| Must-have assessment | Async `assess` job: Ollama (if reachable) → hosted API → heuristic, then `scoreJob` | Same |
 | Prefill | Deterministic `questions[]` + synonym map; `cloud llm map-fields` / `draft` for leftovers and essays | Same |
-| Apply | Playwright + Chromium on a **new Fly Machine** (not Paisewise); agent Submit when the gate passes | Browser adapter `{launch, fill, submit, handoff, heartbeat, close}` |
+| Apply | Async `fill` / `submit` jobs on a **new Fly Machine**; never inline in an HTTP handler | Browser adapter + work queue |
 | Takeover | noVNC / CDP live view URL stored on `browser_sessions` | Cloudflare Browser Run or Steel/Browserbase |
 | Operator UI | One local page, bound to `fly proxy` / WireGuard | Quiet Trust UI on the existing site |
 
@@ -40,10 +40,12 @@ cloud/
     db.mjs              # SQLite
     skill.mjs           # import + subprocess bridge
     discover/{greenhouse,lever,ashby,normalize}.mjs
-    llm.mjs             # assess | map-fields | draft → hosted API, JSON only
-    assess.mjs          # llm first, heuristic fallback, then scoreJob
+    llm.mjs             # assess | map-fields | draft; Ollama then hosted API
+    assess.mjs          # enqueue / drain assess jobs, then scoreJob
+    queue.mjs           # work_queue: discover, assess, fill, submit, handoff
     apply/{browser,greenhouse,lever,ashby,handoff}.mjs
-    server.mjs          # localhost API + operator page
+    worker.mjs          # long-running drain loop
+    server.mjs          # enqueue only; no Playwright in the request path
   data/                 # gitignored
 ```
 
@@ -56,7 +58,7 @@ Must exist before Phase 1 coding:
 - Node 20+, Chromium for Playwright (in that image)
 - Your `profile set` JSON and canonical PDF
 - A `boards.json` seed of companies you would actually join (start with 20 slugs, not 200)
-- A hosted LLM API key as a Fly secret (`ANTHROPIC_API_KEY` or equivalent). Used only by `cloud llm`. Heuristic fallback if unset. No on-box model.
+- Optional: Ollama on your laptop, reachable from Fly over Tailscale (`OLLAMA_HOST=http://<tailnet>:11434`). Optional hosted API key as fallback so async apply does not stall when the laptop is closed. Heuristic if neither is up.
 
 Must **not** be in place: auth, Dodo activation, public DNS, Cloudflare Browser Run, LinkedIn session, anything running on the Paisewise app.
 
@@ -73,6 +75,8 @@ Keep cloud code out of the published skill.
 - [ ] README: how to point `JOB_APPLICATION_STATE_DIR` at the Fly volume (and local `cloud/data/skill-state` for laptop runs)
 - [ ] Dockerfile + `fly.toml` for the new app only: Chromium/Playwright deps, volume mount, no Paisewise hostname
 - [ ] Document `fly proxy` as the operator path; do not allocate a public IPv4 for the UI
+- [ ] `work_queue` table + `worker.mjs` drain loop (discover / assess / fill / submit / handoff)
+- [ ] Server routes only enqueue; Playwright and `cloud llm` run in the worker
 
 **Done when:** `node cloud/src/cli.mjs status` prints skill profile status without writing candidate data into the repo, and the Fly app is a separate process from Paisewise.
 
@@ -100,30 +104,31 @@ HTTP only. No browser.
 - [ ] Normalize to `{company, role, title, description, url, employerJobId, applicationChannel, discoverySource, locations, salaryMaximum, salaryCurrency, workMode}`
 - [ ] Upsert `jobs` on canonical URL / employer job id; skip closed
 - [ ] For Greenhouse, persist the `questions` array for pre-flight later
-- [ ] `cloud discover` is idempotent and safe to cron
+- [ ] `cloud discover` enqueues a `discover` job (or runs in the worker on cron). Idempotent.
 
 **Done when:** 20 slugs produce a de-duplicated `jobs` table with direct apply URLs and descriptions. No scoring yet.
 
-### Phase 3 — Assess and queue
+### Phase 3 — Assess (async)
 
-LLM CLI for accuracy; `scoreJob` stays pure.
+LLM CLI for accuracy; `scoreJob` stays pure. Never call this inside an HTTP handler.
 
-- [ ] `cloud llm assess --stdin`: JD + résumé + profile → `mustHaves[]` with quoted evidence, plus eligibility / seniority / workMode
-- [ ] Fail closed: no quote → `unclear`; invalid JSON → heuristic fallback; you can `cloud assess --job` by hand
-- [ ] Call `scoreJob` on that payload; store the full result (and raw model JSON) on `assessments`
-- [ ] Cache by job id + résumé hash so refill does not re-call
-- [ ] `exclude` / `skip` stay out of the fill queue
-- [ ] `ask` becomes an attention item — no browser yet
-- [ ] `review` enters the fill queue; `autoEligible` + `routine-auto` may Submit after fill
-- [ ] `ledger check` before queueing; hard duplicates never enter
+- [ ] New jobs enqueue `assess`. Worker drains when a provider is up
+- [ ] `cloud llm` tries Ollama (`OLLAMA_HOST` on the tailnet, short timeout) then hosted API then heuristic
+- [ ] Unreachable providers: leave the row `pending_llm`; keep discovering and filling already-assessed jobs
+- [ ] `cloud llm assess --stdin`: JD + résumé + profile → `mustHaves[]` with quoted evidence
+- [ ] Fail closed: no quote → `unclear`; invalid JSON → heuristic; `cloud assess --job` by hand
+- [ ] Call `scoreJob`; cache by job id + résumé hash
+- [ ] `exclude` / `skip` stay out of fill; `ask` → attention; `review` → enqueue `fill`
+- [ ] `ledger check` before enqueueing fill
 - [ ] Review the first 20 assess outputs before trusting `autoEligible`
 
-**Done when:** a discover → `cloud llm assess` → `scoreJob` pass leaves a fill queue whose `met` rows quote the résumé. Empty `mustHaves` never reaches fill.
+**Done when:** `cloud round start` returns immediately, a worker assesses in the background, and `pending_llm` drains when Ollama or the hosted API appears. Empty `mustHaves` never reaches fill.
 
-### Phase 4 — Fill (Greenhouse first)
+### Phase 4 — Fill and submit (async, Greenhouse first)
 
-One channel until it is boring.
+Worker jobs only. One Chromium lease at a time on the personal Machine.
 
+- [ ] `fill` / `submit` are queue types; the API never launches Playwright
 - [ ] Playwright launches Chromium with a dedicated `cloud/data/chrome-profile`
 - [ ] Open the job `url`, not a Google/LinkedIn redirect
 - [ ] Prefill known fields from Greenhouse `questions` ids → profile keys; synonym map next
@@ -228,10 +233,10 @@ Do not start this until Phase 8 is done.
 
 When implementation starts, land in this order so each PR stays reviewable:
 
-1. `cloud/` skeleton + skill bridge + gitignore (Phase 0)
+1. `cloud/` skeleton + skill bridge + work queue + gitignore (Phase 0)
 2. `onboard` / `status` (Phase 1)
-3. `discover` + `boards.json` example (Phase 2)
-4. `cloud llm assess` + fill queue (Phase 3)
+3. async `discover` + `boards.json` example (Phase 2)
+4. async `cloud llm assess` (Ollama then hosted) (Phase 3)
 5. Greenhouse fill + agent Submit (Phase 4)
 6. Handoff for hard stops + `ledger add` on confirmation (Phase 5)
 7. Localhost operator page (Phase 6)

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -13,9 +13,9 @@ Reuse the OSS CLI as the source of truth for candidate state. Add a new `cloud/`
 | Profile, résumé, ledger, rounds, attention enums | Existing `job-application.mjs` via import + subprocess | Extract shared package both skill and worker import |
 | Discovered jobs, watched slugs, assessments, browser sessions | New SQLite in `cloud/data/` (gitignored) | D1 / Postgres + R2 |
 | Must-have assessment | LLM (or you) writes the `score --stdin` payload; never invent evidence | Same, with stored prompts and review |
-| Apply | Playwright + local Chromium, never click Submit | Browser adapter `{launch, fill, handoff, heartbeat, close}` |
+| Apply | Playwright + Chromium on a **new Fly Machine** (not Paisewise), never click Submit | Browser adapter `{launch, fill, handoff, heartbeat, close}` |
 | Takeover | noVNC / CDP live view URL stored on `browser_sessions` | Cloudflare Browser Run or Steel/Browserbase |
-| Operator UI | One local page, bound to localhost / Tailscale | Quiet Trust UI on the existing site |
+| Operator UI | One local page, bound to `fly proxy` / WireGuard | Quiet Trust UI on the existing site |
 
 **Do not extend `attention.ndjson` with a live-view URL.** The CLI schema is closed. Store `session_id` + `live_view_url` on `browser_sessions` and join by `applicationId`.
 
@@ -49,13 +49,14 @@ cloud/
 
 Must exist before Phase 1 coding:
 
-- A machine you control (laptop is fine; a small VM is better)
-- Node 20+, Chromium for Playwright
+- A **new** Fly app in the same org as Paisewise (`job-application-agent` or similar). Do not reuse the Paisewise Machine, volume, or image.
+- That Machine: ≥2 GB RAM, 2 shared CPUs, 10 GB volume, `auto_stop` off during a round
+- Node 20+, Chromium for Playwright (in that image)
 - Your `profile set` JSON and canonical PDF
 - A `boards.json` seed of companies you would actually join (start with 20 slugs, not 200)
 - An LLM key **only** for assessment, or willingness to assess the first batch by hand
 
-Must **not** be in place: auth, Dodo activation, public DNS, Cloudflare Browser Run, LinkedIn session.
+Must **not** be in place: auth, Dodo activation, public DNS, Cloudflare Browser Run, LinkedIn session, anything running on the Paisewise app.
 
 ## Phases
 
@@ -67,9 +68,11 @@ Keep cloud code out of the published skill.
 - [ ] Leave root `package.json` `files` unchanged so `npx job-application-agent` does not ship this
 - [ ] Gitignore `cloud/data/`, `cloud/.env`, uploaded PDFs
 - [ ] `cloud/src/skill.mjs` can `profile check` against a configured state dir
-- [ ] README: how to point `JOB_APPLICATION_STATE_DIR` at `cloud/data/skill-state`
+- [ ] README: how to point `JOB_APPLICATION_STATE_DIR` at the Fly volume (and local `cloud/data/skill-state` for laptop runs)
+- [ ] Dockerfile + `fly.toml` for the new app only: Chromium/Playwright deps, volume mount, no Paisewise hostname
+- [ ] Document `fly proxy` as the operator path; do not allocate a public IPv4 for the UI
 
-**Done when:** `node cloud/src/cli.mjs status` prints skill profile status without writing candidate data into the repo.
+**Done when:** `node cloud/src/cli.mjs status` prints skill profile status without writing candidate data into the repo, and the Fly app is a separate process from Paisewise.
 
 ### Phase 1 — Onboarding
 

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -12,8 +12,8 @@ Reuse the OSS CLI as the source of truth for candidate state. Add a new `cloud/`
 |---|---|---|
 | Profile, résumé, ledger, rounds, attention enums | Existing `job-application.mjs` via import + subprocess | Extract shared package both skill and worker import |
 | Discovered jobs, watched slugs, assessments, browser sessions | New SQLite in `cloud/data/` (gitignored) | D1 / Postgres + R2 |
-| Must-have assessment | Heuristic: JD tokens vs `profile.skills` / résumé text, then `scoreJob`. Hand override. Optional HTTP LLM later, never a local model | Same |
-| Prefill | ATS `questions` + label synonym map + stored answers. No model | Same |
+| Must-have assessment | `cloud llm assess` → hosted API → `mustHaves` + `scoreJob`. Heuristic fallback. Never a local model | Same |
+| Prefill | Deterministic `questions[]` + synonym map; `cloud llm map-fields` / `draft` for leftovers and essays | Same |
 | Apply | Playwright + Chromium on a **new Fly Machine** (not Paisewise); agent Submit when the gate passes | Browser adapter `{launch, fill, submit, handoff, heartbeat, close}` |
 | Takeover | noVNC / CDP live view URL stored on `browser_sessions` | Cloudflare Browser Run or Steel/Browserbase |
 | Operator UI | One local page, bound to `fly proxy` / WireGuard | Quiet Trust UI on the existing site |
@@ -40,7 +40,8 @@ cloud/
     db.mjs              # SQLite
     skill.mjs           # import + subprocess bridge
     discover/{greenhouse,lever,ashby,normalize}.mjs
-    assess.mjs          # heuristic mustHaves + scoreJob; optional HTTP LLM later
+    llm.mjs             # assess | map-fields | draft → hosted API, JSON only
+    assess.mjs          # llm first, heuristic fallback, then scoreJob
     apply/{browser,greenhouse,lever,ashby,handoff}.mjs
     server.mjs          # localhost API + operator page
   data/                 # gitignored
@@ -55,7 +56,7 @@ Must exist before Phase 1 coding:
 - Node 20+, Chromium for Playwright (in that image)
 - Your `profile set` JSON and canonical PDF
 - A `boards.json` seed of companies you would actually join (start with 20 slugs, not 200)
-- No LLM key. Prefill and `scoreJob` are deterministic. An API key is optional later for essays only — never a local model on the Fly box.
+- A hosted LLM API key as a Fly secret (`ANTHROPIC_API_KEY` or equivalent). Used only by `cloud llm`. Heuristic fallback if unset. No on-box model.
 
 Must **not** be in place: auth, Dodo activation, public DNS, Cloudflare Browser Run, LinkedIn session, anything running on the Paisewise app.
 
@@ -105,21 +106,19 @@ HTTP only. No browser.
 
 ### Phase 3 — Assess and queue
 
-No model. The coding agent does this today by reading the posting; on Fly we use a heuristic plus `scoreJob`.
+LLM CLI for accuracy; `scoreJob` stays pure.
 
-- [ ] For each new job, build a `score --stdin` payload:
-  - `postingStatus: active` only after the apply URL still resolves
-  - `eligibility` from structured onboarding flags + location text; `unclear` if not explicit
-  - `mustHaves[]` from JD token overlap with `profile.skills` and résumé text (`met` / `missing` only — no invented evidence)
-- [ ] Call `scoreJob(job, profile)`; store the full result on `assessments`
-- [ ] `cloud assess --job <id>` lets you override a heuristic by hand
+- [ ] `cloud llm assess --stdin`: JD + résumé + profile → `mustHaves[]` with quoted evidence, plus eligibility / seniority / workMode
+- [ ] Fail closed: no quote → `unclear`; invalid JSON → heuristic fallback; you can `cloud assess --job` by hand
+- [ ] Call `scoreJob` on that payload; store the full result (and raw model JSON) on `assessments`
+- [ ] Cache by job id + résumé hash so refill does not re-call
 - [ ] `exclude` / `skip` stay out of the fill queue
 - [ ] `ask` becomes an attention item — no browser yet
 - [ ] `review` enters the fill queue; `autoEligible` + `routine-auto` may Submit after fill
 - [ ] `ledger check` before queueing; hard duplicates never enter
-- [ ] Do not add an on-box LLM. An HTTP assessor is a later optional adapter behind the same `mustHaves` shape.
+- [ ] Review the first 20 assess outputs before trusting `autoEligible`
 
-**Done when:** a discover → assess pass leaves a fill queue of `review` jobs using only Node + the existing CLI. Empty `mustHaves` never reaches fill.
+**Done when:** a discover → `cloud llm assess` → `scoreJob` pass leaves a fill queue whose `met` rows quote the résumé. Empty `mustHaves` never reaches fill.
 
 ### Phase 4 — Fill (Greenhouse first)
 
@@ -127,10 +126,11 @@ One channel until it is boring.
 
 - [ ] Playwright launches Chromium with a dedicated `cloud/data/chrome-profile`
 - [ ] Open the job `url`, not a Google/LinkedIn redirect
-- [ ] Prefill from Greenhouse `questions` ids → profile keys; fall back to a label synonym map; unknown required field → attention
+- [ ] Prefill known fields from Greenhouse `questions` ids → profile keys; synonym map next
+- [ ] Leftover required labels: `cloud llm map-fields`; still `unclear` → attention
 - [ ] Upload résumé with `setInputFiles` / file chooser using `resume path` ([BROWSER_UPLOADS.md](../job-application-agent/references/BROWSER_UPLOADS.md))
 - [ ] After ATS parse, restore any verified field the parser changed
-- [ ] Narratives: paste `motivationBlurb` or stop. No on-box draft model.
+- [ ] Narratives: `cloud llm draft` grounded in `motivationBlurb` + résumé; `review-each` still shows the draft before send
 - [ ] Stop on login, MFA, CAPTCHA, legal, demographic, government-id, unclear compensation/authorization, unverifiable claim, “Apply with LinkedIn”
 - [ ] Implement the submit gate from [cloud-mvp.md](./cloud-mvp.md#when-the-agent-submits)
 - [ ] On a passing gate: screenshot, click Submit, wait for confirmation, `ledger add` with `STANDING AUTHORIZATION`
@@ -202,7 +202,7 @@ Do not start this until Phase 8 is done.
 
 | Risk | Why it shows up | Mitigation |
 |---|---|---|
-| Assessor invents experience | `scoreJob` will happily score invented `met` evidence | H0 heuristic only marks `met` on explicit skill overlap; hand override; no on-box model |
+| Assessor invents experience | `scoreJob` will happily score invented `met` evidence | `cloud llm assess` must quote résumé text; no quote → `unclear`; first 20 reviewed; heuristic fallback only |
 | Greenhouse iframe / “Apply with LinkedIn” | Fill script clicks the wrong surface | Prefer the hosted board apply form; stop on LinkedIn overlay |
 | ATS résumé parse clobbers fields | Local runbook already warns | Re-read fields after upload; restore from profile |
 | Bot detection | Worse on hosted browsers than on a residential VM | Dogfood on your VM first; vendor choice is an output of Phase 8 |

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -2,7 +2,7 @@
 
 **Specification:** [docs/cloud-mvp.md](./cloud-mvp.md)
 
-**Overview.** Build a single-tenant hosted loop you can run for yourself: onboard once, discover Greenhouse / Lever / Ashby jobs over HTTP, score with the existing runbook, fill in a Playwright browser, and hand you the live tab to submit. Auth, multi-tenant isolation, and founding-access gating stay out. Do not fork scoring or ledger rules.
+**Overview.** Build horizon **H0** from [docs/cloud-mvp.md](./cloud-mvp.md): a hosted loop that keeps a truthful search moving and only pulls the candidate in for real decisions. Onboard once, discover Greenhouse / Lever / Ashby over HTTP, score with the existing runbook, fill in Playwright, open a **just-in-time** live view to submit, record `submitted` only after visible confirmation. Auth and multi-tenant isolation stay out of H0. Do not fork scoring or ledger rules. Do not treat “keep the same tab warm” as the goal — that is an H0 convenience. H1/H2 need acquire → refill → release.
 
 ## Technical approach
 

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -304,6 +304,74 @@ Run one round of 10. Write down, per channel:
 
 That log chooses Cloudflare Browser Run vs Steel vs Browserbase for the September product. Do not choose from this document alone.
 
+## Scale: 100 users × 100 pending submits
+
+That is **10,000 ledger rows**, not 10,000 open browsers. The personal Fly Machine will not do this. The control plane can, if we treat a browser as a short lease and the pending queue as data.
+
+### What is actually concurrent
+
+| Work | Count at that load | Needs a live browser? |
+|---|---|---|
+| Discovered / scored jobs | tens of thousands | No. HTTP + `scoreJob`. |
+| Fill backlog (agent completing forms) | up to 10,000 in `queued` / `filling` | Yes, only while filling. One tab per in-flight fill. |
+| Waiting for the user to submit | 10,000 in `needs_attention` | **No.** Persist the row. Do not hold Chromium. |
+| User sitting in live view | maybe 5–30 at once | Yes. One tab per active handoff. |
+
+A Chrome context is hundreds of MB. Holding 10,000 tabs would be terabytes of RAM. Holding **~20 fill workers + ~20 handoff workers** is a normal pool.
+
+Pending-to-submit is an inbox. The already-planned refill path (“session died → reopen URL → refill from profile → new live view”) is the scale path, not an error path.
+
+```mermaid
+flowchart LR
+  Q[Per-user fill queue] --> Pool[Browser pool]
+  Pool --> Ready[needs_attention row]
+  Ready --> Inbox[User inbox]
+  Inbox -->|Open one| Lease[Lease browser + refill]
+  Lease --> Live[Live view]
+  Live -->|Submit + confirm| Done[submitted]
+  Live --> Pool
+```
+
+### Capacity sketch
+
+Assumptions: Greenhouse-class fills, ~3–5 minutes each, users submit when they have time.
+
+- **Fill:** 10,000 × 4 min ≈ 670 browser-hours. A pool of 20 fillers clears a full backlog in a bit over a day, then keeps up with daily discovery.
+- **Handoff:** sized to *people in the tab now*, not pending count. 100 users with 100 ready items still only need ~10–30 browsers if they are not all clicking at once.
+- **One Fly Machine (2–4 GB):** one user, one or two tabs. Fine for dogfood. Not this load.
+- **This load:** a browser pool (more Fly Machines, or Steel / Browserbase / Kernel / Cloudflare Browser Run) behind the same `{launch, fill, handoff, heartbeat, close}` adapter. Postgres (or equivalent), not SQLite. One browser **context per user** — never a shared Chrome profile.
+
+Discovery and scoring stay cheap. They are not the bottleneck.
+
+### What the user sees
+
+A person with 100 ready applications does not get 100 live tabs. They get a queue:
+
+1. Open the inbox (ready to submit / login / legal / missing answer).
+2. Click one. We lease a browser, refill, show live view.
+3. They submit or unblock. We confirm, record, release the browser.
+4. Optional “next ready” so they can walk the list.
+
+That is still 100 human submits unless a channel later earns auto-submit. The product win at this scale is “every form is already true,” not “one click empties 100.” Auto-submit, if it ever lands, is per-channel after dogfood — not a way to skip the pool.
+
+### Isolation and abuse
+
+- Tenant boundary: profile, résumé, answers, ledger, attention, and browser context are per user.
+- Same-user fills may reuse that user’s context (cookies they created). **Never** reuse it across users.
+- Stagger fills. One Fly egress IP blasting 10,000 Greenhouse POSTs will look like a botnet. Per-user or small-pool proxies, plus rate limits per channel, become required.
+- D1 is fine for founding checkout. 10,000 applications with JD snapshots and screenshots want Postgres + object storage.
+
+### What we must not paint into a corner in the MVP
+
+The single-user Fly box can keep a tab warm overnight. The APIs should still look like this so the pool can replace it:
+
+- Applications are rows with `queued | filling | needs_attention | submitted | abandoned`.
+- Attention items join to a *session id that may be null*.
+- “Open live session” means *acquire, refill, hand off*, not *attach to a process that has been up for hours*.
+- Browser vendor is behind the adapter.
+
+If we do that on day one, 100 × 100 is an ops and tenancy problem, not a new agent.
+
 ## Path to the public cloud
 
 Only after the personal loop works.

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -178,6 +178,32 @@ Job-board scraping, scoring, “must-have” lists, Ollama, Fly, Playwright. If 
 
 Monday: set up. Monday evening: start 10. Tuesday–Thursday: two or three “needs you” pings, you spend a minute each. Friday: History shows the ones that really sent.
 
+## How AI helps (and which)
+
+AI is a **reader and writer**, not the applicant. It never logs in, never solves CAPTCHA, never clicks Send on its own authority. `scoreJob` and the form filler stay ordinary code.
+
+It does three jobs:
+
+1. **Fit** — Read this job post against your résumé. List must-haves as met / partial / missing, with a quote from the résumé. That is how we skip a Staff role when you are Senior, or a GraphQL-required role you do not have.
+2. **Weird labels** — The form says “Corporate e-mail” or “Notice (days)”. Map it to a profile field or say “unclear” and ping you. It does not invent a value.
+3. **Short answers** — “Why this company?” It rewrites your saved paragraph so it names that product, still only using résumé facts.
+
+Without AI we can still type name, email, phone, and attach the PDF. We apply to more wrong jobs and write flatter “why us” answers.
+
+### Which AI
+
+One CLI (`cloud llm`). Swap the engine; keep the JSON contract.
+
+| Order | Engine | Where it runs | When |
+|---|---|---|---|
+| 1 | **Ollama** (a model you already pull, e.g. Llama 3.1 or Qwen 2.5) | Your laptop / home box | Tailscale is up. Résumé stays on your LAN. |
+| 2 | **Anthropic Claude Sonnet** (default hosted) | Their API, called from Fly | Ollama is off, so the round still moves. |
+| 3 | Keyword overlap | Fly, no model | Both of the above are down. Worse fit. |
+
+OpenAI is a drop-in second hosted option if we do not want an Anthropic key. We are **not** putting Cursor, Codex, or Claude Code in the cloud to click the page. We are **not** training our own job model. We are **not** running Ollama on the small Fly Machine next to Chrome.
+
+Default for H0: Claude Sonnet on Fly when you are away; Ollama when you leave it on. You review the first 20 fit/draft outputs. If it cannot quote the résumé, it must say unclear — then you get the inbox, not a lie on the form.
+
 ## User and system flow
 
 You do a little, up front and when something is actually a decision. The Fly worker does the rest in the background.

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -182,7 +182,11 @@ The product need is narrow: a Chromium we drive with Playwright, a way to upload
 
 ### Recommendation
 
-**Personal MVP: Playwright on a VM you control.** One persistent Chromium user-data dir, Playwright driving it, and a VNC / Live View tab you open when attention fires. Pair it with SQLite or local Postgres and the existing `score` / `ledger` CLI.
+**Personal MVP: a new Fly app, not the Paisewise Machine.** Paisewise (Founder's Office / payroll) stays on its current Fly Machine. The apply loop gets a second app in the same Fly org, with its own Machine, volume, and sleep settings. Do not share the Paisewise process, volume, or public hostname.
+
+Target size: ≥2 GB RAM, 2 shared CPUs, a 10 GB volume for Chrome profile / SQLite / résumé / ledger, `auto_stop` off while a round is running. Reach it with `fly proxy` or WireGuard, not a public `.fly.dev` URL.
+
+Playwright on that Machine: one persistent Chromium user-data dir, and a VNC / Live View tab you open when attention fires. Pair it with SQLite and the existing `score` / `ledger` CLI.
 
 **If the first week shows takeover is the painful part,** switch the browser host to Steel Cloud or Browserbase. Keep the same control plane.
 

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -246,6 +246,8 @@ Rules carried over unchanged:
 
 ## Personal MVP build order
 
+The sequenced tasks, acceptance checks, and first-commit order live in [docs/cloud-implementation-plan.md](./cloud-implementation-plan.md). This section is the short version.
+
 Keep this small enough to run for yourself before any customer auth.
 
 ### 1. Control plane on one box

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -116,7 +116,7 @@ Auth is a later gate in front of the same API. For MVP, bind the process to a ma
 1. **Onboard.** Collect every field the current CLI already requires, plus the extras that ATS forms ask every week. Upload one canonical résumé. Nothing is inferred.
 2. **Discover.** Pull public ATS boards and the existing catalog. Normalize to `{company, role, url, employerJobId, applicationChannel, discoverySource}`.
 3. **Qualify.** Reuse `score`. Keep `exclude` / `ask` / `skip` / `review` and `autoEligible`. `autoEligible` plus `routine-auto` plus a clean page means the agent may Submit.
-4. **Fill.** Open the direct apply URL in the hosted browser. Fill profile facts, upload the résumé, draft narrative answers from `APPLICATION_GUIDANCE.md`.
+4. **Fill.** Open the direct apply URL. Prefill from the profile and ATS question schema — no model. Upload the résumé. Narratives use a stored blurb or, optionally, an HTTP LLM. See [Prefill without a model](#prefill-without-a-model).
 5. **Submit or pause.** If the submit gate below passes, the agent clicks Submit and waits for confirmation. If a hard stop fires or the profile is `review-each`, write an attention item instead.
 6. **Handoff (only when needed).** The operator opens a live view (same tab if it is still up, otherwise acquire + refill) and handles login / CAPTCHA / legal / judgment. They may also Submit in `review-each`.
 7. **Confirm.** Only after a visible success page does the system write `submitted`. No confirmation, no ledger row. Never click Submit a second time if confirmation is unclear — queue attention as `other` / site-error.
@@ -140,6 +140,46 @@ The agent clicks Submit only when **all** of these are true:
 Otherwise stop and hand off. First Greenhouse dogfood run may still be watched (log the click, screenshot before/after) so a bad detector cannot silently double-apply. After one clean confirmed Greenhouse submit, that channel stays allowlisted until friction says otherwise.
 
 `review-each` is still a first-class mode: fill everything, then live view for the candidate to send.
+
+## Prefill without a model
+
+The local product looks like it “uses AI” because a coding agent reads the page. The CLI itself has **no model**. `scoreJob`, `validateProfile`, and `ledger check` are pure functions. Cloud should keep it that way on the Fly Machine.
+
+**Do not run a local LLM in the CLI or on that box.** A 2 GB Fly Machine cannot host a useful model next to Chromium. If we want generated prose or richer must-haves later, the worker calls a **hosted API** (Anthropic, OpenAI, etc.) over HTTPS. That is optional and off by default for H0.
+
+### What fills the form
+
+| Input | How it gets onto the page | AI? |
+|---|---|---|
+| Name, email, phone, location, links | Profile JSON → Greenhouse/Lever/Ashby `questions` (field id + type) or DOM hints (`type=email`, `autocomplete`, label synonym map) | No |
+| Résumé | `resume path` + `setInputFiles` | No |
+| Work auth / sponsorship / salary | Structured onboarding fields, then exact label match or stored `answers` fingerprint | No |
+| “Have you applied here?” | `ledger check` for that company | No |
+| Must-haves for `scoreJob` | Keyword overlap: JD text vs `profile.skills` / résumé text → `met` / `missing`. Coverage below the floor → `skip` | No |
+| “Why this company” / cover letter | Stored `motivationBlurb` from onboard, or attention if the form requires a long original | No (default) |
+| Richer evidence / company-specific essay | Optional HTTP LLM with résumé + JD; never invent; you review the first batch | API only, not on-box |
+
+Greenhouse is the reason this works without a model: `GET /v1/boards/{slug}/jobs/{id}` returns a `questions` array (name, email, phone, resume, custom ids). The adapter maps those ids to profile keys. Lever and Ashby are the same idea with worse schemas; unknown labels become attention, not a guess.
+
+A synonym map covers the messy DOM case: `["email", "e-mail", "work email"]` → `profile.email`. If nothing matches, stop. Do not ask a model to invent a mapping on the first pass.
+
+### What still runs on the Fly Machine
+
+Node, the existing CLI (`score`, `ledger`, `profile`, `resume`), Playwright, SQLite. That is the whole runtime.
+
+`assess.mjs` in H0 is a **heuristic**: tokenize the JD, match `profile.skills`, emit `mustHaves`, call `scoreJob`. You can override with `cloud assess --job` by hand. An LLM key is not a dependency.
+
+### What we collect so we do not need a model mid-form
+
+Add these at onboard (structured, not prose):
+
+- `authorizedWithoutSponsorship` per target country (yes / no / unclear)
+- `needsSponsorship` (yes / no)
+- `willingToRelocate` (yes / no / unclear)
+- `motivationBlurb` — 100–150 words, written by you, reused when a form asks “why us” / cover letter
+- `howHeard` default (“company careers page” / “other”)
+
+Visa and salary stay in your words as today; the booleans are what the checkboxes actually ask.
 
 ## Details to collect
 
@@ -168,6 +208,8 @@ Collect on the same screen even though some are optional in the CLI. They appear
 - Citizenship / visa status as free text (“Indian citizen, no US sponsorship needed” / “Need H-1B transfer”) — stored as `workAuthorization`, never as a government ID
 - Preferred name, pronouns only if the candidate volunteers them
 - How they want to hear about pauses (email is enough for MVP)
+- Structured flags so forms do not need a model: `authorizedWithoutSponsorship`, `needsSponsorship`, `willingToRelocate`
+- `motivationBlurb` (100–150 words, written by you) and a default `howHeard`
 
 ### Ask when a form requires it
 

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -98,7 +98,8 @@ flowchart TB
   Score --> DB
   Score --> Apply
   Apply --> DB
-  Apply -->|needs human or ready to submit| Live
+  Apply -->|hard stop or review-each| Live
+  Apply -->|gate passes| DB
   Live --> UI
   Live -->|confirmed| DB
 ```
@@ -110,6 +111,72 @@ Three layers, one tenant:
 - **Apply.** A real Chromium session. The agent fills and, when the form is routine and complete, clicks Submit. The operator is pulled in only for hard stops or `review-each`.
 
 Auth is a later gate in front of the same API. For MVP, bind the process to a machine you control and do not expose it publicly.
+
+## End user flow
+
+This is the product as you use it. No queues, no worker names.
+
+```mermaid
+flowchart TD
+  A[Open the app] --> B[Fill your profile once]
+  B --> C[Upload résumé]
+  C --> D[Start a round]
+  D --> E[Close the app and go do something else]
+  E --> F{Phone buzzes?}
+  F -->|Submitted quietly| G[Open History: another job is in]
+  F -->|Needs you| H[Open Inbox]
+  H --> I[One company page is already filled]
+  I --> J[You log in / solve CAPTCHA / answer one thing / press Submit]
+  J --> E
+  G --> E
+```
+
+### Screen 1 — First time only
+
+You open the app (your private page in H0; login later in H1).
+
+You type the facts employers always ask: name, email, phone, location, visa, roles you want, salary floor, LinkedIn. You upload one PDF. You write a short “about me / why I am looking” paragraph once. You pick:
+
+- **Send for me** when the form is straightforward, or
+- **I will press Send** on every job
+
+You are done with setup. You do not hunt for jobs on this screen.
+
+### Screen 2 — Start a round
+
+You tap something like **Find and apply to 10**. The app says “Running” and that is it. You can lock the phone.
+
+You do not watch listings load. You do not watch forms fill.
+
+### Screen 3 — Home, later
+
+When you come back you see three piles:
+
+- **Sent** — the company showed a thank-you page. That is the only “applied” that counts.
+- **Needs you** — a form is stuck on login, CAPTCHA, a legal box, or a question we will not guess.
+- **Working** — still searching or filling. You can ignore this.
+
+Most Greenhouse-style jobs should move from Working → Sent without you.
+
+### Screen 4 — Inbox (only when it buzzes)
+
+A notification: “Acme needs you — sign in.”
+
+You tap it. You see **their** apply page, already filled with your name, email, résumé. You only do the human bit (Google login, CAPTCHA, “I agree”, or Send if you chose review-each). You tap Done. The app goes back to working. You can leave.
+
+You never get 100 tabs. You get the next one that actually needs you.
+
+### Screen 5 — A question, not a page
+
+Sometimes it is not a CAPTCHA. The form asked “salary for this role?” and we do not have a number. The inbox is one field. You type it. We remember it for the next company. No live browser.
+
+### What you never see
+
+Job-board scraping, scoring, “must-have” lists, Ollama, Fly, Playwright. If Ollama is off, apply still runs (hosted model or it waits to score). You are not asked to start a model to use the product.
+
+### One week in a sentence
+
+Monday: set up. Monday evening: start 10. Tuesday–Thursday: two or three “needs you” pings, you spend a minute each. Friday: History shows the ones that really sent.
 
 ## User and system flow
 

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -152,12 +152,10 @@ Known facts stay deterministic. Accuracy-sensitive reading uses an **LLM CLI** o
 | Step | Who | Why |
 |---|---|---|
 | Name, email, phone, links, résumé, stored answers, ledger “applied here?” | Deterministic adapter (`questions[]` + synonym map + profile) | Fast, no hallucination |
-| Must-haves + evidence, messy labels, eligibility nuance, “why this company” | `cloud llm …` → hosted API | Same judgment quality as the laptop agent |
+| Must-haves + evidence, messy labels, eligibility nuance, “why this company” | `cloud llm …` → first reachable provider | Same judgment quality as the laptop agent |
 | Hard stops (legal, demographics, IDs, CAPTCHA) | Human | Model must not answer |
 
-Heuristic skill-overlap is the **fallback** if the key is missing or the call fails — not the accuracy path.
-
-### LLM CLI (on our Fly Machine, not a local model)
+### LLM CLI and providers
 
 ```text
 cloud llm assess --stdin    # JD + résumé + profile → mustHaves[], eligibility, seniority, workMode
@@ -165,7 +163,17 @@ cloud llm map-fields --stdin  # leftover labels → profile key | stored answer 
 cloud llm draft --stdin     # question + company + résumé → short answer per APPLICATION_GUIDANCE.md
 ```
 
-Implementation: Node `fetch` to Anthropic or OpenAI, or a thin shell-out to an installed `llm` / vendor CLI. Same JSON contract either way. Store the API key as a Fly secret. **Do not run Ollama or another on-box model** — 2 GB cannot hold Chrome and weights, and we want one testable interface.
+Same JSON contract. The worker does **not** block the apply HTTP call on this. Assess is a queue job (see [Async apply](#async-apply)).
+
+Provider order, first success wins:
+
+1. **Ollama on your machine** — when reachable. You run `ollama serve` locally (or on a home box). Fly reaches it over the same Tailscale / WireGuard path as `fly proxy` (`http://<tailnet-host>:11434`). Bind Ollama to the tailnet interface, not public `0.0.0.0`. Résumé text stays on your LAN when this path is up.
+2. **Hosted API** (Anthropic / OpenAI) — Fly secret. Used when Ollama is down or unconfigured so the async loop keeps moving.
+3. **Heuristic** — skill-overlap only. Last resort, not the accuracy path.
+
+`cloud llm` probes Ollama with a short timeout (a couple of seconds). Unreachable → try the next provider. Do **not** install Ollama on the 2 GB Fly Machine next to Chromium.
+
+If nothing is available, the job stays `pending_llm`. Discovery and already-assessed fills continue. When your laptop comes online, a worker drains that queue. Apply never sits in a request handler waiting for you to wake Ollama.
 
 Rules (same as `SKILL.md`):
 
@@ -180,7 +188,31 @@ Running full Codex/Claude Code on the box would also be accurate (that is today�
 
 ### What we still collect at onboard
 
-Structured flags and a `motivationBlurb` remain. They ground the model and fill checkboxes when the LLM is down.
+Structured flags and a `motivationBlurb` remain. They ground the model and fill checkboxes when every LLM provider is down.
+
+## Async apply
+
+Cloud apply is a **background queue**, not a request that holds a browser until Submit.
+
+`POST /rounds` (or `cloud round start`) returns a `roundId` immediately. Workers pull jobs:
+
+| Job | Waits for | Emits |
+|---|---|---|
+| `discover` | nothing | new `jobs` rows |
+| `assess` | a job row + an LLM provider (Ollama or hosted) | `assessments` + fill or `pending_llm` or attention |
+| `fill` | `review` assessment | filled application, or attention |
+| `submit` | passing submit gate | confirmation → ledger, or attention |
+| `handoff` | you opening a live view | resolved attention |
+
+Rules:
+
+- The operator API never calls Playwright or `cloud llm` inline. It enqueues.
+- One fill/submit at a time on the personal Fly Machine; later a pool. Other jobs stay queued.
+- `pending_llm` is a normal state. Ollama appearing later is a wake-up, not a deploy.
+- Attention pings you; it does not stall the rest of the round.
+- Idempotent: the same job id is not filled twice; `ledger check` still runs immediately before Submit.
+
+That is what “100 pending” already assumed. H0 uses the same shape with one worker.
 
 ## Details to collect
 
@@ -329,7 +361,8 @@ resumes             bytes or object-store key, sha256, original filename.
 discovery_sources   packaged + watched ATS slugs.
 jobs                canonical url, employer_job_id, company, role, channel, raw snapshot.
 assessments         score result + must-haves + gates. Private evidence stays here.
-applications        ledger rows. status: queued | filling | needs_attention | submitted | abandoned.
+applications        ledger rows. status: queued | pending_llm | filling | needs_attention | submitted | abandoned.
+work_queue          discover | assess | fill | submit | handoff. Async only.
 answers             reusable question fingerprint → candidate text.
 attention           existing attention event + session_id + live_view_url.
 rounds              requested count, counts, timestamps.

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -111,6 +111,78 @@ Three layers, one tenant:
 
 Auth is a later gate in front of the same API. For MVP, bind the process to a machine you control and do not expose it publicly.
 
+## User and system flow
+
+You do a little, up front and when something is actually a decision. The Fly worker does the rest in the background.
+
+```mermaid
+sequenceDiagram
+  actor You
+  participant UI as Operator UI
+  participant Q as Work queue
+  participant W as Fly worker
+  participant LLM as cloud llm
+  participant ATS as ATS board / apply page
+
+  You->>UI: Onboard profile + résumé + blurb
+  You->>UI: Start round of N
+  UI->>Q: enqueue discover
+  UI-->>You: roundId immediately
+
+  loop Background
+    W->>ATS: list jobs HTTP
+    W->>Q: enqueue assess per new job
+    W->>LLM: Ollama if up else hosted API
+    LLM-->>W: mustHaves JSON
+    W->>W: scoreJob + ledger check
+    alt skip exclude or ask
+      W->>UI: attention or drop
+    else review
+      W->>Q: enqueue fill
+      W->>ATS: Playwright prefill + résumé
+      alt submit gate passes
+        W->>ATS: click Submit
+        ATS-->>W: thank-you page
+        W->>UI: submitted in ledger
+      else hard stop or review-each
+        W->>UI: attention + live view
+        You->>ATS: unblock or Submit
+        W->>UI: submitted after confirm
+      end
+    end
+  end
+```
+
+### You (candidate)
+
+| When | What you do | What you do not do |
+|---|---|---|
+| Once | Onboard: profile, résumé, flags, `motivationBlurb`, `routine-auto` or `review-each`. Optionally start Ollama on the tailnet. | Sit in a browser while jobs are found |
+| Start a search | “Round of 10.” Get a `roundId` back immediately | Wait for fills to finish |
+| Optional | Leave Ollama running so assess is local; or leave it off and hosted API / `pending_llm` takes over | Keep the laptop open for apply to work |
+| When pinged | Open the inbox. Live view only for login, CAPTCHA, legal, ID, judgment, or `review-each` | Click Submit on every Greenhouse-class form |
+| Anytime | Answer a queued question, record an outcome, look at the ledger | Drive discovery or scoring |
+
+### System (Fly worker + CLI)
+
+| Job | System does | Stops and asks you |
+|---|---|---|
+| `discover` | Pull Greenhouse / Lever / Ashby JSON. Dedupe. Enqueue `assess` | Never |
+| `assess` | `cloud llm` (Ollama → hosted → heuristic) → `scoreJob` → `ledger check` | `ask` (unclear visa/pay/evidence). `pending_llm` if no provider — not a ping, a wait |
+| `fill` | Open apply URL. Map `questions[]` + profile. Upload résumé. Restore parser drift. `map-fields` / `draft` if needed | Unknown required field, LinkedIn overlay |
+| `submit` | If gate passes: screenshot, click Submit, wait for thank-you, `ledger add` | Hard stop, `review-each`, unclear confirmation (never click twice) |
+| `handoff` | Keep or re-acquire a tab, give you a live URL, resume after you mark done | You must be in the tab |
+
+### What a day looks like
+
+1. You onboard once (or already did).
+2. You start a round. UI returns. You close the laptop if you want.
+3. Worker discovers, assesses (Ollama if your tailnet is up), fills, Submits routine Greenhouse jobs.
+4. You get a ping only for a pause. You open one live view, unblock, go away again.
+5. Ledger shows confirmed rows only. Inbox is the leftover human work.
+
+H1/H2 are the same flow with auth in front of the UI and more workers behind the same queue.
+
 ## The application loop
 
 1. **Onboard.** Collect every field the current CLI already requires, plus the extras that ATS forms ask every week. Upload one canonical résumé. Nothing is inferred.

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -116,7 +116,7 @@ Auth is a later gate in front of the same API. For MVP, bind the process to a ma
 1. **Onboard.** Collect every field the current CLI already requires, plus the extras that ATS forms ask every week. Upload one canonical résumé. Nothing is inferred.
 2. **Discover.** Pull public ATS boards and the existing catalog. Normalize to `{company, role, url, employerJobId, applicationChannel, discoverySource}`.
 3. **Qualify.** Reuse `score`. Keep `exclude` / `ask` / `skip` / `review` and `autoEligible`. `autoEligible` plus `routine-auto` plus a clean page means the agent may Submit.
-4. **Fill.** Open the direct apply URL. Prefill from the profile and ATS question schema — no model. Upload the résumé. Narratives use a stored blurb or, optionally, an HTTP LLM. See [Prefill without a model](#prefill-without-a-model).
+4. **Fill.** Open the direct apply URL. Prefill known profile fields from the ATS schema. Use `cloud llm` for leftover labels, must-haves, and drafts. See [Prefill and the LLM CLI](#prefill-and-the-llm-cli).
 5. **Submit or pause.** If the submit gate below passes, the agent clicks Submit and waits for confirmation. If a hard stop fires or the profile is `review-each`, write an attention item instead.
 6. **Handoff (only when needed).** The operator opens a live view (same tab if it is still up, otherwise acquire + refill) and handles login / CAPTCHA / legal / judgment. They may also Submit in `review-each`.
 7. **Confirm.** Only after a visible success page does the system write `submitted`. No confirmation, no ledger row. Never click Submit a second time if confirmation is unclear — queue attention as `other` / site-error.
@@ -141,45 +141,46 @@ Otherwise stop and hand off. First Greenhouse dogfood run may still be watched (
 
 `review-each` is still a first-class mode: fill everything, then live view for the candidate to send.
 
-## Prefill without a model
+## Prefill and the LLM CLI
 
-The local product looks like it “uses AI” because a coding agent reads the page. The CLI itself has **no model**. `scoreJob`, `validateProfile`, and `ledger check` are pure functions. Cloud should keep it that way on the Fly Machine.
+Known facts stay deterministic. Accuracy-sensitive reading uses an **LLM CLI** on the Fly Machine — a small command that calls a hosted model over HTTPS. That is how the local skill is accurate today (a coding agent reads the JD). We keep that accuracy; we do not keep a chat session, and we do not load weights next to Chromium.
 
-**Do not run a local LLM in the CLI or on that box.** A 2 GB Fly Machine cannot host a useful model next to Chromium. If we want generated prose or richer must-haves later, the worker calls a **hosted API** (Anthropic, OpenAI, etc.) over HTTPS. That is optional and off by default for H0.
+`scoreJob`, `validateProfile`, and `ledger check` stay pure. The model only produces structured inputs those functions already accept.
 
-### What fills the form
+### Two layers
 
-| Input | How it gets onto the page | AI? |
+| Step | Who | Why |
 |---|---|---|
-| Name, email, phone, location, links | Profile JSON → Greenhouse/Lever/Ashby `questions` (field id + type) or DOM hints (`type=email`, `autocomplete`, label synonym map) | No |
-| Résumé | `resume path` + `setInputFiles` | No |
-| Work auth / sponsorship / salary | Structured onboarding fields, then exact label match or stored `answers` fingerprint | No |
-| “Have you applied here?” | `ledger check` for that company | No |
-| Must-haves for `scoreJob` | Keyword overlap: JD text vs `profile.skills` / résumé text → `met` / `missing`. Coverage below the floor → `skip` | No |
-| “Why this company” / cover letter | Stored `motivationBlurb` from onboard, or attention if the form requires a long original | No (default) |
-| Richer evidence / company-specific essay | Optional HTTP LLM with résumé + JD; never invent; you review the first batch | API only, not on-box |
+| Name, email, phone, links, résumé, stored answers, ledger “applied here?” | Deterministic adapter (`questions[]` + synonym map + profile) | Fast, no hallucination |
+| Must-haves + evidence, messy labels, eligibility nuance, “why this company” | `cloud llm …` → hosted API | Same judgment quality as the laptop agent |
+| Hard stops (legal, demographics, IDs, CAPTCHA) | Human | Model must not answer |
 
-Greenhouse is the reason this works without a model: `GET /v1/boards/{slug}/jobs/{id}` returns a `questions` array (name, email, phone, resume, custom ids). The adapter maps those ids to profile keys. Lever and Ashby are the same idea with worse schemas; unknown labels become attention, not a guess.
+Heuristic skill-overlap is the **fallback** if the key is missing or the call fails — not the accuracy path.
 
-A synonym map covers the messy DOM case: `["email", "e-mail", "work email"]` → `profile.email`. If nothing matches, stop. Do not ask a model to invent a mapping on the first pass.
+### LLM CLI (on our Fly Machine, not a local model)
 
-### What still runs on the Fly Machine
+```text
+cloud llm assess --stdin    # JD + résumé + profile → mustHaves[], eligibility, seniority, workMode
+cloud llm map-fields --stdin  # leftover labels → profile key | stored answer | unclear
+cloud llm draft --stdin     # question + company + résumé → short answer per APPLICATION_GUIDANCE.md
+```
 
-Node, the existing CLI (`score`, `ledger`, `profile`, `resume`), Playwright, SQLite. That is the whole runtime.
+Implementation: Node `fetch` to Anthropic or OpenAI, or a thin shell-out to an installed `llm` / vendor CLI. Same JSON contract either way. Store the API key as a Fly secret. **Do not run Ollama or another on-box model** — 2 GB cannot hold Chrome and weights, and we want one testable interface.
 
-`assess.mjs` in H0 is a **heuristic**: tokenize the JD, match `profile.skills`, emit `mustHaves`, call `scoreJob`. You can override with `cloud assess --job` by hand. An LLM key is not a dependency.
+Rules (same as `SKILL.md`):
 
-### What we collect so we do not need a model mid-form
+- JSON only. No free-form “looks good.”
+- `met` / `partial` must quote résumé or profile text. No quote → `unclear` → `ask`.
+- Unknown field → `unclear`, not a guess.
+- Drafts adapt `motivationBlurb` + résumé facts to the company; they do not invent stack, scale, or employment.
+- Cache the result on the `assessments` / `answers` row so refill does not pay twice.
+- You review the first 20 assess/draft outputs. After that, `routine-auto` may Submit through the existing gate.
 
-Add these at onboard (structured, not prose):
+Running full Codex/Claude Code on the box would also be accurate (that is today’s loop). Prefer the thin `cloud llm` CLI so scoring and ledger stay unit-testable and we are not paying for a general agent to click the DOM.
 
-- `authorizedWithoutSponsorship` per target country (yes / no / unclear)
-- `needsSponsorship` (yes / no)
-- `willingToRelocate` (yes / no / unclear)
-- `motivationBlurb` — 100–150 words, written by you, reused when a form asks “why us” / cover letter
-- `howHeard` default (“company careers page” / “other”)
+### What we still collect at onboard
 
-Visa and salary stay in your words as today; the booleans are what the checkboxes actually ask.
+Structured flags and a `motivationBlurb` remain. They ground the model and fill checkboxes when the LLM is down.
 
 ## Details to collect
 
@@ -193,7 +194,7 @@ Required today (`REQUIRED_PROFILE` plus résumé):
 - Work authorization in the candidate’s own words
 - Target role families, seniority, years of experience
 - Target locations and work modes
-- Submission mode (`review-each` for the cloud MVP)
+- Submission mode (`routine-auto` or `review-each`)
 - Score floors: `autoSubmitMinScore`, `manualReviewMinScore`, `minMustHaveCoverage`
 - Canonical résumé (PDF)
 
@@ -220,7 +221,7 @@ Typical mid-run prompts:
 - Salary expectation on this requisition
 - “Are you authorized to work in X without sponsorship?”
 - “Have you previously applied / been employed here?”
-- Cover-letter or “why this company” (draft from guidance, confirm if `review-each`)
+- Cover-letter or “why this company” (`motivationBlurb`, or attention if that is not enough)
 - Start date, willingness to relocate, travel percentage
 - How they heard about the role
 - Website / additional links not in the profile

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -13,7 +13,7 @@ That is the same promise as the site (“Set the goal. Keep the search moving.�
 Three things must stay true at every horizon:
 
 1. **Facts.** Fills use the verified profile and one canonical résumé. Nothing is invented.
-2. **Judgment.** Login, MFA, CAPTCHA, legal, demographics, government IDs, unclear authorization/compensation, and Submit (until a channel earns auto-submit) stay with the candidate.
+2. **Judgment.** Login, MFA, CAPTCHA, legal, demographics, government IDs, and unclear authorization/compensation stay with the candidate. Submit does **not** — the agent clicks it when the form is routine and complete.
 3. **Ledger.** `submitted` means a visible confirmation. Volume, open tabs, and “probably sent” do not count.
 
 ### Why the earlier wording was weak
@@ -27,9 +27,9 @@ Three things must stay true at every horizon:
 
 | Horizon | Who | Done when |
 |---|---|---|
-| **H0 — Personal dogfood** | You, one new Fly app (not Paisewise) | One Greenhouse (then Lever/Ashby) loop: onboard → discover via API → assess → fill → **just-in-time** live view → you submit → ledger row exists only after the thank-you page. A killed session can be refilled. |
-| **H1 — Founding cloud** | Paying users, after H0 | They set boundaries once, get a scheduled round, and an inbox of pauses. Auth and isolation exist. Same ledger rules. Still no auto-submit. |
-| **H2 — Many inboxes** | ~100 users, ~100 `needs_attention` each | Those 10,000 items are inbox rows. Browser pool ≈ in-flight fills + people in live view. One Chrome context per user. “Open” means acquire → refill → hand off → release. |
+| **H0 — Personal dogfood** | You, one new Fly app (not Paisewise) | One Greenhouse loop: onboard → discover → assess → fill → **agent Submit** on a clean form → ledger row only after the thank-you page. Hard stops still open a live view. A killed session can be refilled. |
+| **H1 — Founding cloud** | Paying users, after H0 | They set boundaries once, including `review-each` vs `routine-auto`. Scheduled rounds. Inbox is only real pauses, not every ready form. Same submit rules as the local skill. |
+| **H2 — Many inboxes** | ~100 users, up to ~100 attention items each | Inbox is hard stops and `review-each` items, not 10,000 “please click Submit.” Browser pool ≈ in-flight fills/submits + people in live view. One Chrome context per user. |
 
 H0 is what we build first. H1 is the 18 September offer. H2 is a capacity and tenancy problem if H0 APIs already treat a session as a lease.
 
@@ -48,7 +48,7 @@ Do not count: forms filled but not confirmed, tabs held open, applications per h
 
 - Application volume as a success metric
 - LinkedIn Easy Apply, X, or other session-gated social apply
-- Auto-submit before a channel is boringly reliable
+- Auto-submit through a hard stop, or on a channel whose confirmation detector is not trusted yet
 - Sharing the Paisewise Machine
 - A second scoring system or a second meaning of `submitted`
 
@@ -107,7 +107,7 @@ Three layers, one tenant:
 
 - **Control plane.** Profile, résumé, jobs, assessments, applications, attention, answers, rounds. SQLite is enough for personal dogfood. Postgres or D1 later.
 - **Discovery.** Prefer HTTP APIs. Use a browser only when the source has no structured feed.
-- **Apply.** A real Chromium session. The agent fills. The operator submits when the form is complete or a hard stop fires.
+- **Apply.** A real Chromium session. The agent fills and, when the form is routine and complete, clicks Submit. The operator is pulled in only for hard stops or `review-each`.
 
 Auth is a later gate in front of the same API. For MVP, bind the process to a machine you control and do not expose it publicly.
 
@@ -115,14 +115,31 @@ Auth is a later gate in front of the same API. For MVP, bind the process to a ma
 
 1. **Onboard.** Collect every field the current CLI already requires, plus the extras that ATS forms ask every week. Upload one canonical résumé. Nothing is inferred.
 2. **Discover.** Pull public ATS boards and the existing catalog. Normalize to `{company, role, url, employerJobId, applicationChannel, discoverySource}`.
-3. **Qualify.** Reuse `score`. Keep `exclude` / `ask` / `skip` / `review` and `autoEligible`. For MVP, `autoEligible` means “safe to fill,” not “safe to submit.”
+3. **Qualify.** Reuse `score`. Keep `exclude` / `ask` / `skip` / `review` and `autoEligible`. `autoEligible` plus `routine-auto` plus a clean page means the agent may Submit.
 4. **Fill.** Open the direct apply URL in the hosted browser. Fill profile facts, upload the résumé, draft narrative answers from `APPLICATION_GUIDANCE.md`.
-5. **Pause.** If a hard stop fires *or* the form is ready to submit, write an attention item and keep the tab alive.
-6. **Handoff.** The operator opens a live view of that same tab, finishes login / CAPTCHA / legal / judgment, and clicks Submit.
-7. **Confirm.** Only after a visible success page does the system write `submitted`. No confirmation, no ledger row.
-8. **Continue.** Other jobs keep moving while one tab waits for you.
+5. **Submit or pause.** If the submit gate below passes, the agent clicks Submit and waits for confirmation. If a hard stop fires or the profile is `review-each`, write an attention item instead.
+6. **Handoff (only when needed).** The operator opens a live view (same tab if it is still up, otherwise acquire + refill) and handles login / CAPTCHA / legal / judgment. They may also Submit in `review-each`.
+7. **Confirm.** Only after a visible success page does the system write `submitted`. No confirmation, no ledger row. Never click Submit a second time if confirmation is unclear — queue attention as `other` / site-error.
+8. **Continue.** Other jobs keep moving while one item waits for you.
 
-This is stricter than local `routine-auto`. The first hosted version should never click Submit. That is the cheapest way to learn which sites we can actually finish.
+### When the agent submits
+
+Same contract as the local skill. Playwright clicking the button is not the hard part. The gate is.
+
+The agent clicks Submit only when **all** of these are true:
+
+- `submissionMode` is `routine-auto` (H0: your own grant)
+- `ledger check` is clean (no hard duplicate; company reapply allowed)
+- Score decision is `review` and `autoEligible` is true — or H0 you have approved that channel as routine
+- Every required field is a verified profile fact, a stored answer, or a guidance-draft the mode allows
+- Canonical résumé is attached; ATS-parsed fields that drifted were restored
+- The page has no login, MFA, CAPTCHA, legal attestation, demographic, government-id, or identity overlay (“Apply with LinkedIn”)
+- Authorization and compensation on the form are unambiguous
+- This ATS is on the submit allowlist, and we have a conservative confirmation detector for it
+
+Otherwise stop and hand off. First Greenhouse dogfood run may still be watched (log the click, screenshot before/after) so a bad detector cannot silently double-apply. After one clean confirmed Greenhouse submit, that channel stays allowlisted until friction says otherwise.
+
+`review-each` is still a first-class mode: fill everything, then live view for the candidate to send.
 
 ## Details to collect
 
@@ -244,14 +261,15 @@ Local attention already names the stops. Cloud adds a live tab.
 | Unclear authorization / compensation | Ask in the UI, then resume | Confirm the stored answer |
 | Unverifiable claim | Stop | Provide evidence or skip the job |
 | Judgment / video | Stop | Write or record |
-| Ready to submit | Verify fields + résumé filename | Click Submit, wait for the success page |
+| Ready to submit, `review-each` | Verify fields + résumé filename, hand off | Click Submit, wait for the success page |
+| Ready to submit, `routine-auto` + gate | Click Submit, wait for confirmation | Only if confirmation is unclear |
 | Site error | Friction row, retry later | Optional live inspect |
 
 Handoff contract for an attention item:
 
 - `applicationId`, canonical `url`, `stage`, `blocker`, `requiredActions` (existing enums)
 - `sessionId` and a short-lived `liveViewUrl`
-- `instructions` (“Review the filled form. If it is truthful, click Submit and wait for the thank-you page.”)
+- `instructions` (hard-stop specific, or “Review and Submit” only in `review-each`)
 - `expiresAt`
 
 The agent watches for either a structured handoff completion (Cloudflare / Steel) or a visible confirmation selector. Only then `ledger add`.
@@ -308,13 +326,12 @@ Keep this small enough to run for yourself before any customer auth.
 - Playwright against local Chromium with a dedicated user-data directory.
 - Résumé upload via `setInputFiles` / file chooser (same as `BROWSER_UPLOADS.md`).
 - Channel adapters in this order: Greenhouse hosted board, Lever hosted, Ashby hosted. Everything else is `other` and skipped.
-- Never click the final Submit.
+- Click Submit when the gate passes; otherwise attention.
 
 ### 4. Takeover
 
-- When the form is complete or a hard stop hits: start noVNC (or Steel/Browserbase live view) and write the attention row.
-- You open the link, submit or unblock, mark done.
-- Worker detects the confirmation page and records `submitted`.
+- Hard stop or `review-each`: live view. After unblock, agent may Submit if the gate now passes.
+- Worker detects the confirmation page and records `submitted`. Never click twice if confirmation is unclear.
 
 ### 5. Operator surface
 
@@ -360,20 +377,23 @@ Pending-to-submit is an inbox. The already-planned refill path (“session died 
 ```mermaid
 flowchart LR
   Q[Per-user fill queue] --> Pool[Browser pool]
-  Pool --> Ready[needs_attention row]
+  Pool -->|gate passes| Submit[Agent Submit]
+  Submit --> Done[submitted]
+  Pool -->|hard stop or review-each| Ready[needs_attention]
   Ready --> Inbox[User inbox]
-  Inbox -->|Open one| Lease[Lease browser + refill]
+  Inbox -->|Open one| Lease[Lease + refill]
   Lease --> Live[Live view]
-  Live -->|Submit + confirm| Done[submitted]
+  Live --> Done
+  Submit --> Pool
   Live --> Pool
 ```
 
 ### Capacity sketch
 
-Assumptions: Greenhouse-class fills, ~3–5 minutes each, users submit when they have time.
+Assumptions: Greenhouse-class fills, ~3–5 minutes each including Submit.
 
-- **Fill:** 10,000 × 4 min ≈ 670 browser-hours. A pool of 20 fillers clears a full backlog in a bit over a day, then keeps up with daily discovery.
-- **Handoff:** sized to *people in the tab now*, not pending count. 100 users with 100 ready items still only need ~10–30 browsers if they are not all clicking at once.
+- **Fill + agent Submit:** 10,000 × 4 min ≈ 670 browser-hours. A pool of 20 workers clears a full backlog in a bit over a day, then keeps up with daily discovery.
+- **Handoff:** sized to *people in the tab now* — hard stops and `review-each`, not every ready form.
 - **One Fly Machine (2–4 GB):** one user, one or two tabs. Fine for dogfood. Not this load.
 - **This load:** a browser pool (more Fly Machines, or Steel / Browserbase / Kernel / Cloudflare Browser Run) behind the same `{launch, fill, handoff, heartbeat, close}` adapter. Postgres (or equivalent), not SQLite. One browser **context per user** — never a shared Chrome profile.
 
@@ -381,14 +401,14 @@ Discovery and scoring stay cheap. They are not the bottleneck.
 
 ### What the user sees
 
-A person with 100 ready applications does not get 100 live tabs. They get a queue:
+A person with 100 scored matches does not get 100 live tabs. Routine Greenhouse-class forms are filled and submitted by the agent. They see an inbox of the rest:
 
-1. Open the inbox (ready to submit / login / legal / missing answer).
+1. Open the inbox (login / CAPTCHA / legal / missing answer / `review-each`).
 2. Click one. We lease a browser, refill, show live view.
-3. They submit or unblock. We confirm, record, release the browser.
-4. Optional “next ready” so they can walk the list.
+3. They unblock (or Submit in `review-each`). We confirm, record, release the browser.
+4. Optional “next ready” so they can walk the pauses.
 
-That is still 100 human submits unless a channel later earns auto-submit. The product win at this scale is “every form is already true,” not “one click empties 100.” Auto-submit, if it ever lands, is per-channel after dogfood — not a way to skip the pool.
+The product win at this scale is that most applications leave the machine without them, and the ones that do not are actually judgment.
 
 ### Isolation and abuse
 
@@ -417,7 +437,7 @@ Only after the personal loop works.
 3. **Put** a browser adapter behind `{launch, fill, handoff, heartbeat, close}`. The rest of the app should not care which vendor is behind it.
 4. **Add** auth and founding activation in front of that API. Paid access already exists; it currently activates nothing product-shaped.
 5. **Schedule** discovery. Reuse rounds. Notify on attention.
-6. **Keep** the same hard stops. `routine-auto` in the cloud still does not click Submit until dogfood says a channel is boringly reliable.
+6. **Keep** the same hard stops. `routine-auto` clicks Submit only when the submit gate passes and the channel’s confirmation detector is trusted.
 
 ## Gaps the first personal run will hit
 
@@ -446,14 +466,14 @@ These are expected. Capture them as friction rows.
 
 **Operator experience**
 
-- You will still do login, MFA, legal, and submit. The win is not “zero clicks.” It is “the form is already true when you arrive.”
+- You will still do login, MFA, legal, and `review-each`. Routine Submit is the agent’s. The win is that you only arrive for judgment.
 - Mid-run questions need a faster loop than email. The first UI should let you answer and resume without losing the tab.
 - Discovery quality depends on the company slug list. Garbage in, garbage out. Start from companies you would actually join.
 
 ## What this MVP will not do
 
 - User accounts, OAuth, or founding-access gating
-- Auto-submit
+- Submit through a hard stop, or a second click when confirmation is unclear
 - LinkedIn Easy Apply, X, or other session-gated social apply
 - Demographic answers, government IDs, or stored passwords
 - Résumé rewriting or per-company résumé variants
@@ -466,8 +486,8 @@ Use this when the personal run is done.
 
 - [ ] Onboarding can represent a complete `profile set` plus résumé.
 - [ ] Discovery from at least 20 ATS slugs produces scored, de-duplicated jobs.
-- [ ] A Greenhouse or Lever application can be filled in a hosted browser from those facts.
-- [ ] Attention items include a live URL; you can submit from that tab.
+- [ ] A Greenhouse application can be filled and agent-submitted; the ledger row exists only after the thank-you page.
+- [ ] A hard stop produces an attention item with a live URL; after unblock the agent or you can finish.
 - [ ] `submitted` rows exist only after a visible confirmation.
 - [ ] A killed session can be reopened and refilled without cookie export.
 - [ ] Notes exist for bot detection, missing questions, and confirmation misses per channel.

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -6,15 +6,51 @@ The public site already promises cloud access on 18 September 2026: scheduled di
 
 ## Goal
 
-One operator (you) can:
+**Keep a truthful search moving while the candidate is away. Pull them in only for real decisions. Record a submission only when the employer visibly confirms it.**
 
-1. Enter a verified profile and canonical résumé once.
-2. Search for matching, still-open roles.
-3. Have a hosted browser fill the application from those facts.
-4. Take over that same browser when a human is required — especially to submit.
-5. See every lead, pause, and confirmed submission in one database.
+That is the same promise as the site (“Set the goal. Keep the search moving.”) and the local skill. Cloud does not get a different goal. It gets a hosted loop that can survive the candidate closing the laptop.
 
-Success for this MVP is not volume. It is a complete, inspectable loop on Greenhouse / Lever / Ashby public apply pages, with every confirmed row as trustworthy as the local ledger is today.
+Three things must stay true at every horizon:
+
+1. **Facts.** Fills use the verified profile and one canonical résumé. Nothing is invented.
+2. **Judgment.** Login, MFA, CAPTCHA, legal, demographics, government IDs, unclear authorization/compensation, and Submit (until a channel earns auto-submit) stay with the candidate.
+3. **Ledger.** `submitted` means a visible confirmation. Volume, open tabs, and “probably sent” do not count.
+
+### Why the earlier wording was weak
+
+- It described a **mechanism** (“take over that same browser”) instead of an outcome. Warm tabs do not scale and are not the point.
+- It optimized for **one operator’s session**, so 100 users × 100 pending submits looked like a new product.
+- It said success is “not volume” but did not say what **is** success, so the September launch and the 10,000-row inbox had no finish line.
+- It mixed **dogfood**, **founding access**, and **multi-tenant load** into one list.
+
+### Horizons
+
+| Horizon | Who | Done when |
+|---|---|---|
+| **H0 — Personal dogfood** | You, one new Fly app (not Paisewise) | One Greenhouse (then Lever/Ashby) loop: onboard → discover via API → assess → fill → **just-in-time** live view → you submit → ledger row exists only after the thank-you page. A killed session can be refilled. |
+| **H1 — Founding cloud** | Paying users, after H0 | They set boundaries once, get a scheduled round, and an inbox of pauses. Auth and isolation exist. Same ledger rules. Still no auto-submit. |
+| **H2 — Many inboxes** | ~100 users, ~100 `needs_attention` each | Those 10,000 items are inbox rows. Browser pool ≈ in-flight fills + people in live view. One Chrome context per user. “Open” means acquire → refill → hand off → release. |
+
+H0 is what we build first. H1 is the 18 September offer. H2 is a capacity and tenancy problem if H0 APIs already treat a session as a lease.
+
+### What we measure (and what we do not)
+
+Count:
+
+- Confirmed unique submissions (visible employer/ATS success)
+- Attention items by blocker, and time from “ready” to “opened”
+- Fills that had to be refilled after a dead session
+- False or skipped confirmations (should be ~0)
+
+Do not count: forms filled but not confirmed, tabs held open, applications per hour, or “autoEligible” as a submit.
+
+### Non-goals (all horizons)
+
+- Application volume as a success metric
+- LinkedIn Easy Apply, X, or other session-gated social apply
+- Auto-submit before a channel is boringly reliable
+- Sharing the Paisewise Machine
+- A second scoring system or a second meaning of `submitted`
 
 ## What we already have
 

--- a/docs/cloud-mvp.md
+++ b/docs/cloud-mvp.md
@@ -1,0 +1,366 @@
+# Cloud apply MVP
+
+Personal-first plan for hosted discovery, application filling, human takeover, and a central ledger. Auth, multi-tenant accounts, and paid activation stay out of this MVP.
+
+The public site already promises cloud access on 18 September 2026: scheduled discovery, resumable runs, and decision notifications. The local Agent Skill already has the runbook. This document is the shortest path from “works in a coding-agent browser on my laptop” to “I can start a round from a hosted box and finish the hard steps myself.”
+
+## Goal
+
+One operator (you) can:
+
+1. Enter a verified profile and canonical résumé once.
+2. Search for matching, still-open roles.
+3. Have a hosted browser fill the application from those facts.
+4. Take over that same browser when a human is required — especially to submit.
+5. See every lead, pause, and confirmed submission in one database.
+
+Success for this MVP is not volume. It is a complete, inspectable loop on Greenhouse / Lever / Ashby public apply pages, with every confirmed row as trustworthy as the local ledger is today.
+
+## What we already have
+
+Do not rebuild these. Host them.
+
+| Local capability | Where it lives today | Cloud reuse |
+|---|---|---|
+| Required profile + targeting | `profile set` / `SCHEMAS.md` | Same JSON, stored in the central DB instead of OS keychain |
+| Canonical résumé | `resume import` / `resume path` | Object storage + absolute path inside the browser host |
+| Fit scoring and gates | `score --stdin` | Call the existing CLI as a library or subprocess |
+| Duplicate + company-reapply rules | `ledger check` / `ledger add` | Same IDs and overrides, persisted as tables |
+| Attention / friction queues | `attention.*` / `friction.*` | Same enums; attention items now carry a live-session URL |
+| Discovery catalog | `SOURCES.json` + community jobs | Same packaged sources; ATS board APIs add structured search |
+| Safety hard stops | `SKILL.md` / `AUTONOMY.md` | Unchanged. The cloud runtime must still stop. |
+| Landing, D1, founding checkout | `site/` | Later activation. Not required to dogfood. |
+
+The local product already encodes the product contract: fill only verified facts, record `submitted` only after visible confirmation, queue blockers instead of inventing answers, and never inspect cookies or session files from the operator’s own browser.
+
+## Recommended shape
+
+```mermaid
+flowchart TB
+  subgraph operator [Operator]
+    UI[Onboarding + queue UI]
+    Live[Live browser takeover]
+  end
+
+  subgraph control [Control plane]
+    API[Single-tenant API]
+    DB[(Central DB)]
+    Files[Résumé store]
+  end
+
+  subgraph workers [Workers]
+    Discover[Discover: ATS APIs + catalog]
+    Score[Score + dedupe]
+    Apply[Apply: hosted browser]
+  end
+
+  UI --> API
+  API --> DB
+  API --> Files
+  API --> Discover
+  Discover --> Score
+  Score --> DB
+  Score --> Apply
+  Apply --> DB
+  Apply -->|needs human or ready to submit| Live
+  Live --> UI
+  Live -->|confirmed| DB
+```
+
+Three layers, one tenant:
+
+- **Control plane.** Profile, résumé, jobs, assessments, applications, attention, answers, rounds. SQLite is enough for personal dogfood. Postgres or D1 later.
+- **Discovery.** Prefer HTTP APIs. Use a browser only when the source has no structured feed.
+- **Apply.** A real Chromium session. The agent fills. The operator submits when the form is complete or a hard stop fires.
+
+Auth is a later gate in front of the same API. For MVP, bind the process to a machine you control and do not expose it publicly.
+
+## The application loop
+
+1. **Onboard.** Collect every field the current CLI already requires, plus the extras that ATS forms ask every week. Upload one canonical résumé. Nothing is inferred.
+2. **Discover.** Pull public ATS boards and the existing catalog. Normalize to `{company, role, url, employerJobId, applicationChannel, discoverySource}`.
+3. **Qualify.** Reuse `score`. Keep `exclude` / `ask` / `skip` / `review` and `autoEligible`. For MVP, `autoEligible` means “safe to fill,” not “safe to submit.”
+4. **Fill.** Open the direct apply URL in the hosted browser. Fill profile facts, upload the résumé, draft narrative answers from `APPLICATION_GUIDANCE.md`.
+5. **Pause.** If a hard stop fires *or* the form is ready to submit, write an attention item and keep the tab alive.
+6. **Handoff.** The operator opens a live view of that same tab, finishes login / CAPTCHA / legal / judgment, and clicks Submit.
+7. **Confirm.** Only after a visible success page does the system write `submitted`. No confirmation, no ledger row.
+8. **Continue.** Other jobs keep moving while one tab waits for you.
+
+This is stricter than local `routine-auto`. The first hosted version should never click Submit. That is the cheapest way to learn which sites we can actually finish.
+
+## Details to collect
+
+Ask the known set up front. When a form asks something new, queue it, keep the tab, and do not invent an answer.
+
+### Ask during onboarding
+
+Required today (`REQUIRED_PROFILE` plus résumé):
+
+- Identity: name, email, phone, location
+- Work authorization in the candidate’s own words
+- Target role families, seniority, years of experience
+- Target locations and work modes
+- Submission mode (`review-each` for the cloud MVP)
+- Score floors: `autoSubmitMinScore`, `manualReviewMinScore`, `minMustHaveCoverage`
+- Canonical résumé (PDF)
+
+Collect on the same screen even though some are optional in the CLI. They appear on almost every ATS form:
+
+- LinkedIn, GitHub, portfolio
+- Availability / notice period
+- Current compensation and target compensation
+- Compensation floor (amount, currency, annual)
+- Skills, industries
+- Excluded companies and excluded locations
+- Citizenship / visa status as free text (“Indian citizen, no US sponsorship needed” / “Need H-1B transfer”) — stored as `workAuthorization`, never as a government ID
+- Preferred name, pronouns only if the candidate volunteers them
+- How they want to hear about pauses (email is enough for MVP)
+
+### Ask when a form requires it
+
+Keep a `candidate_answers` table keyed by question fingerprint (`normalized label + channel`). Reuse an answer the next time the same question appears.
+
+Typical mid-run prompts:
+
+- Salary expectation on this requisition
+- “Are you authorized to work in X without sponsorship?”
+- “Have you previously applied / been employed here?”
+- Cover-letter or “why this company” (draft from guidance, confirm if `review-each`)
+- Start date, willingness to relocate, travel percentage
+- How they heard about the role
+- Website / additional links not in the profile
+
+Never store, and never ask the agent to answer:
+
+- Passwords, SSO, MFA codes, CAPTCHA solutions
+- Government IDs, SSN / Aadhaar / passport numbers
+- Demographic or voluntary self-identification
+- Legal attestations the candidate has not already approved as boilerplate
+
+Those stay in the live browser, typed by the operator.
+
+## Discovery: APIs first
+
+Most of the search problem does not need a browser.
+
+| Source | What we can do without a browser | Apply path |
+|---|---|---|
+| Greenhouse board | `GET https://boards-api.greenhouse.io/v1/boards/{token}/jobs?content=true` | Browser. The Job Board *submit* POST needs the **employer’s** API key, which we do not have. |
+| Lever | `GET https://api.lever.co/v0/postings/{slug}?mode=json` | Browser on `hostedUrl` |
+| Ashby | `GET https://api.ashbyhq.com/posting-api/job-board/{slug}` | Browser on `jobUrl` / `applyUrl` |
+| Workable / SmartRecruiters / Recruitee | Public board / widget JSON | Browser |
+| Workday | Public CXS search POST on some tenants | Browser. High friction; not an MVP target. |
+| Packaged catalog | `SOURCES.json` + `sources jobs` | Resolve to the employer / ATS page, then treat as above |
+| Community jobs | Existing maintainer-reviewed feed | Same |
+| Hacker News / company career pages | HTML or browser | Only after ATS boards are producing enough leads |
+| LinkedIn, X, YC Work at a Startup | Session required | Out of MVP. Needs a persistent logged-in profile and is ToS-sensitive. |
+
+MVP discovery is a watched list of company board slugs (Greenhouse / Lever / Ashby) plus the existing catalog. You seed 30–80 companies you actually want. The worker polls, normalizes, scores, and inserts new `jobs` rows.
+
+That is enough to dogfood apply. Broader search is a later gap, not a blocker.
+
+### Why ATS submit APIs do not bypass the browser
+
+Greenhouse documents `POST /v1/boards/{board_token}/jobs/{id}`. It is built for a company hosting its own careers site. It authenticates with that company’s Job Board API key. Lever and Ashby application writes are the same class of problem: employer-side, not candidate-side.
+
+So: **APIs for search and form-schema hints. Browser for apply.** If a future employer-hosted apply widget is truly keyless and ToS-clean, add it as a channel adapter. Do not plan the MVP around it.
+
+Greenhouse job detail responses do include the `questions` array. Use that to pre-flight missing answers *before* opening a browser.
+
+## Browser options
+
+The product need is narrow: a Chromium we drive with Playwright, a way to upload the résumé by path, and a live view the operator can take over without us reading their cookies.
+
+| Option | Fit | Strength | Main limit |
+|---|---|---|---|
+| **Playwright on a small VM you control** (Fly, Hetzner, a home box) + noVNC or Chrome remote debugging | Best personal MVP | Full control, cheap, headed, easy file upload, session can sit for hours | You operate the machine; no productized handoff UI |
+| **Steel** (self-host Docker, or Steel Cloud) | Best next step if the VM works | Open-source browser API, Playwright/CDP, Profiles, Live View, 24h sessions on cloud | Another vendor or another container to run |
+| **Cloudflare Browser Run** (formerly Browser Rendering) | Best long-term stack fit | Site already on Workers/D1; Playwright; **Live View + `Cloudflare.handoff`** with Done/Failed; Durable Objects for session reuse | Traffic is **always labeled bot**; free tier is 10 browser-minutes/day; idle timeout 60s (max 10 min) unless kept alive |
+| **Browserbase + Stagehand** | Strong hosted alternative | Live View, Contexts, uploads, observability, stealth options | Cost; another vendor; less overlap with the current Cloudflare site |
+| **Kernel** | Cost / long session | Per-second billing, 72h sessions, managed auth, live view | Newer; less overlap with current stack |
+| **Coding-agent browser on a cloud VM** | Emergency fallback | Same workflow as today | Not a product; session dies with the chat |
+
+### Recommendation
+
+**Personal MVP: Playwright on a VM you control.** One persistent Chromium user-data dir, Playwright driving it, and a VNC / Live View tab you open when attention fires. Pair it with SQLite or local Postgres and the existing `score` / `ledger` CLI.
+
+**If the first week shows takeover is the painful part,** switch the browser host to Steel Cloud or Browserbase. Keep the same control plane.
+
+**If dogfood shows Cloudflare Browser Run can complete Greenhouse/Lever/Ashby fills** despite the bot label, prefer it for the public product. It is the only option that already matches the site’s runtime and has a first-party handoff protocol (`Cloudflare.getLiveView` + `Cloudflare.handoff` + `Cloudflare.handoffComplete`, timeout up to 30 minutes). Keep a heartbeat so idle sessions survive past 10 minutes.
+
+Do not pick the public-product browser until you have applied to a handful of real boards from a hosted session. Bot detection is the decision, not the brochure.
+
+## Human intervention
+
+Local attention already names the stops. Cloud adds a live tab.
+
+| Blocker | Agent does | Operator does in live view |
+|---|---|---|
+| Authentication / SSO / MFA | Stop, keep tab | Sign in. Agent never sees the password. |
+| CAPTCHA | Stop, keep tab | Solve it. Do not add a CAPTCHA-solving vendor. |
+| Legal attestation | Stop | Read and accept, or reject the job |
+| Demographic questions | Leave blank, stop | Skip or fill. Agent does not answer. |
+| Government ID | Stop | Type it only in the page, or abandon |
+| Unclear authorization / compensation | Ask in the UI, then resume | Confirm the stored answer |
+| Unverifiable claim | Stop | Provide evidence or skip the job |
+| Judgment / video | Stop | Write or record |
+| Ready to submit | Verify fields + résumé filename | Click Submit, wait for the success page |
+| Site error | Friction row, retry later | Optional live inspect |
+
+Handoff contract for an attention item:
+
+- `applicationId`, canonical `url`, `stage`, `blocker`, `requiredActions` (existing enums)
+- `sessionId` and a short-lived `liveViewUrl`
+- `instructions` (“Review the filled form. If it is truthful, click Submit and wait for the thank-you page.”)
+- `expiresAt`
+
+The agent watches for either a structured handoff completion (Cloudflare / Steel) or a visible confirmation selector. Only then `ledger add`.
+
+If the session dies before you arrive, reopen the URL, refill from the profile, and recreate the attention item. Do not restore cookies from a dump.
+
+## Central database
+
+Personal MVP can be SQLite. The schema should match the local documents so a later hosted product and the OSS CLI stay compatible.
+
+```text
+profiles            one row. Same fields as profile set.
+resumes             bytes or object-store key, sha256, original filename.
+discovery_sources   packaged + watched ATS slugs.
+jobs                canonical url, employer_job_id, company, role, channel, raw snapshot.
+assessments         score result + must-haves + gates. Private evidence stays here.
+applications        ledger rows. status: queued | filling | needs_attention | submitted | abandoned.
+answers             reusable question fingerprint → candidate text.
+attention           existing attention event + session_id + live_view_url.
+rounds              requested count, counts, timestamps.
+outcomes            same as ledger outcome.
+browser_sessions    provider, session_id, status, last_heartbeat, current_application_id.
+```
+
+Rules carried over unchanged:
+
+- Applications are append-mostly. Do not rewrite a `submitted` row.
+- `submitted` requires a confirmation artifact (URL + excerpt or screenshot stored privately).
+- Duplicate keys: ledger id, canonical URL, employer job id.
+- Company reapply: 15-day cooldown, explicit override phrase.
+- No passwords, MFA, government IDs, demographic answers, or raw cookie jars in this database.
+
+## Personal MVP build order
+
+Keep this small enough to run for yourself before any customer auth.
+
+### 1. Control plane on one box
+
+- SQLite (or local Postgres) with the tables above.
+- Import path: `profile set` JSON + `resume import` PDF.
+- Thin HTTP API or CLI: `onboard`, `round start`, `attention list`, `jobs list`, `ledger review`.
+- No public DNS. Tailscale / SSH tunnel is enough.
+
+### 2. Discovery worker
+
+- Config file of `{channel, slug}` for Greenhouse / Lever / Ashby.
+- Normalize, store, run `score --stdin`.
+- Insert `review` jobs into a fill queue. Surface `ask` jobs as questions, not applications.
+
+### 3. Apply worker
+
+- Playwright against local Chromium with a dedicated user-data directory.
+- Résumé upload via `setInputFiles` / file chooser (same as `BROWSER_UPLOADS.md`).
+- Channel adapters in this order: Greenhouse hosted board, Lever hosted, Ashby hosted. Everything else is `other` and skipped.
+- Never click the final Submit.
+
+### 4. Takeover
+
+- When the form is complete or a hard stop hits: start noVNC (or Steel/Browserbase live view) and write the attention row.
+- You open the link, submit or unblock, mark done.
+- Worker detects the confirmation page and records `submitted`.
+
+### 5. Operator surface
+
+A single page is enough:
+
+- Profile completeness
+- Fill queue and today’s round
+- Open attention items with “Open live session”
+- Submitted ledger
+- A prompt for any mid-run missing answer
+
+Email or a Telegram/ntfy ping when attention is non-empty.
+
+### 6. Dogfood, then decide the hosted browser
+
+Run one round of 10. Write down, per channel:
+
+- Could we find it via API?
+- Could we fill every required field?
+- Did bot detection or login block us?
+- Did you need to be in the tab to submit?
+- Did confirmation detection work?
+
+That log chooses Cloudflare Browser Run vs Steel vs Browserbase for the September product. Do not choose from this document alone.
+
+## Path to the public cloud
+
+Only after the personal loop works.
+
+1. **Extract** scoring, ledger, attention, and source-normalization from the CLI into a package both the skill and the worker import. Do not fork the rules.
+2. **Move** the control plane onto the existing Cloudflare site: D1 or Postgres, R2 for résumés, the Quiet Trust UI.
+3. **Put** a browser adapter behind `{launch, fill, handoff, heartbeat, close}`. The rest of the app should not care which vendor is behind it.
+4. **Add** auth and founding activation in front of that API. Paid access already exists; it currently activates nothing product-shaped.
+5. **Schedule** discovery. Reuse rounds. Notify on attention.
+6. **Keep** the same hard stops. `routine-auto` in the cloud still does not click Submit until dogfood says a channel is boringly reliable.
+
+## Gaps the first personal run will hit
+
+These are expected. Capture them as friction rows.
+
+**Apply reliability**
+
+- Cloudflare Browser Run (and many hosted browsers) are labeled as bots. Greenhouse is often fine; Workday, LinkedIn, and some Ashby/Cloudflare-protected career sites are not.
+- Hosted apply pages are not one DOM. Greenhouse iFrames, Ashby multi-step, Lever custom questions, and “Apply with LinkedIn” overlays will each need a thin adapter.
+- Résumé parsing on the ATS side overwrites truthful fields. The local runbook already says to restore them. The worker must do the same.
+- Confirmation pages vary. Screenshot + URL + a conservative “thank you / application received” detector; if unsure, leave the row in `needs_attention`.
+
+**Sessions and time**
+
+- LinkedIn / YC / Workday SSO need a long-lived profile. Out of MVP, but the VM user-data dir is how we will learn whether persistence is even acceptable.
+- Cloudflare idle cap (10 minutes) is too short for a human to notice a Slack ping and finish MFA. A heartbeat or a longer-lived vendor is required for handoff.
+- A tab that waits overnight needs either a vendor with 24h+ sessions (Steel / Kernel) or a refill-on-reopen path.
+
+**Product and policy**
+
+- We will not have candidate-side submit APIs. Anyone claiming otherwise is using an employer key or unofficial scrape-and-POST.
+- LinkedIn Easy Apply is a ToS and detection minefield. Do not include it in the first hosted offer.
+- Storing a résumé and work-authorization text in a cloud DB is a privacy event the current local product avoided on purpose. The privacy page already says cloud access needs explicit controls before it accepts this data. Even for personal dogfood, encrypt at rest and keep the machine off the public internet.
+- CAPTCHA-solving services are out of bounds. Human takeover is the product.
+- Multi-tenant isolation, audit logs, and “delete my profile” are launch blockers, not MVP blockers — unless someone else can reach your instance.
+
+**Operator experience**
+
+- You will still do login, MFA, legal, and submit. The win is not “zero clicks.” It is “the form is already true when you arrive.”
+- Mid-run questions need a faster loop than email. The first UI should let you answer and resume without losing the tab.
+- Discovery quality depends on the company slug list. Garbage in, garbage out. Start from companies you would actually join.
+
+## What this MVP will not do
+
+- User accounts, OAuth, or founding-access gating
+- Auto-submit
+- LinkedIn Easy Apply, X, or other session-gated social apply
+- Demographic answers, government IDs, or stored passwords
+- Résumé rewriting or per-company résumé variants
+- Guaranteed interviews or “apply to 100 jobs overnight”
+- A second scoring system or a second ledger format
+
+## Decision checklist
+
+Use this when the personal run is done.
+
+- [ ] Onboarding can represent a complete `profile set` plus résumé.
+- [ ] Discovery from at least 20 ATS slugs produces scored, de-duplicated jobs.
+- [ ] A Greenhouse or Lever application can be filled in a hosted browser from those facts.
+- [ ] Attention items include a live URL; you can submit from that tab.
+- [ ] `submitted` rows exist only after a visible confirmation.
+- [ ] A killed session can be reopened and refilled without cookie export.
+- [ ] Notes exist for bot detection, missing questions, and confirmation misses per channel.
+- [ ] A browser adapter interface is clean enough to swap VM Playwright for Cloudflare / Steel / Browserbase.
+
+If those are true, the September product is an isolation, auth, and vendor-hardening job — not a new agent.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Personal apply loop in `cloud/`, kept out of the published skill. **Default path is your laptop**, not Fly.

On this machine: `cd cloud && npm install && npx playwright install chromium && npm run local`, then open `http://127.0.0.1:8787`. Click **Use my laptop skill profile** if the Agent Skill is already onboarded here. Start a round and leave. Home is **Sent** / **Needs you** / **Working**. `submitted` only after a visible thank-you page.

HTTP handlers only enqueue. The worker discovers Greenhouse / Lever / Ashby board APIs, assesses with Ollama → hosted API → heuristic, then `scoreJob`. Greenhouse fill + submit uses local Playwright. Lever / Ashby hand off until one Greenhouse agent-submit is confirmed.

Fly remains optional (new app, not Paisewise, `fly proxy` only).

## Risk and invariants

- Candidate profile, résumé, and SQLite live under `cloud/data/` (gitignored). Import copies the laptop skill profile from Keychain/Secret Service and the canonical PDF; it does not point the worker at the skill state dir.
- `scoreJob`, `validateProfile`, and `validateLedgerEntry` are imported from the skill, not copied.
- The API never launches Playwright or calls the LLM inline.
- Agent Submit only when the routine-auto gate passes. Unclear confirmation → attention, never a second click.
- `attention.ndjson` is unchanged. H0 stubs noVNC: inbox shows the apply URL.
- Larger than ~300 lines because H0 is one runnable loop.

## Verification

- [x] Offline `cloud/tests` cover local env defaults, skill import, operator page, queue, heuristic/LLM fallback, submit gate, and onboard + `POST /rounds` without Playwright.
- [x] `npm test`
- [ ] Live Chromium on a laptop (run `npm run local` locally)

## Scope

H0 implementation plus local launcher. Follow `cloud/README.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ba6944a-efbe-469d-8795-98d61e71b6ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ba6944a-efbe-469d-8795-98d61e71b6ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

