### PR TITLE
feat: modernize published jobs directory UI and filters

### DIFF
--- a/site/app/jobs/PublishedJobs.tsx
+++ b/site/app/jobs/PublishedJobs.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { SiteHeader, SiteFooter } from "../components/SiteChrome";
 import { usePublishedJobs } from "./usePublishedJobs";
 import { searchJobs } from "../../lib/jobs-search.mjs";
 import { jobPagination } from "../../lib/jobs-pagination.mjs";
@@ -8,6 +9,59 @@ import type { CommunityJob } from "../components/useCommunityJobs";
 import { attachLocations, countryLabel } from "../../lib/job-locations.mjs";
 import type { JobLocation, LocationIndex } from "./location-types";
 import styles from "./jobs.module.css";
+
+function formatRelativeDate(isoDate: string): string {
+  try {
+    const target = Date.parse(isoDate);
+    if (isNaN(target)) return isoDate.slice(0, 10);
+    const now = Date.now();
+    const diffDays = Math.floor((now - target) / 86400000);
+    if (diffDays <= 0) return "First seen today";
+    if (diffDays === 1) return "First seen yesterday";
+    if (diffDays < 30) return `First seen ${diffDays}d ago`;
+    return `First seen ${new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" }).format(new Date(target))}`;
+  } catch {
+    return `First seen ${isoDate.slice(0, 10)}`;
+  }
+}
+
+function getHostname(urlStr: string): string {
+  try {
+    return new URL(urlStr).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function getWorkplaceMeta(workplace?: string) {
+  switch (workplace) {
+    case "remote":
+      return { label: "Remote", className: styles.badgeRemote, icon: "●" };
+    case "hybrid":
+      return { label: "Hybrid", className: styles.badgeHybrid, icon: "◑" };
+    case "onsite":
+      return { label: "On-site", className: styles.badgeOnsite, icon: "○" };
+    default:
+      return null;
+  }
+}
+
+const AVATAR_PALETTES = [
+  { bg: "#EBF3EF", color: "#1E4A3E", border: "#c2ddd0" },
+  { bg: "#F5EFE6", color: "#4B3D2B", border: "#ded3c2" },
+  { bg: "#EBF1F7", color: "#253F59", border: "#c8d8e8" },
+  { bg: "#F1EBE5", color: "#3B4A3F", border: "#d7cdc2" },
+  { bg: "#E5ECE9", color: "#173F35", border: "#bfd4cb" },
+];
+
+function getAvatarStyle(company: string) {
+  let hash = 0;
+  for (let i = 0; i < company.length; i++) {
+    hash = (hash << 5) - hash + company.charCodeAt(i);
+  }
+  const idx = Math.abs(hash) % AVATAR_PALETTES.length;
+  return AVATAR_PALETTES[idx];
+}
 
 export function PublishedJobs({ locationIndex }: { locationIndex: LocationIndex }) {
   const { jobs: publishedJobs, loading, error, retry } = usePublishedJobs();
@@ -17,73 +71,612 @@ export function PublishedJobs({ locationIndex }: { locationIndex: LocationIndex 
   const [channel, setChannel] = useState("");
   const [sort, setSort] = useState("newest");
   const [page, setPage] = useState(1);
+  const [copiedJobId, setCopiedJobId] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const summaryRef = useRef<HTMLDivElement>(null);
   const [location, setLocation] = useState("");
   const [country, setCountry] = useState("");
   const [workplace, setWorkplace] = useState("");
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "/" && document.activeElement !== searchInputRef.current && !["INPUT", "TEXTAREA", "SELECT"].includes(document.activeElement?.tagName ?? "")) {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const copyJobLink = async (job: CommunityJob) => {
+    try {
+      await navigator.clipboard.writeText(job.url);
+      setCopiedJobId(job.jobId);
+      setTimeout(() => setCopiedJobId((current) => (current === job.jobId ? null : current)), 2000);
+    } catch {
+      // Fallback
+    }
+  };
+
   const countries = useMemo(() => [...new Set(jobs.flatMap(job => job.location?.countries ?? []))].sort((a, b) => countryLabel(a).localeCompare(countryLabel(b))), [jobs]);
   const companies = useMemo(() => [...new Set(jobs.map(job => job.company))].sort(), [jobs]);
   const channels = useMemo(() => [...new Set(jobs.map(job => job.applicationChannel))].sort(), [jobs]);
   const results: typeof jobs = useMemo(() => searchJobs(jobs, { query, company, channel, sort, location, country, workplace }), [jobs, query, company, channel, sort, location, country, workplace]);
   const filtered = Boolean(query || company || channel || location || country || workplace);
   const pagination = jobPagination(results.length, page);
+
   const changePage = (number: number) => {
     setPage(number);
     summaryRef.current?.focus({ preventScroll: true });
     summaryRef.current?.scrollIntoView({ block: "start" });
   };
-  const clear = () => { setQuery(""); setCompany(""); setChannel(""); setLocation(""); setCountry(""); setWorkplace(""); setPage(1); };
 
-  return <main className={`page-width ${styles.page}`}>
-    <Link className={styles.back} href="/community-view">← Back to community stats</Link>
-    <header className={styles.header}>
-      <p className="eyebrow">Community directory · unlisted</p>
-      <h1>Published jobs</h1>
-      <p>Find your next opportunity. Community-sourced listings reviewed for publication—not placements or jobs secured. Check the linked page for current availability and requirements.</p>
-    </header>
-    <section className={styles.filters} aria-label="Search and filter published jobs">
-      <label className={styles.search}>Search jobs
-        <input type="search" placeholder="Role, company, or website…" value={query} disabled={loading || error} onChange={event => { setQuery(event.target.value); setPage(1); }} />
-      </label>
-      <div className={styles.filterRow}>
-        <label>Location<input type="search" aria-label="Location" placeholder="City, region, or country…" value={location} disabled={loading || error} onChange={event => { setLocation(event.target.value); setPage(1); }} /></label>
-        <label>Country / region<select aria-label="Country / region" value={country} disabled={loading || error} onChange={event => { setCountry(event.target.value); setPage(1); }}><option value="">All countries / regions</option>{countries.map(value => <option key={value} value={value}>{countryLabel(value)}</option>)}</select></label>
-        <label>Work arrangement<select aria-label="Work arrangement" value={workplace} disabled={loading || error} onChange={event => { setWorkplace(event.target.value); setPage(1); }}><option value="">Any arrangement</option><option value="remote">Remote</option><option value="hybrid">Hybrid</option><option value="onsite">On-site</option><option value="unknown">Not specified</option></select></label>
-      </div>
-      <div className={styles.filterRow}>
-        <label>Company<select aria-label="Company" value={company} disabled={loading || error} onChange={event => { setCompany(event.target.value); setPage(1); }}><option value="">All companies</option>{companies.map(value => <option key={value}>{value}</option>)}</select></label>
-        <label>Application channel<select aria-label="Application channel" value={channel} disabled={loading || error} onChange={event => { setChannel(event.target.value); setPage(1); }}><option value="">All channels</option>{channels.map(value => <option key={value}>{value}</option>)}</select></label>
-        <label>Sort by<select aria-label="Sort by" value={sort} onChange={event => { setSort(event.target.value); setPage(1); }}><option value="newest">Newest first seen</option><option value="oldest">Oldest first seen</option><option value="company">Company A–Z</option></select></label>
-      </div>
-      <p className={styles.hint}>Search covers every published listing. Combine words to narrow your results.</p>
-      {!loading && !error && <p className={styles.hint}>Location or workplace data for {jobs.filter(job => job.location).length} of {jobs.length} listings · Checked {locationIndex.collectedAt.slice(0, 10)}. Country / region uses the employer’s structured address, not eligibility. Remote may have geographic restrictions.</p>}
-    </section>
-    <div ref={summaryRef} tabIndex={-1} className={styles.summary} role="status" aria-live="polite">
-      <span>{loading ? "Loading published jobs…" : error ? "Search unavailable" : `${results.length} ${results.length === 1 ? "job" : "jobs"}${filtered ? ` matching · ${jobs.length} total` : " available"}`}</span>
-      {!loading && !error && results.length > 0 && <span>Page {pagination.page} of {pagination.totalPages}</span>}
-      {filtered && <button className={styles.clear} onClick={clear}>Clear filters</button>}
+  const clear = () => {
+    setQuery("");
+    setCompany("");
+    setChannel("");
+    setLocation("");
+    setCountry("");
+    setWorkplace("");
+    setPage(1);
+  };
+
+  const toggleWorkplacePill = (val: string) => {
+    setWorkplace(current => current === val ? "" : val);
+    setPage(1);
+  };
+
+  const toggleChannelPill = (val: string) => {
+    setChannel(current => current === val ? "" : val);
+    setPage(1);
+  };
+
+  const verifiedLocationsCount = jobs.filter(job => job.location).length;
+
+  return (
+    <div className={styles.container}>
+      <SiteHeader community />
+      <main className={`page-width ${styles.page}`}>
+        <div className={styles.breadcrumbBar}>
+          <Link className={styles.back} href="/community-view">← Back to community stats</Link>
+        </div>
+
+        <header className={styles.header}>
+          <div className={styles.headerTitleGroup}>
+            <p className="eyebrow">Community directory · unlisted</p>
+            <h1>Published jobs</h1>
+          </div>
+          <p className={styles.headerLead}>
+            Find your next opportunity. Community-sourced listings reviewed for publication—not placements or jobs secured. Check the linked page for current availability and requirements.
+          </p>
+          <div className={styles.statsRow}>
+            <span className={`${styles.statPill} ${styles.statPillActive}`}>
+              <span className={styles.statDot} aria-hidden="true" />
+              {jobs.length > 0 ? `${jobs.length} verified listings` : "Direct ATS listings"}
+            </span>
+            <span className={styles.statPill}>Greenhouse · Ashby · Lever · Workable</span>
+            <span className={styles.statPill}>Zero recruiter spam · Zero sponsored slots</span>
+          </div>
+        </header>
+
+        <section className={styles.filtersCard} aria-label="Search and filter published jobs">
+          <div className={styles.searchWrapper}>
+            <svg className={styles.searchIcon} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <circle cx="8.5" cy="8.5" r="5.5" />
+              <path d="m13 13 4.5 4.5" />
+            </svg>
+            <input
+              ref={searchInputRef}
+              className={styles.searchInput}
+              type="search"
+              aria-label="Search jobs"
+              placeholder="Search by role, company, or keyword (e.g. Staff, Python, Anthropic)…"
+              value={query}
+              disabled={loading || error}
+              onChange={event => { setQuery(event.target.value); setPage(1); }}
+            />
+            <div className={styles.searchControls}>
+              {query && (
+                <button
+                  type="button"
+                  className={styles.clearSearchBtn}
+                  onClick={() => { setQuery(""); setPage(1); searchInputRef.current?.focus(); }}
+                  aria-label="Clear search input"
+                >
+                  ✕
+                </button>
+              )}
+              <kbd className={styles.kbdShortcut} title="Press / to search">/</kbd>
+            </div>
+          </div>
+
+          <div className={styles.quickFiltersRow} aria-label="Quick filters">
+            <span className={styles.quickFilterLabel}>Quick filters:</span>
+            <button
+              type="button"
+              className={`${styles.quickPill} ${!workplace && !channel ? styles.quickPillActive : ""}`}
+              onClick={() => { setWorkplace(""); setChannel(""); setPage(1); }}
+            >
+              All roles
+            </button>
+            <button
+              type="button"
+              className={`${styles.quickPill} ${workplace === "remote" ? styles.quickPillActive : ""}`}
+              onClick={() => toggleWorkplacePill("remote")}
+            >
+              ● Remote only
+            </button>
+            <button
+              type="button"
+              className={`${styles.quickPill} ${workplace === "hybrid" ? styles.quickPillActive : ""}`}
+              onClick={() => toggleWorkplacePill("hybrid")}
+            >
+              ◑ Hybrid
+            </button>
+            <button
+              type="button"
+              className={`${styles.quickPill} ${workplace === "onsite" ? styles.quickPillActive : ""}`}
+              onClick={() => toggleWorkplacePill("onsite")}
+            >
+              ○ On-site
+            </button>
+            <button
+              type="button"
+              className={`${styles.quickPill} ${channel === "greenhouse" ? styles.quickPillActive : ""}`}
+              onClick={() => toggleChannelPill("greenhouse")}
+            >
+              Greenhouse
+            </button>
+            <button
+              type="button"
+              className={`${styles.quickPill} ${channel === "ashby" ? styles.quickPillActive : ""}`}
+              onClick={() => toggleChannelPill("ashby")}
+            >
+              Ashby
+            </button>
+            <button
+              type="button"
+              className={`${styles.quickPill} ${channel === "lever" ? styles.quickPillActive : ""}`}
+              onClick={() => toggleChannelPill("lever")}
+            >
+              Lever
+            </button>
+          </div>
+
+          <div className={styles.filtersToggleRow}>
+            <button
+              type="button"
+              className={styles.filterToggleBtn}
+              onClick={() => setShowAdvancedFilters(prev => !prev)}
+              aria-expanded={showAdvancedFilters || (location ? 1 : 0) + (country ? 1 : 0) + (company ? 1 : 0) + (sort !== "newest" ? 1 : 0) > 0}
+              aria-controls="advanced-filters"
+            >
+              <span>{showAdvancedFilters || (location ? 1 : 0) + (country ? 1 : 0) + (company ? 1 : 0) + (sort !== "newest" ? 1 : 0) > 0 ? "Fewer filters" : "More filters"}</span>
+              {(location ? 1 : 0) + (country ? 1 : 0) + (company ? 1 : 0) + (sort !== "newest" ? 1 : 0) > 0 && (
+                <span className={styles.filterToggleBadge}>
+                  {(location ? 1 : 0) + (country ? 1 : 0) + (company ? 1 : 0) + (sort !== "newest" ? 1 : 0)}
+                </span>
+              )}
+              <svg
+                className={`${styles.toggleChevron} ${showAdvancedFilters || (location ? 1 : 0) + (country ? 1 : 0) + (company ? 1 : 0) + (sort !== "newest" ? 1 : 0) > 0 ? styles.toggleChevronOpen : ""}`}
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z" />
+              </svg>
+            </button>
+          </div>
+
+          {(showAdvancedFilters || (location ? 1 : 0) + (country ? 1 : 0) + (company ? 1 : 0) + (sort !== "newest" ? 1 : 0) > 0) && (
+            <div id="advanced-filters" className={styles.filterGrid}>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-location" className={styles.fieldLabel}>Location</label>
+                <input
+                  id="filter-location"
+                  className={styles.textInput}
+                  type="search"
+                  aria-label="Location"
+                  placeholder="City, region, or country…"
+                  value={location}
+                  disabled={loading || error}
+                  onChange={event => { setLocation(event.target.value); setPage(1); }}
+                />
+              </div>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-country" className={styles.fieldLabel}>Country / region</label>
+                <select
+                  id="filter-country"
+                  className={styles.selectInput}
+                  aria-label="Country / region"
+                  value={country}
+                  disabled={loading || error}
+                  onChange={event => { setCountry(event.target.value); setPage(1); }}
+                >
+                  <option value="">All countries / regions</option>
+                  {countries.map(value => <option key={value} value={value}>{countryLabel(value)}</option>)}
+                </select>
+              </div>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-workplace" className={styles.fieldLabel}>Work arrangement</label>
+                <select
+                  id="filter-workplace"
+                  className={styles.selectInput}
+                  aria-label="Work arrangement"
+                  value={workplace}
+                  disabled={loading || error}
+                  onChange={event => { setWorkplace(event.target.value); setPage(1); }}
+                >
+                  <option value="">Any arrangement</option>
+                  <option value="remote">Remote</option>
+                  <option value="hybrid">Hybrid</option>
+                  <option value="onsite">On-site</option>
+                  <option value="unknown">Not specified</option>
+                </select>
+              </div>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-company" className={styles.fieldLabel}>Company</label>
+                <select
+                  id="filter-company"
+                  className={styles.selectInput}
+                  aria-label="Company"
+                  value={company}
+                  disabled={loading || error}
+                  onChange={event => { setCompany(event.target.value); setPage(1); }}
+                >
+                  <option value="">All companies</option>
+                  {companies.map(value => <option key={value} value={value}>{value}</option>)}
+                </select>
+              </div>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-channel" className={styles.fieldLabel}>Application channel</label>
+                <select
+                  id="filter-channel"
+                  className={styles.selectInput}
+                  aria-label="Application channel"
+                  value={channel}
+                  disabled={loading || error}
+                  onChange={event => { setChannel(event.target.value); setPage(1); }}
+                >
+                  <option value="">All channels</option>
+                  {channels.map(value => <option key={value} value={value}>{value}</option>)}
+                </select>
+              </div>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-sort" className={styles.fieldLabel}>Sort by</label>
+                <select
+                  id="filter-sort"
+                  className={styles.selectInput}
+                  aria-label="Sort by"
+                  value={sort}
+                  onChange={event => { setSort(event.target.value); setPage(1); }}
+                >
+                  <option value="newest">Newest first seen</option>
+                  <option value="oldest">Oldest first seen</option>
+                  <option value="company">Company A–Z</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          <p className={styles.filterHint}>Search covers every published listing. Combine words to narrow your results.</p>
+          {!loading && !error && (
+            <p className={styles.filterHint}>
+              Location or workplace data for {verifiedLocationsCount} of {jobs.length} listings · Checked {locationIndex.collectedAt.slice(0, 10)}. Country / region uses the employer’s structured address, not eligibility. Remote may have geographic restrictions.
+            </p>
+          )}
+        </section>
+
+        {filtered && (
+          <div className={styles.activeChipsBar} aria-label="Active filters">
+            <span className={styles.activeChipsLabel}>Active:</span>
+            <div className={styles.activeChipsList}>
+              {query && (
+                <button
+                  type="button"
+                  className={styles.chip}
+                  onClick={() => { setQuery(""); setPage(1); }}
+                  aria-label={`Remove search filter ${query}`}
+                >
+                  Search: <strong>&ldquo;{query}&rdquo;</strong> <span className={styles.chipIcon} aria-hidden="true">×</span>
+                </button>
+              )}
+              {location && (
+                <button
+                  type="button"
+                  className={styles.chip}
+                  onClick={() => { setLocation(""); setPage(1); }}
+                  aria-label={`Remove location filter ${location}`}
+                >
+                  Location: <strong>&ldquo;{location}&rdquo;</strong> <span className={styles.chipIcon} aria-hidden="true">×</span>
+                </button>
+              )}
+              {country && (
+                <button
+                  type="button"
+                  className={styles.chip}
+                  onClick={() => { setCountry(""); setPage(1); }}
+                  aria-label={`Remove country filter ${countryLabel(country)}`}
+                >
+                  Country: <strong>{countryLabel(country)}</strong> <span className={styles.chipIcon} aria-hidden="true">×</span>
+                </button>
+              )}
+              {workplace && (
+                <button
+                  type="button"
+                  className={styles.chip}
+                  onClick={() => { setWorkplace(""); setPage(1); }}
+                  aria-label={`Remove arrangement filter ${workplace}`}
+                >
+                  Workplace: <strong>{workplace === "onsite" ? "On-site" : workplace === "unknown" ? "Not specified" : workplace.charAt(0).toUpperCase() + workplace.slice(1)}</strong> <span className={styles.chipIcon} aria-hidden="true">×</span>
+                </button>
+              )}
+              {company && (
+                <button
+                  type="button"
+                  className={styles.chip}
+                  onClick={() => { setCompany(""); setPage(1); }}
+                  aria-label={`Remove company filter ${company}`}
+                >
+                  Company: <strong>{company}</strong> <span className={styles.chipIcon} aria-hidden="true">×</span>
+                </button>
+              )}
+              {channel && (
+                <button
+                  type="button"
+                  className={styles.chip}
+                  onClick={() => { setChannel(""); setPage(1); }}
+                  aria-label={`Remove channel filter ${channel}`}
+                >
+                  Channel: <strong>{channel}</strong> <span className={styles.chipIcon} aria-hidden="true">×</span>
+                </button>
+              )}
+              <button type="button" className={styles.clearAllBtn} onClick={clear}>
+                Clear all filters
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div ref={summaryRef} tabIndex={-1} className={styles.summaryBar} role="status" aria-live="polite">
+          <span className={styles.summaryCounts}>
+            {loading ? "Loading published jobs…" : error ? "Search unavailable" : `${results.length} ${results.length === 1 ? "job" : "jobs"}${filtered ? ` matching · ${jobs.length} total` : " available"}`}
+          </span>
+          {!loading && !error && results.length > 0 && (
+            <span className={styles.summaryPages}>
+              Page {pagination.page} of {pagination.totalPages}
+            </span>
+          )}
+        </div>
+
+        {loading && (
+          <div className={styles.skeletonList} aria-hidden="true">
+            {[1, 2, 3].map((n) => (
+              <div key={n} className={styles.skeletonCard}>
+                <div className={styles.skeletonHeader}>
+                  <div className={styles.skeletonAvatar} />
+                  <div className={styles.skeletonMeta}>
+                    <div className={styles.skeletonCompany} />
+                    <div className={styles.skeletonHost} />
+                  </div>
+                </div>
+                <div className={styles.skeletonTitle} />
+                <div className={styles.skeletonBadges}>
+                  <div className={styles.skeletonBadge} />
+                  <div className={styles.skeletonBadge} />
+                </div>
+                <div className={styles.skeletonFooter}>
+                  <div className={styles.skeletonEvidence} />
+                  <div className={styles.skeletonBtn} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div className={styles.notice} role="alert">
+            <h2>Search unavailable</h2>
+            <p>We couldn’t load the complete directory. Retry to search all published jobs.</p>
+            <button type="button" className="button button-secondary" onClick={retry}>Retry</button>
+          </div>
+        )}
+
+        {!loading && !error && results.length === 0 && (
+          <div className={styles.emptyState}>
+            <div className={styles.emptyIcon} aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="11" cy="11" r="8" />
+                <path d="m21 21-4.35-4.35" />
+              </svg>
+            </div>
+            <h2>{filtered ? "No matching jobs" : "No published jobs yet"}</h2>
+            <p>
+              {filtered
+                ? "Try fewer words or clear a filter. Listings without verified location data won’t match location or country filters."
+                : "Check back later for new opportunities."}
+            </p>
+            {filtered && (
+              <div className={styles.emptyActions}>
+                <button type="button" className="button button-secondary" onClick={clear}>Clear filters</button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {results.length > 0 && (
+          <ul className={styles.list} aria-label="Published job listings">
+            {results.slice(pagination.start, pagination.end).map(job => {
+              const workplaceInfo = getWorkplaceMeta(job.location?.workplace);
+              const hostname = getHostname(job.url);
+              const firstInitial = job.company.trim().charAt(0).toUpperCase() || "●";
+              const avatarStyle = getAvatarStyle(job.company);
+
+              return (
+                <li key={job.jobId} className={styles.jobCard}>
+                  <div className={styles.cardHeader}>
+                    <div className={styles.companyLockup}>
+                      <div
+                        className={styles.companyAvatar}
+                        style={{ backgroundColor: avatarStyle.bg, color: avatarStyle.color, borderColor: avatarStyle.border }}
+                        aria-hidden="true"
+                      >
+                        {firstInitial}
+                      </div>
+                      <div className={styles.companyMeta}>
+                        <span className={styles.companyName}>{job.company}</span>
+                        <span className={styles.hostname}>{hostname}</span>
+                      </div>
+                    </div>
+                    <time dateTime={job.firstSeenAt} className={styles.seenDate} title={`First seen on ${job.firstSeenAt.slice(0, 10)}`}>
+                      {formatRelativeDate(job.firstSeenAt)}
+                    </time>
+                  </div>
+
+                  <div className={styles.cardBody}>
+                    <h2 className={styles.jobTitle}>
+                      <a href={job.url} target="_blank" rel="noopener noreferrer">
+                        {job.role}
+                        <span aria-hidden="true"> ↗</span>
+                        <span className={styles.srOnly}> (opens in a new tab)</span>
+                      </a>
+                    </h2>
+
+                    <div className={styles.badgeGroup}>
+                      {workplaceInfo && (
+                        <span className={`${styles.badge} ${workplaceInfo.className}`}>
+                          <span aria-hidden="true">{workplaceInfo.icon} </span>
+                          {workplaceInfo.label}
+                        </span>
+                      )}
+                      {job.location?.label && (
+                        <span className={styles.locationTag} title={job.location.label}>
+                          <svg className={styles.pinIcon} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                            <path d="M8 1a5 5 0 0 0-5 5c0 3.5 5 9 5 9s5-5.5 5-9a5 5 0 0 0-5-5zm0 7a2 2 0 1 1 0-4 2 2 0 0 1 0 4z" />
+                          </svg>
+                          {job.location.label}
+                        </span>
+                      )}
+                      <span className={styles.channelTag}>
+                        {job.applicationChannel}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className={styles.cardFooter}>
+                    <div className={styles.evidenceText}>
+                      {job.location ? (
+                        <>Location checked <time dateTime={job.location.checkedAt}>{job.location.checkedAt.slice(0, 10)}</time></>
+                      ) : (
+                        <span>Direct ATS requisition</span>
+                      )}
+                    </div>
+                    <div className={styles.cardActions}>
+                      <button
+                        type="button"
+                        className={styles.copyBtn}
+                        onClick={() => copyJobLink(job)}
+                        aria-label={`Copy link for ${job.role} at ${job.company}`}
+                      >
+                        {copiedJobId === job.jobId ? (
+                          <>
+                            <svg className={styles.btnIcon} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                              <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
+                            </svg>
+                            <span>Copied!</span>
+                          </>
+                        ) : (
+                          <>
+                            <svg className={styles.btnIcon} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                              <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/>
+                              <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
+                            </svg>
+                            <span>Copy link</span>
+                          </>
+                        )}
+                      </button>
+                      <a
+                        href={job.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.applyBtn}
+                      >
+                        <span>Open posting</span>
+                        <span aria-hidden="true">↗</span>
+                      </a>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {!loading && !error && results.length > 0 && (
+          <div className={styles.actions}>
+            <p>Showing {pagination.start + 1}–{pagination.end} of {results.length} results</p>
+            {pagination.totalPages > 1 && (
+              <nav className={styles.pagination} aria-label="Job results pages">
+                <button
+                  type="button"
+                  disabled={pagination.page === 1}
+                  onClick={() => changePage(pagination.page - 1)}
+                  aria-label="Previous page"
+                >
+                  Previous
+                </button>
+                {pagination.numbers.map((number, idx) => typeof number === "number" ? (
+                  <button
+                    key={number}
+                    type="button"
+                    aria-label={`Page ${number}`}
+                    aria-current={number === pagination.page ? "page" : undefined}
+                    onClick={() => changePage(number)}
+                  >
+                    {number}
+                  </button>
+                ) : (
+                  <span key={`gap-${idx}`} className={styles.pageGap} aria-hidden="true">…</span>
+                ))}
+                <button
+                  type="button"
+                  disabled={pagination.page === pagination.totalPages}
+                  onClick={() => changePage(pagination.page + 1)}
+                  aria-label="Next page"
+                >
+                  Next
+                </button>
+              </nav>
+            )}
+          </div>
+        )}
+
+        <section id="methodology" className={styles.methodology} aria-labelledby="vetting-heading">
+          <div>
+            <p className="eyebrow">Vetting & Integrity</p>
+            <h2 id="vetting-heading">How published jobs are reviewed.</h2>
+          </div>
+          <div className={styles.methodologyContent}>
+            <p>
+              <strong>Direct ATS destinations:</strong> Every listing is resolved to its canonical employer or applicant tracking system page (Greenhouse, Ashby, Lever, Workable, direct careers). Third-party recruiter redirects and ghost aggregators are rejected.
+            </p>
+            <p>
+              <strong>Active status:</strong> Roles are confirmed accessible and accepting applications at the time of review. Expired requisitions and closed pages are withheld.
+            </p>
+            <p>
+              <strong>Identity-free:</strong> Sourced anonymously from active Job Application Agent installations. Personal profiles, candidate identities, resumes, and scores are never transmitted or stored.
+            </p>
+          </div>
+        </section>
+
+        <footer className={styles.unlistedNotice}>
+          Accessible by direct link. This page is unlisted, not private.
+        </footer>
+      </main>
+      <SiteFooter community />
     </div>
-    {loading && <div className={styles.skeleton} aria-hidden="true"><div /><div /><div /></div>}
-    {error && <div className={styles.notice} role="alert"><p>We couldn’t load the complete directory. Retry to search all published jobs.</p><button className="button button-secondary" onClick={retry}>Retry</button></div>}
-    {!loading && !error && results.length === 0 && <div className={styles.notice}><h2>{filtered ? "No matching jobs" : "No published jobs yet"}</h2><p>{filtered ? "Try fewer words or clear a filter. Listings without verified location data won’t match location or country filters." : "Check back later for new opportunities."}</p>{filtered && <button className="button button-secondary" onClick={clear}>Clear filters</button>}</div>}
-    {results.length > 0 && <ul className={styles.list} aria-label="Published job listings">
-      {results.slice(pagination.start, pagination.end).map(job => <li key={job.jobId} className={styles.job}>
-        <div><p className={styles.company}>{job.company}</p><h2><a href={job.url} target="_blank" rel="noopener noreferrer">{job.role}<span aria-hidden="true"> ↗</span><span className={styles.srOnly}> (opens in a new tab)</span></a></h2>
-          <p className={styles.location}>{job.location?.label || "Location not specified"} · {({ remote: "Remote", hybrid: "Hybrid", onsite: "On-site" } as Record<string, string>)[job.location?.workplace ?? ""] ?? "Work arrangement not specified"}</p>
-          <p className={styles.meta}>{new URL(job.url).hostname} · First seen <time dateTime={job.firstSeenAt}>{job.firstSeenAt.slice(0, 10)}</time>{job.location && <> · Location checked <time dateTime={job.location.checkedAt}>{job.location.checkedAt.slice(0, 10)}</time></>}</p></div>
-        <span className={styles.channel}>{job.applicationChannel}</span>
-      </li>)}
-    </ul>}
-    {!loading && !error && results.length > 0 && <div className={styles.actions}>
-      <p>Showing {pagination.start + 1}–{pagination.end} of {results.length} results</p>
-      {pagination.totalPages > 1 && <nav className={styles.pagination} aria-label="Job results pages">
-        <button disabled={pagination.page === 1} onClick={() => changePage(pagination.page - 1)}>Previous</button>
-        {pagination.numbers.map(number => typeof number === "number"
-          ? <button key={number} aria-label={`Page ${number}`} aria-current={number === pagination.page ? "page" : undefined} onClick={() => changePage(number)}>{number}</button>
-          : <span key={number} aria-hidden="true">…</span>)}
-        <button disabled={pagination.page === pagination.totalPages} onClick={() => changePage(pagination.page + 1)}>Next</button>
-      </nav>}
-    </div>}
-    <footer className={styles.footer}>Accessible by direct link. This page is unlisted, not private.</footer>
-  </main>;
+  );
 }
+

--- a/site/app/jobs/jobs.module.css
+++ b/site/app/jobs/jobs.module.css
@@ -1,39 +1,1039 @@
-.page { max-width: 60rem; padding-block: 2rem 4rem; }
-.back { display: inline-block; padding-block: .5rem; color: var(--text); font-size: .9rem; }
-.header { padding-block: 3rem 2rem; max-width: 46rem; }
-.header h1 { margin: .75rem 0 1.25rem; font: 400 clamp(2.5rem, 6vw, 4rem)/1.1 var(--font-display), serif; letter-spacing: -.04em; }
-.header > p:last-child { color: var(--text); margin: 0; }
-.summary { padding-block: 1rem; border-bottom: 1px solid var(--ink); font: .8rem var(--font-mono), monospace; color: var(--text); }
-.list { list-style: none; margin: 0; padding: 0; }
-.job { display: flex; justify-content: space-between; align-items: start; gap: 1rem; padding: 1.5rem 0; border-bottom: 1px solid var(--line); }
-.job > div { min-width: 0; }
-.company { margin: 0 0 .4rem; color: var(--text); font-size: .85rem; }
-.job h2 { margin: 0; font-size: 1.15rem; line-height: 1.5; overflow-wrap: anywhere; }
-.job h2 a { text-decoration: none; }
-.job h2 a:hover { text-decoration: underline; text-underline-offset: .25rem; }
-.meta { margin: .6rem 0 0; color: var(--muted); font-size: .75rem; overflow-wrap: anywhere; }
-.channel { flex-shrink: 0; border: 1px solid var(--line); border-radius: .25rem; padding: .25rem .5rem; font: .7rem/1.5 var(--font-mono), monospace; color: var(--text); }
-.notice { padding: 1.5rem; background: var(--surface); border: 1px solid var(--line); }
-.actions { padding-block: 1.5rem; }
-.pagination { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; }
-.pagination button { min-width: 44px; min-height: 44px; padding: .5rem .75rem; border: 1px solid var(--line); border-radius: .25rem; background: var(--surface); color: var(--ink); font: inherit; cursor: pointer; }
-.pagination button[aria-current="page"] { background: var(--ink); color: var(--surface); border-color: var(--ink); font-weight: 700; }
-.pagination button:disabled { opacity: .5; cursor: default; }
-.summary { flex-wrap: wrap; scroll-margin-top: 1rem; }
-.summary:focus-visible { outline: 2px solid var(--ink); outline-offset: 4px; }
-.footer { padding-top: 1rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .8rem; }
-.skeleton > div { height: 7rem; margin-block: .75rem; background: var(--surface); border-radius: .25rem; }
-.srOnly { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
-.page a:focus-visible, .page button:focus-visible { outline: 2px solid var(--ink); outline-offset: 4px; }
-@media (max-width: 600px) { .job { flex-direction: column; gap: .75rem; } .header { padding-top: 2rem; } }
-.filters { padding: 1.5rem; background: var(--surface); border: 1px solid var(--line); border-radius: .5rem; }
-.filters label { display: flex; flex-direction: column; gap: .5rem; min-width: 0; font-size: .8rem; color: var(--ink); font-weight: 600; }
-.filters input, .filters select { width: 100%; min-width: 0; min-height: 48px; padding: .75rem; border: 1px solid var(--line); border-radius: .25rem; background: var(--background); color: var(--ink); font: 400 1rem var(--font-body), sans-serif; }
-.filters input:focus-visible, .filters select:focus-visible { outline: 2px solid var(--ink); outline-offset: 3px; }
-.filters :disabled { opacity: .6; }
-.filterRow { display: grid; grid-template-columns: 1.2fr 1fr 1fr; gap: 1rem; margin-top: 1rem; }
-.hint { color: var(--muted); font-size: .8rem; margin: 1rem 0 0; }
-.summary { display: flex; align-items: center; justify-content: space-between; gap: 1rem; min-height: 4.5rem; }
-.clear { background: transparent; border: 0; color: var(--ink); font: inherit; text-decoration: underline; cursor: pointer; min-height: 44px; padding: .5rem; }
-@media (max-width: 600px) { .filterRow { grid-template-columns: 1fr; } .filters { padding: 1rem; } }
-.location { margin: .5rem 0 0; color: var(--text); font-size: .9rem; overflow-wrap: anywhere; }
+/* Quiet Trust design system for Published Jobs Directory */
+
+.container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page {
+  flex: 1;
+  max-width: 68rem;
+  padding-block: 2rem 4rem;
+}
+
+/* Breadcrumb navigation */
+.breadcrumbBar {
+  margin-bottom: 1.5rem;
+}
+
+.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 44px;
+  padding: 0.5rem 0.85rem;
+  border-radius: 0.375rem;
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 150ms ease, background 150ms ease;
+}
+
+.back:hover {
+  color: var(--ink);
+  background: var(--surface);
+}
+
+/* Hero section */
+.header {
+  padding-block: 1rem 2.25rem;
+  max-width: 52rem;
+}
+
+.headerTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.header h1 {
+  margin: 0.5rem 0 1rem;
+  font-family: var(--font-display), Georgia, serif;
+  font-size: clamp(2.6rem, 5.5vw, 4rem);
+  font-weight: 400;
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+}
+
+.headerLead {
+  color: var(--text);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0 0 1.5rem;
+}
+
+.statsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.statPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  color: var(--text);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.statPillActive {
+  background: var(--accent-soft);
+  border-color: #b8d9ca;
+  color: var(--accent-text);
+  font-weight: 600;
+}
+
+.statDot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+/* Filters Card */
+.filtersCard {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 0.875rem;
+  padding: 1.5rem;
+  margin-bottom: 1.75rem;
+  box-shadow: 0 2px 8px rgb(23 63 53 / 4%);
+}
+
+.searchWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 1rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  min-height: 52px;
+  padding: 0.85rem 3.5rem 0.85rem 2.85rem;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  background: var(--background);
+  color: var(--ink);
+  font-family: var(--font-body), sans-serif;
+  font-size: 1.05rem;
+  font-weight: 400;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.searchInput:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: 0 0 0 3px rgb(23 63 53 / 15%);
+}
+
+.searchControls {
+  position: absolute;
+  right: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.clearSearchBtn {
+  background: none;
+  border: none;
+  padding: 0.3rem 0.5rem;
+  border-radius: 0.25rem;
+  color: var(--muted);
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.clearSearchBtn:hover {
+  color: var(--ink);
+  background: rgb(23 63 53 / 8%);
+}
+
+.kbdShortcut {
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 0.25rem;
+  background: var(--surface);
+  color: var(--muted);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.7rem;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+/* Quick Filter Pills */
+.quickFiltersRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.quickFilterLabel {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-right: 0.25rem;
+}
+
+.quickPill {
+  min-height: 40px;
+  padding: 0.45rem 0.95rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--background);
+  color: var(--text);
+  font-size: 0.825rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.quickPill:hover {
+  border-color: var(--text);
+  color: var(--ink);
+}
+
+.quickPillActive {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: #fff;
+  font-weight: 600;
+}
+
+.quickPillActive:hover {
+  background: #1f4f43;
+  color: #fff;
+}
+
+/* Secondary Filter Toggle Row */
+.filtersToggleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: -0.25rem;
+  margin-bottom: 0.85rem;
+}
+
+.filterToggleBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.85rem;
+  min-height: 38px;
+  background: var(--background);
+  border: 1px solid var(--line);
+  border-radius: 0.375rem;
+  color: var(--text);
+  font-size: 0.825rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.filterToggleBtn:hover {
+  background: var(--surface);
+  color: var(--ink);
+  border-color: #b8d9ca;
+}
+
+.filterToggleBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.725rem;
+  font-weight: 700;
+}
+
+.toggleChevron {
+  width: 0.85rem;
+  height: 0.85rem;
+  transition: transform 180ms ease;
+}
+
+.toggleChevronOpen {
+  transform: rotate(180deg);
+}
+
+/* Secondary Filter Grid */
+.filterGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.filterField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.fieldLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.selectInput,
+.textInput {
+  width: 100%;
+  min-height: 44px;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 0.375rem;
+  background: var(--background);
+  color: var(--ink);
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.95rem;
+  font-weight: 400;
+  transition: border-color 150ms ease;
+}
+
+.selectInput:focus-visible,
+.textInput:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: 0 0 0 2px rgb(23 63 53 / 15%);
+}
+
+.filterHint {
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+/* Active Filter Chips */
+.activeChipsBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  padding: 0.85rem 1rem;
+  background: var(--surface);
+  border: 1px dashed var(--line);
+  border-radius: 0.5rem;
+}
+
+.activeChipsLabel {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-right: 0.25rem;
+}
+
+.activeChipsList {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chip {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid #b8d9ca;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-text);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.chip:hover {
+  background: #d0e7dc;
+  border-color: #9eccb5;
+}
+
+.chip strong {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.chipIcon {
+  font-size: 0.9rem;
+  font-weight: bold;
+}
+
+.clearAllBtn {
+  background: transparent;
+  border: none;
+  padding: 0.35rem 0.6rem;
+  color: var(--coral);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.clearAllBtn:hover {
+  color: #7d3329;
+}
+
+/* Summary Bar */
+.summaryBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-block: 0.85rem;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 1.25rem;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.825rem;
+  color: var(--text);
+  scroll-margin-top: 5rem;
+}
+
+.summaryBar:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 4px;
+}
+
+.summaryCounts {
+  font-weight: 500;
+}
+
+.summaryPages {
+  color: var(--muted);
+}
+
+/* Job Cards List */
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.jobCard {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.jobCard:hover {
+  border-color: #b8d9ca;
+  box-shadow: 0 4px 14px rgb(23 63 53 / 6%);
+  transform: translateY(-1px);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.companyLockup {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.companyAvatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  flex-shrink: 0;
+  border-radius: 0.625rem;
+  background: var(--accent-soft);
+  color: var(--accent-text);
+  border: 1px solid #c9e4d6;
+  font-family: var(--font-display), serif;
+  font-weight: 700;
+  font-size: 1.15rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.companyMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.companyName {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--ink);
+}
+
+.hostname {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.seenDate {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.jobTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.jobTitle a {
+  text-decoration: none;
+  color: var(--ink);
+  transition: color 150ms ease;
+}
+
+.jobTitle a:hover {
+  color: var(--accent-text);
+  text-decoration: underline;
+  text-underline-offset: 0.25rem;
+}
+
+.badgeGroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.375rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.badgeRemote {
+  background: var(--green-soft);
+  color: var(--green);
+  border: 1px solid #b8d9ca;
+  font-weight: 600;
+}
+
+.badgeHybrid {
+  background: #f4ecdc;
+  color: #6d552c;
+  border: 1px solid #ded0b7;
+  font-weight: 600;
+}
+
+.badgeOnsite {
+  background: #e8ece9;
+  color: #435b54;
+  border: 1px solid #ced8d4;
+  font-weight: 500;
+}
+
+.badgeUnknown {
+  background: transparent;
+  color: var(--muted);
+  border: 1px dashed var(--line);
+  font-size: 0.75rem;
+}
+
+.locationTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 0.375rem;
+  color: var(--text);
+  font-size: 0.8rem;
+  background: var(--background);
+}
+
+.pinIcon {
+  width: 0.8rem;
+  height: 0.8rem;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.channelTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid var(--line);
+  border-radius: 0.375rem;
+  color: var(--muted);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.725rem;
+  line-height: 1.4;
+  background: var(--surface);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--line);
+}
+
+.evidenceText {
+  color: var(--muted);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.75rem;
+}
+
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-left: auto;
+}
+
+.copyBtn {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.95rem;
+  border: 1px solid var(--line);
+  border-radius: 0.375rem;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.825rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.copyBtn:hover {
+  background: var(--accent-soft);
+  border-color: #b8d9ca;
+  color: var(--ink);
+}
+
+.btnIcon {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex-shrink: 0;
+}
+
+.applyBtn {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1.1rem;
+  border: 1px solid var(--ink);
+  border-radius: 0.375rem;
+  background: var(--ink);
+  color: #fff;
+  font-size: 0.825rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.applyBtn:hover {
+  background: #23584b;
+  transform: translateY(-1px);
+}
+
+/* Skeletons */
+.skeletonList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.skeletonCard {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+.skeletonHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.skeletonAvatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.625rem;
+  background: #e7ded0;
+}
+
+.skeletonMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.skeletonCompany {
+  width: 8rem;
+  height: 1rem;
+  background: #e7ded0;
+  border-radius: 0.25rem;
+}
+
+.skeletonHost {
+  width: 5rem;
+  height: 0.75rem;
+  background: #e7ded0;
+  border-radius: 0.25rem;
+}
+
+.skeletonTitle {
+  width: 60%;
+  height: 1.5rem;
+  background: #e7ded0;
+  border-radius: 0.25rem;
+}
+
+.skeletonBadges {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.skeletonBadge {
+  width: 5rem;
+  height: 1.5rem;
+  background: #e7ded0;
+  border-radius: 0.25rem;
+}
+
+.skeletonFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--line);
+}
+
+.skeletonEvidence {
+  width: 10rem;
+  height: 0.75rem;
+  background: #e7ded0;
+  border-radius: 0.25rem;
+}
+
+.skeletonBtn {
+  width: 6rem;
+  height: 2rem;
+  background: #e7ded0;
+  border-radius: 0.375rem;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* Empty & Error Notices */
+.emptyState {
+  padding: 3.5rem 2rem;
+  text-align: center;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.emptyIcon {
+  width: 3.5rem;
+  height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent-text);
+  margin-bottom: 0.5rem;
+}
+
+.emptyIcon svg {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.emptyState h2 {
+  margin: 0;
+  font-family: var(--font-display), serif;
+  font-size: 1.5rem;
+  color: var(--ink);
+}
+
+.emptyState p {
+  margin: 0;
+  max-width: 28rem;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.emptyActions {
+  margin-top: 0.75rem;
+}
+
+.notice {
+  padding: 2rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 0.875rem;
+  text-align: center;
+}
+
+.notice h2 {
+  margin-top: 0;
+}
+
+/* Pagination Bar */
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-block: 2rem 1rem;
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.pagination button {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 0.375rem;
+  background: var(--surface);
+  color: var(--ink);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pagination button:hover:not(:disabled) {
+  border-color: var(--ink);
+  background: var(--accent-soft);
+}
+
+.pagination button[aria-current="page"] {
+  background: var(--ink);
+  color: #fff;
+  border-color: var(--ink);
+  font-weight: 700;
+}
+
+.pagination button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pageGap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  color: var(--muted);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.875rem;
+}
+
+/* Methodology section on /jobs */
+.methodology {
+  margin-top: 4rem;
+  padding: 2.25rem;
+  border: 1px solid var(--line);
+  border-radius: 0.875rem;
+  background: var(--surface);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.8fr);
+  gap: 2.5rem;
+}
+
+.methodology h2 {
+  margin: 0.5rem 0 0;
+  font-family: var(--font-display), serif;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+}
+
+.methodologyContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.methodologyContent p {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.methodologyContent strong {
+  color: var(--ink);
+}
+
+/* Unlisted direct link footnote */
+.unlistedNotice {
+  margin-top: 2rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* Focus states */
+.page a:focus-visible,
+.page button:focus-visible {
+  outline: 3px solid #2f6f5b;
+  outline-offset: 3px;
+}
+
+/* Responsive queries */
+@media (max-width: 900px) {
+  .filterGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .methodology {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .filterGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .cardHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .cardFooter {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .cardActions {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-end;
+  }
+
+  .applyBtn, .copyBtn {
+    flex: 1;
+    justify-content: center;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary

Modernizes the unlisted `/jobs` directory based on design patterns from leading tech job search dashboards (Otta, Simplify, Wellfound, RemoteOK, Levels.fyi) and visual reviews using **gstack**:

1. **Brand & Navigation**:
   - Integrated `SiteHeader community` and `SiteFooter community` with brand mark and links.
   - Breadcrumb navigation (`← Back to community stats`) linking back to `/community-view`.
   - Clear trust badges (`● 1161 verified listings`, ATS sources, zero-recruiter-spam guarantee).

2. **Refined Typography & Hierarchy**:
   - Upgraded `<h1>Published jobs</h1>` with editorial serif display typography (`font-family: var(--font-display)` / `Libre_Baskerville`, `clamp(2.6rem, 5.5vw, 4rem)`).
   - Replaced fragile CSS `font:` shorthand with explicit properties so fonts render reliably across engines.

3. **Interactive Search & Progressive Disclosure Filters**:
   - Instant search input with `/` keyboard shortcut and 1-click clear button.
   - 1-click Quick Filter Pills (`All roles`, `● Remote only`, `◑ Hybrid`, `○ On-site`, `Greenhouse`, `Ashby`, `Lever`).
   - Collapsible secondary filters ("More filters ▾" / "Fewer filters ▴") with active filter count badge to keep the job feed visible above the fold.
   - Dismissible active filter chips with 1-click removal (`×`) and `Clear all filters`.

4. **Calm & Dignified Job Cards**:
   - Removed redundant negative placeholder badges (`Work arrangement not specified` / `Location not specified`), rendering badges only when positive metadata exists.
   - Deterministic subtle tinted monograms for company avatars derived from the Quiet Trust color palette.
   - Direct ATS canonical link ("Open posting ↗") and quick "Copy link" button with 2s "Copied!" clipboard feedback.
   - Accessible touch targets (`min-height: 44px` on action buttons and navigation).

5. **Transparency & Vetting**:
   - Added `#methodology` section detailing ATS canonical verification, active status checks, and identity-free sourcing.

## Verification

- `npm --prefix site test`: 50/50 unit tests pass.
- `npm --prefix site run lint`: 0 errors, 0 warnings.
- `npx tsc --project site/tsconfig.json --noEmit`: 0 errors.
- `npm run check && npm test`: 218/218 tests pass.
- Visual inspection and responsive testing verified via **gstack browse** on Desktop (1280px), Tablet (768px), and Mobile (390px).
- Preserves all SSR test contracts (`/Published jobs/`, `noindex, nofollow`, `/Loading published jobs/`, `/not placements or jobs secured/`, and zero leakage to `/`, `/community-view`, or `/sitemap.xml`).