### PR TITLE
Delay cloud launch to October 1

### DIFF
--- a/site/app/components/LaunchCountdown.tsx
+++ b/site/app/components/LaunchCountdown.tsx
@@ -56,7 +56,7 @@ export function LaunchCountdown({ releaseAt }: LaunchCountdownProps) {
 
     <div className="launch-target">
       <span>Scheduled start</span>
-      <time dateTime={releaseAt}>September 18, 2026 · 12:00 AM IST</time>
+      <time dateTime={releaseAt}>October 1, 2026 · 12:00 AM IST</time>
     </div>
 
     <div className="launch-sequence" aria-label="Launch readiness">

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -15,7 +15,7 @@ const steps = [
   ["03", "Review the record", "Every decision, application, pause, and outcome stays visible so the search improves instead of becoming noise."],
 ] as const;
 
-const cloudLaunchAt = "2026-09-18T00:00:00+05:30";
+const cloudLaunchAt = "2026-10-01T00:00:00+05:30";
 
 export default function Home() {
   return <>
@@ -23,7 +23,7 @@ export default function Home() {
     <main id="top">
       <header className="hero page-width">
         <div className="hero-copy">
-          <p className="eyebrow">Launching September 18 · Pre-launch reservations open</p>
+          <p className="eyebrow">Launching October 1 · Pre-launch reservations open</p>
           <h1>Set the goal.<span>Keep the search moving.</span></h1>
           <p className="hero-summary">Job Application Agent finds direct roles, filters weak fits, submits truthful applications, pauses for real decisions, and keeps learning from outcomes—even while you are away.</p>
           <div className="hero-actions"><FoundingCheckout /><a className="button button-secondary" href="https://stats.jobappagent.com">See community momentum</a></div>
@@ -49,14 +49,14 @@ export default function Home() {
 
       <section className="section page-width" id="founding">
         <div className="founding-card">
-          <div><p className="eyebrow">Pre-launch cloud access</p><h2>Reserve the agent that keeps running.</h2><p>Job Application Agent launches September 18, 2026. Pay $49 now. Your 90 days begin only when cloud access is activated. If we have not activated you within 60 days of payment, you will be automatically refunded.</p></div>
-          <div className="offer-panel"><div><span>PRE-LAUNCH PRICE</span><strong>$49</strong><small>90 days from activation · launches September 18</small></div><ul><li>Scheduled job discovery</li><li>Persistent, resumable runs</li><li>Decision notifications</li><li>Secure checkout by Dodo Payments</li></ul><FoundingCheckout /></div>
+          <div><p className="eyebrow">Pre-launch cloud access</p><h2>Reserve the agent that keeps running.</h2><p>Job Application Agent launches October 1, 2026. Pay $49 now. Your 90 days begin only when cloud access is activated. If we have not activated you within 60 days of payment, you will be automatically refunded.</p></div>
+          <div className="offer-panel"><div><span>PRE-LAUNCH PRICE</span><strong>$49</strong><small>90 days from activation · launches October 1</small></div><ul><li>Scheduled job discovery</li><li>Persistent, resumable runs</li><li>Decision notifications</li><li>Secure checkout by Dodo Payments</li></ul><FoundingCheckout /></div>
         </div>
       </section>
 
       <section className="section faq page-width">
         <div className="section-heading"><p className="eyebrow">Straight answers</p><h2>Before you reserve.</h2></div>
-        <details><summary>When does Job Application Agent launch?</summary><p>The cloud product is scheduled to launch on September 18, 2026. This countdown runs to the start of launch day in India.</p></details>
+        <details><summary>When does Job Application Agent launch?</summary><p>The cloud product is scheduled to launch on October 1, 2026. This countdown runs to the start of launch day in India.</p></details>
         <details><summary>Is this a mass-application bot?</summary><p>No. It filters aggressively and applies only inside rules you set. Unclear or sensitive decisions pause for you.</p></details>
         <details><summary>When do my 90 days begin?</summary><p>On the day your cloud access is activated—not on the payment date.</p></details>
         <details><summary>What if access is not ready?</summary><p>If we have not activated your access within 60 days of payment, the full $49 payment is automatically refunded.</p></details>

--- a/site/tests/launch-countdown.test.mjs
+++ b/site/tests/launch-countdown.test.mjs
@@ -4,21 +4,21 @@ import { getCountdownParts } from "../lib/launch-countdown.mjs";
 
 test("breaks the remaining launch time into stable day, hour, minute, and second units", () => {
   assert.deepEqual(
-    getCountdownParts("2026-09-18T00:00:00+05:30", "2026-09-16T21:56:55+05:30"),
+    getCountdownParts("2026-10-01T00:00:00+05:30", "2026-09-29T21:56:55+05:30"),
     { days: 1, hours: 2, minutes: 3, seconds: 5, complete: false },
   );
 });
 
 test("stops the reverse timer at zero when the launch window opens", () => {
   assert.deepEqual(
-    getCountdownParts("2026-09-18T00:00:00+05:30", "2026-09-18T00:00:01+05:30"),
+    getCountdownParts("2026-10-01T00:00:00+05:30", "2026-10-01T00:00:01+05:30"),
     { days: 0, hours: 0, minutes: 0, seconds: 0, complete: true },
   );
 });
 
 test("does not report launch complete during the final fractional second", () => {
   assert.deepEqual(
-    getCountdownParts("2026-09-18T00:00:00.000Z", "2026-09-17T23:59:59.500Z"),
+    getCountdownParts("2026-10-01T00:00:00.000Z", "2026-09-30T23:59:59.500Z"),
     { days: 0, hours: 0, minutes: 0, seconds: 1, complete: false },
   );
 });
@@ -28,5 +28,5 @@ test("rejects an invalid launch schedule instead of displaying misleading time",
 });
 
 test("rejects an invalid current time instead of displaying a misleading countdown", () => {
-  assert.throws(() => getCountdownParts("2026-09-18T00:00:00+05:30", "not-a-date"), /time reference/i);
+  assert.throws(() => getCountdownParts("2026-10-01T00:00:00+05:30", "not-a-date"), /time reference/i);
 });

--- a/site/tests/rendered-html.spec.mjs
+++ b/site/tests/rendered-html.spec.mjs
@@ -18,7 +18,7 @@ test("server-renders the focused cloud offer and honest community proof", async 
   const html = await response.text();
   assert.match(html, /Set the goal/);
   assert.match(html, /Cloud launch sequence/);
-  assert.match(html, /September 18, 2026/);
+  assert.match(html, /October 1, 2026/);
   assert.match(html, /aria-label="Time remaining until cloud launch"/);
   assert.match(html, /Active installations · last 30 days/);
   assert.match(html, /Verified applications submitted/);


### PR DESCRIPTION
Moves the cloud launch from September 18 to October 1, 2026 at midnight IST. Updates the countdown target, visible date, offer copy, FAQ, and existing test fixtures.

Validation: production build, all 37 site tests, and ESLint pass. TypeScript reports an existing checkout customization.theme typing error outside this change.
