### PR TITLE
Add jobappagent.com to README discovery links

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Updates are staged and validated before replacement. Private candidate state liv
 
 ## 📍 Where to find it
 
+- [jobappagent.com](https://jobappagent.com) — product site (cloud launch Oct 1; open-source skill on GitHub/npm)
 - [GitHub](https://github.com/vaibhavarora14/job-application-agent)
 - [npm](https://www.npmjs.com/package/job-application-agent)
 - [skills.sh](https://skills.sh/vaibhavarora14/job-application-agent)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the product site as the first item in the README **Where to find it** section:

- [jobappagent.com](https://jobappagent.com) — product site (cloud launch Oct 1; open-source skill on GitHub/npm)

No other README sections changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2aa86894-fe65-4c9b-9ad6-72fdacda8e3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2aa86894-fe65-4c9b-9ad6-72fdacda8e3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

