### PR TITLE
fix(site): add typecheck script and use in deploy workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run site tests
         run: npm --prefix site test
       - name: Run site lint and typecheck
-        run: npm --prefix site run lint && npx tsc --project site/tsconfig.json --noEmit
+        run: npm --prefix site run lint && npm --prefix site run typecheck
       - name: Build site
         run: npm --prefix site run build
       - name: Deploy Worker

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
     "test": "npm run build && node --test tests/*.test.mjs tests/*.spec.mjs",
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next",
+    "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate"
   },
   "dependencies": {


### PR DESCRIPTION
### Summary
Add `"typecheck": "tsc --noEmit"` to `site/package.json` and use `npm --prefix site run typecheck` in `.github/workflows/deploy-site.yml`. This ensures TypeScript compiles using the locally installed TypeScript dependency in `site/node_modules` rather than resolving root `npx tsc`.