### PR TITLE
chore(site-proxy): add Vercel reverse proxy config for jobappagent.com

### DIFF
--- a/site-proxy/README.md
+++ b/site-proxy/README.md
@@ -1,0 +1,13 @@
+# JobAppAgent Vercel Proxy
+
+This directory configures the Vercel project (`jobappagent-proxy`) that connects the custom apex domain `https://jobappagent.com` to the Cloudflare Worker:
+`https://job-application-agent-site.varora1406.workers.dev`
+
+## Architecture
+
+- **Domain Registrar / DNS**: Vercel (`jobappagent.com`)
+- **DNS Records**:
+  - Apex `A` record points to Vercel edge (`76.76.21.21`).
+  - ImprovMX and Amazon SES MX/TXT records remain untouched in Vercel DNS.
+- **Vercel Project**: Proxies all routes `/*` to the Cloudflare Worker.
+- **Origin Worker**: Deployed via GitHub Actions (`.github/workflows/deploy-site.yml`) to Cloudflare Workers on every push to `main`.

--- a/site-proxy/vercel.json
+++ b/site-proxy/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "https://job-application-agent-site.varora1406.workers.dev/$1"
+    }
+  ]
+}


### PR DESCRIPTION
Configures Vercel to route custom domain `https://jobappagent.com` to the origin Cloudflare Worker `https://job-application-agent-site.varora1406.workers.dev`.