### PR TITLE
Release 3.4.2 — npm homepage and keywords

### DIFF
--- a/job-application-agent/scripts/version.mjs
+++ b/job-application-agent/scripts/version.mjs
@@ -1,1 +1,1 @@
-export const SKILL_VERSION = '3.4.1';
+export const SKILL_VERSION = '3.4.2';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-application-agent",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-application-agent",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "bin": {
         "job-application-agent": "bin/job-application-agent.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-application-agent",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "A privacy-first Agent Skill and CLI for evidence-based job discovery, application completion, and outcome tracking.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Patch release so the npm package metadata from #53 can publish.

## Changes
- Bump version `3.4.1` → `3.4.2` in `package.json`, `package-lock.json`, and `SKILL_VERSION` (`job-application-agent/scripts/version.mjs`)
- No product behavior changes

## Confirmed metadata (unchanged from #53)
- `homepage`: `https://jobappagent.com`
- `keywords` include: `privacy`, `claude`, `cursor`, `codex`, `resume`, `browser-automation`

No CHANGELOG file exists in the repo, so none was updated.

Does not create a GitHub Release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f805178-641a-4d94-b01a-f96f2cfe7535?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f805178-641a-4d94-b01a-f96f2cfe7535&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

