### PR TITLE
Remove ClawHub review note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Updates are staged and validated before replacement. Private candidate state liv
 - [Agent Skills discussion](https://github.com/agentskills/agentskills/discussions/537)
 - [awesome-agent-skills (Community Skills)](https://github.com/VoltAgent/awesome-agent-skills)
 - [SkillHub](https://www.skillhub.club/app/skills/b99cbef5-2445-47d0-94d0-e6d1fac81263) (may still be in review)
-- [ClawHub](https://clawhub.ai/vaibhavarora14/skills/job-application-agent) (may still be in review)
+- [ClawHub](https://clawhub.ai/vaibhavarora14/skills/job-application-agent)
 - [cursor.directory](https://cursor.directory/plugins/job-application-agent) (pending review)
 
 ## 🧰 Develop


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tiny README fix in **Where to find it**: drop “(may still be in review)” from the ClawHub bullet so it reads as a normal public link. SkillHub and cursor.directory review notes are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1207e6e5-e09f-4537-8289-b2a61872879b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1207e6e5-e09f-4537-8289-b2a61872879b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

