### PR TITLE
fix(site): add TELEMETRY service binding for internal proxying

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -38,6 +38,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Verify site deployment
         run: |
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$SITE_WORKER_URL/api/health"
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$SITE_WORKER_URL/api/community-stats"
+          curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$SITE_WORKER_URL/api/community-jobs?limit=1"
           curl --fail --silent --show-error --retry 6 --retry-all-errors --retry-delay 2 --retry-max-time 30 "$SITE_WORKER_URL/jobs" > /dev/null
         env:
           SITE_WORKER_URL: https://job-application-agent-site.varora1406.workers.dev

--- a/site/app/api/community-jobs/route.ts
+++ b/site/app/api/community-jobs/route.ts
@@ -14,7 +14,10 @@ export async function GET(request: Request) {
   catch { return Response.json({ error: "invalid_job_query" }, { status: 400, headers: { "cache-control": "no-store" } }); }
 
   try {
-    const response = await fetch(upstream, { headers: { accept: "application/json" } });
+    const fetcher = (env as unknown as { TELEMETRY?: { fetch: typeof fetch } }).TELEMETRY?.fetch?.bind(
+      (env as unknown as { TELEMETRY?: { fetch: typeof fetch } }).TELEMETRY,
+    ) ?? fetch;
+    const response = await fetcher(new Request(upstream, { headers: { accept: "application/json" } }));
     if (!response.ok) throw new Error("upstream unavailable");
     const raw = await response.text();
     if (new TextEncoder().encode(raw).byteLength > MAX_UPSTREAM_BYTES) throw new Error("upstream response too large");

--- a/site/app/api/community-stats/route.ts
+++ b/site/app/api/community-stats/route.ts
@@ -8,7 +8,10 @@ export async function GET() {
   const upstream = env.COMMUNITY_STATS_UPSTREAM;
   if (!upstream) return Response.json({ error: "stats_unavailable" }, { status: 503, headers: { "cache-control": "no-store" } });
   try {
-    const response = await fetch(upstream, { headers: { accept: "application/json" } });
+    const fetcher = (env as unknown as { TELEMETRY?: { fetch: typeof fetch } }).TELEMETRY?.fetch?.bind(
+      (env as unknown as { TELEMETRY?: { fetch: typeof fetch } }).TELEMETRY,
+    ) ?? fetch;
+    const response = await fetcher(new Request(upstream, { headers: { accept: "application/json" } }));
     if (!response.ok) throw new Error("upstream unavailable");
     const raw = await response.text();
     if (new TextEncoder().encode(raw).byteLength > MAX_UPSTREAM_BYTES) throw new Error("upstream response too large");

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -23,6 +23,12 @@
       "migrations_dir": "drizzle"
     }
   ],
+  "services": [
+    {
+      "binding": "TELEMETRY",
+      "service": "job-application-agent-telemetry"
+    }
+  ],
   "observability": {
     "enabled": false
   }


### PR DESCRIPTION
### Summary
Add `TELEMETRY` service binding to `site/wrangler.jsonc` pointing to `job-application-agent-telemetry`, and consume it in `/api/community-jobs` and `/api/community-stats`.

### Context & Fix
- In Cloudflare Workers, a worker on `workers.dev` cannot fetch another worker on `workers.dev` within the same account over public HTTP without hitting Cloudflare's loop prevention.
- Service bindings provide secure, zero-latency, direct in-process Worker-to-Worker communication without public HTTP subrequest limitations.
- Expands `.github/workflows/deploy-site.yml` post-deploy verification to assert `/api/health`, `/api/community-stats`, `/api/community-jobs?limit=1`, and `/jobs` all succeed.